### PR TITLE
improve the existing plugin architecture

### DIFF
--- a/examples/inline/sample-inline-journey.js
+++ b/examples/inline/sample-inline-journey.js
@@ -3,7 +3,7 @@ step('Go to home page', async (page, params) => {
 });
 
 step('Go to login page', async (page, params) => {
-  await page.click("#navbarSupportedContent > ul > li:nth-child(3) > a")
+  await page.click('#navbarSupportedContent > ul > li:nth-child(3) > a');
 });
 
 // This step doesn't work

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 import { red, green, yellow, grey, cyan } from 'kleur';
+import { hrtime } from 'process';
 
 export function debug(message: string) {
   if (process.env.DEBUG) {
@@ -29,4 +30,13 @@ export function formatError(error: Error) {
   }
   const { name, message, stack } = error;
   return { name, message, stack };
+}
+
+/**
+ * As per the timings used in the Network Events from
+ * Chrome devtools protocol
+ */
+export function getMonotonicTime() {
+  const hrTime = process.hrtime();
+  return hrTime[0] * 1 + hrTime[1] / 1e9;
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,46 @@
+import { NetworkManager } from './network';
+import { Tracing, filterFilmstrips } from './tracing';
+import { CDPSession } from 'playwright';
+import { NetworkInfo, FilmStrip } from '../common_types';
+
+type PluginType = 'network' | 'trace';
+
+type PluginOutput = {
+  filmstrips?: Array<FilmStrip>;
+  networkinfo?: Array<NetworkInfo>;
+};
+
+export class PluginManager {
+  protected plugins: Array<NetworkManager | Tracing> = [];
+
+  constructor(private session: CDPSession) {}
+
+  async start(type: PluginType) {
+    let instance: NetworkManager | Tracing;
+    switch (type) {
+      case 'network':
+        instance = new NetworkManager();
+        break;
+      case 'trace':
+        instance = new Tracing();
+    }
+    this.plugins.push(instance);
+    await instance.start(this.session);
+  }
+
+  async output(): Promise<PluginOutput> {
+    const data = {
+      filmstrips: [],
+      networkinfo: []
+    };
+    for (const plugin of this.plugins) {
+      if (plugin instanceof NetworkManager) {
+        data.networkinfo = plugin.stop();
+      } else if (plugin instanceof Tracing) {
+        const result = await plugin.stop(this.session);
+        data.filmstrips = filterFilmstrips(result);
+      }
+    }
+    return data;
+  }
+}


### PR DESCRIPTION
+ Enhancement of the work done here -https://github.com/elastic/elastic-synthetics/pull/23#discussion_r480288445 
+ Improves the existing plugins by introducing a `PluginManger` which abstracts away all of the underlying Plugins used for trace events and network. 
+ Added a monotonic clock helper that can be used to filter network events for each step instead of running the tracer for every step which is slower. 