### PR TITLE
fix: skipped tests should not report error

### DIFF
--- a/examples/sample-app/journeys/sample-inline-journey.js
+++ b/examples/sample-app/journeys/sample-inline-journey.js
@@ -1,5 +1,5 @@
 step('Go to home page', async (page, params) => {
-  await page.goto("https://www.elastic.co");
+  await page.goto('https://www.elastic.co');
 });
 
 step('Go to login page', async (page, params) => {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "root": "built",
   "scripts": {
     "build": "tsc",
+    "watch": "tsc -w",
     "lint": "eslint .",
     "test": "jest",
     "coverage": "jest --coverage"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { red, green, yellow, grey } from 'kleur';
+import { red, green, yellow, grey, cyan } from 'kleur';
 
 export function debug(message: string) {
   if (process.env.DEBUG) {
@@ -12,8 +12,9 @@ export function indent(lines: string, tab = '   ') {
 
 export const symbols = {
   warning: yellow('⚠'),
-  pass: green('✓'),
-  fail: red('✖')
+  skipped: cyan('-'),
+  succeeded: green('✓'),
+  failed: red('✖')
 };
 
 export function getMilliSecs(startTime: [number, number]) {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -40,13 +40,9 @@ export default class JSONReporter extends BaseReporter {
       }
     });
 
-    this.runner.on('journey:end', ({ journey, durationMs, error }) => {
+    this.runner.on('journey:end', ({ journey, durationMs }) => {
       const journeyOutput = journeyMap.get(journey.options.name);
       journeyOutput.duration_ms = durationMs;
-      if (error) {
-        journeyOutput.error = formatError(error);
-        journeyOutput.status = 'failed';
-      }
     });
 
     this.runner.on(
@@ -62,7 +58,7 @@ export default class JSONReporter extends BaseReporter {
         // If there's an error we hoist it up to the journey for convenience
         // and set the status to down
         if (error) {
-          journeyOutput.error = error;
+          journeyOutput.error = formatError(error);
           journeyOutput.status = 'failed';
         }
 
@@ -79,7 +75,6 @@ export default class JSONReporter extends BaseReporter {
     );
 
     this.runner.on('end', () => {
-      this.write('\n'); // Ensure that we're writing this on its own line
       this.write(this._getOutput(journeyMap));
     });
   }


### PR DESCRIPTION
+ Skipped tests does not report the errors from previous steps in CLI
+ Journey errors are not thrown, instead we hoist the errors from step as before. 
+ CLI reports have been modified to account for new status fields. 