### PR TITLE
Add .prettierrc file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,36 +1,25 @@
 module.exports = {
   env: {
     es6: true,
-    node: true
+    node: true,
   },
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module'
+    sourceType: 'module',
   },
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'prettier'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
-    'plugin:prettier/recommended'
+    'plugin:prettier/recommended',
   ],
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        semi: true,
-        printWidth: 80,
-        tabWidth: 2,
-        trailingComma: 'none',
-        arrowParens: 'avoid'
-      }
-    ],
     '@typescript-eslint/no-unused-vars': 2,
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/no-empty-function': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
     '@typescript-eslint/no-explicit-any': 0,
-    '@typescript-eslint/member-delimiter-style': 0
-  }
+    '@typescript-eslint/member-delimiter-style': 0,
+  },
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "arrowParens": "avoid"
+}


### PR DESCRIPTION
Adds a `.prettierrc` in an attempt to improve developer experience. Removes `prettier`-related config from `.eslintrc.js`.

Several of the configured fields were already the `prettier` default, so they have been removed. I did change `trailingComma` from `none` to `es5`, which is the default. It's a stylistic choice on my part, so if we prefer to not have trailing commas that is something we should discuss.