### PR TITLE
fix: format errors correctly for json reporter

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,3 +21,11 @@ export function getMilliSecs(startTime: [number, number]) {
   const hrTime = process.hrtime(startTime);
   return Math.trunc(hrTime && hrTime[0] * 1e3 + hrTime[1] / 1e6);
 }
+
+export function formatError(error: Error) {
+  if (!(error instanceof Error)) {
+    return;
+  }
+  const { name, message, stack } = error;
+  return { name, message, stack };
+}


### PR DESCRIPTION
+ Format errors raised from steps correctly. was `undefined` before since toString(Error) would return '{}' 
+ capture errors in `journey:end`, not in `step:end`