### PR TITLE
add logger to improve debugging experience

### DIFF
--- a/__tests__/core/logger.test.ts
+++ b/__tests__/core/logger.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import { log, setLogger } from '../../src/core/logger';
+import { generateTempPath } from '../../src/helpers';
+
+describe('Logger', () => {
+  const dest = generateTempPath();
+  const message = 'wrote something';
+  setLogger(fs.openSync(dest, 'w'));
+  afterAll(() => {
+    fs.unlinkSync(dest);
+  });
+  it('log to specified fd', async () => {
+    process.env.DEBUG = '1';
+    log(message);
+    // wait one micro task to let the stream flush content
+    await Promise.resolve();
+    const buffer = fs.readFileSync(fs.openSync(dest, 'r'), 'utf-8');
+    expect(buffer).toContain(message);
+  });
+});

--- a/__tests__/helper.test.ts
+++ b/__tests__/helper.test.ts
@@ -1,16 +1,4 @@
-import {
-  getMilliSecs,
-  indent,
-  getMonotonicTime,
-  formatError,
-} from '../src/helpers';
-
-it('get millseconds since start', () => {
-  const start = process.hrtime();
-  const elapsedTime = getMilliSecs(start);
-  expect(elapsedTime).toBeDefined();
-  expect(typeof elapsedTime).toBe('number');
-});
+import { indent, getMonotonicTime, formatError } from '../src/helpers';
 
 it('indent message with seperator', () => {
   // tabWidth: 2

--- a/__tests__/reporters/base.test.ts
+++ b/__tests__/reporters/base.test.ts
@@ -6,26 +6,25 @@ process.env.NO_COLOR = '1';
 import fs from 'fs';
 import { runner, step, journey } from '../../src/core';
 import BaseReporter from '../../src/reporters/base';
-import { generateTempPath } from '../../src/helpers';
+import * as helpers from '../../src/helpers';
 
 describe('base reporter', () => {
-  const dest = generateTempPath();
+  const dest = helpers.generateTempPath();
   afterAll(() => {
     fs.unlinkSync(dest);
     process.env.NO_COLOR = '';
   });
 
   it('writes each step to the FD', async () => {
-    jest.spyOn(process, 'hrtime').mockImplementation(() => {
-      return [0, 0];
-    });
+    const timestamp = 1600300800000000;
+    jest.spyOn(helpers, 'now').mockImplementation(() => 0);
     const { stream } = new BaseReporter(runner, { fd: fs.openSync(dest, 'w') });
     runner.emit('start', { numJourneys: 1 });
     const j1 = journey('j1', () => {});
     runner.emit('journey:start', {
       journey: j1,
       params: {},
-      timestamp: 1600300800000000,
+      timestamp,
     });
     const error = {
       name: 'Error',
@@ -40,7 +39,7 @@ describe('base reporter', () => {
       url: 'dummy',
       start: 0,
       end: 1,
-      timestamp: 1600300800000000,
+      timestamp,
     });
     runner.emit('end', 'done');
     /**

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -1,22 +1,24 @@
 import fs from 'fs';
 import { runner, step, journey } from '../../src/core';
 import JSONReporter from '../../src/reporters/json';
-import { generateTempPath } from '../../src/helpers';
+import * as helpers from '../../src/helpers';
 
 describe('json reporter', () => {
-  const dest = generateTempPath();
+  const dest = helpers.generateTempPath();
   afterAll(() => {
     fs.unlinkSync(dest);
   });
 
   it('writes each step as NDJSON to the FD', async () => {
+    const timestamp = 1600300800000000;
     const { stream } = new JSONReporter(runner, { fd: fs.openSync(dest, 'w') });
-    jest.useFakeTimers('modern').setSystemTime(new Date('2020-09-17'));
+    jest.spyOn(helpers, 'getTimestamp').mockImplementation(() => timestamp);
+
     const j1 = journey('j1', () => {});
     runner.emit('journey:start', {
       journey: j1,
       params: {},
-      timestamp: 1600300800000000,
+      timestamp,
     });
     runner.emit('step:end', {
       journey: j1,
@@ -24,7 +26,7 @@ describe('json reporter', () => {
       step: step('s1', async () => {}),
       screenshot: 'dummy',
       url: 'dummy',
-      timestamp: 1600300800000000,
+      timestamp,
       start: 0,
       end: 10,
     });
@@ -34,7 +36,7 @@ describe('json reporter', () => {
       status: 'succeeded',
       start: 0,
       end: 11,
-      timestamp: 1600300800000000,
+      timestamp,
       filmstrips: [
         {
           snapshot: 'dummy',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,6 @@
 import { readFileSync } from 'fs';
 import { createInterface as createReadlineInterface } from 'readline';
 import { journey, step } from './core';
-import { debug } from './helpers';
 import { run } from './';
 import { parseArgs } from './parse_args';
 
@@ -26,7 +25,6 @@ const program = parseArgs();
 const loadInlineScript = (source, suiteParams) => {
   const scriptFn = new Function('step', 'suiteParams', 'console', source);
   journey('inline', async () => {
-    debug('Creating steps for inline journey');
     scriptFn.apply(null, [step, suiteParams, console]);
   });
 };
@@ -48,7 +46,6 @@ process.env.DEBUG = program.debug || '';
     const source = program.stdin
       ? await readStdin()
       : readFileSync(filePath, 'utf8');
-    debug('Running single script...' + source.toString());
     loadInlineScript(source, suiteParams);
   }
 

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -7,6 +7,7 @@ import {
 } from 'playwright';
 import { PluginManager } from '../plugins';
 import { RunOptions } from './runner';
+import { log } from './logger';
 
 export type Driver = {
   browser: ChromiumBrowser;
@@ -21,6 +22,7 @@ export type Driver = {
  */
 export class Gatherer {
   static async setupDriver(headless?: boolean): Promise<Driver> {
+    log('Gatherer: launching chrome');
     const browser = await chromium.launch({ headless });
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -33,6 +35,7 @@ export class Gatherer {
    * https://chromedevtools.github.io/devtools-protocol/v8/
    */
   static async beginRecording(driver: Driver, options: RunOptions) {
+    log('Gatherer: started recording');
     const { screenshots, network, metrics } = options;
     const pluginManager = new PluginManager(driver.client);
     screenshots && (await pluginManager.start('trace'));

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,22 @@
+import SonicBoom from 'sonic-boom';
+import { grey, cyan, dim, italic } from 'kleur/colors';
+import { now } from '../helpers';
+
+const defaultFd = process.stdout.fd;
+let logger = new SonicBoom({ fd: defaultFd });
+export const setLogger = (fd: number) => {
+  if (fd && fd !== defaultFd) {
+    logger = new SonicBoom({ fd });
+  }
+};
+
+export function log(msg) {
+  if (!process.env.DEBUG || !msg) {
+    return;
+  }
+  if (typeof msg === 'object') {
+    msg = JSON.stringify(msg);
+  }
+  const time = dim(cyan(`at ${parseInt(String(now()))} ms `));
+  logger.write(time + italic(grey(msg)) + '\n');
+}

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -7,6 +7,7 @@ import { StatusValue, FilmStrip, NetworkInfo } from '../common_types';
 import { PluginManager } from '../plugins';
 import { PerformanceManager, Metrics } from '../plugins';
 import { Driver, Gatherer } from './gatherer';
+import { log } from './logger';
 
 type RunParamaters = Record<string, any>;
 
@@ -101,6 +102,7 @@ export default class Runner {
     const data: StepResult = {
       status: 'succeeded',
     };
+    log(`Runner: start step(${step.name})`);
     const { metrics, screenshots } = options;
     const { driver, pluginManager, params } = context;
     try {
@@ -117,6 +119,7 @@ export default class Runner {
       data.status = 'failed';
       data.error = error;
     }
+    log(`Runner: end step(${step.name})`);
     return data;
   }
 
@@ -183,6 +186,7 @@ export default class Runner {
     const result: JourneyResult = {
       status: 'succeeded',
     };
+    log(`Runner: start journey(${journey.options.name})`);
     try {
       const timestamp = getTimestamp();
       const start = getMonotonicTime();
@@ -212,19 +216,20 @@ export default class Runner {
       result.status = 'failed';
       result.error = e;
     }
+    log(`Runner: end journey(${journey.options.name})`);
     return result;
   }
 
   async run(options: RunOptions) {
     const result: RunResult = {};
     const { reporter = 'default', journeyName, outfd } = options;
-
-    this.emit('start', { numJourneys: this.journeys.length });
     /**
      * Set up the corresponding reporter
      */
     const Reporter = reporters[reporter];
     new Reporter(this, { fd: outfd });
+
+    this.emit('start', { numJourneys: this.journeys.length });
 
     for (const journey of this.journeys) {
       // TODO: Replace functionality with journey.only

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,12 +1,7 @@
-import { red, green, yellow, grey, cyan } from 'kleur/colors';
+import { red, green, yellow, cyan } from 'kleur/colors';
 import os from 'os';
 import path from 'path';
-
-export function debug(message: string) {
-  if (process.env.DEBUG) {
-    process.stdout.write(grey(message + '\n'));
-  }
-}
+import { performance } from 'perf_hooks';
 
 export function indent(lines: string, tab = '   ') {
   return lines.replace(/^/gm, tab);
@@ -19,18 +14,16 @@ export const symbols = {
   failed: red('✖'),
 };
 
-export function getMilliSecs(startTime: [number, number]) {
-  // [seconds, nanoseconds]
-  const hrTime = process.hrtime(startTime);
-  return Math.trunc(hrTime && hrTime[0] * 1e3 + hrTime[1] / 1e6);
-}
-
 export function formatError(error: Error) {
   if (!(error instanceof Error)) {
     return;
   }
   const { name, message, stack } = error;
   return { name, message, stack };
+}
+
+export function generateTempPath() {
+  return path.join(os.tmpdir(), `synthetics-${process.hrtime().toString()}`);
 }
 
 /**
@@ -42,10 +35,17 @@ export function getMonotonicTime() {
   return hrTime[0] * 1 + hrTime[1] / 1e9;
 }
 
-export function generateTempPath() {
-  return path.join(os.tmpdir(), `synthetics-${process.hrtime().toString()}`);
+/**
+ * Timestamp at which the current node process began.
+ */
+const processStart = performance.timeOrigin;
+export function getTimestamp() {
+  return (processStart + now()) * 1000;
 }
 
-export function getTimestamp() {
-  return Date.now() * 1000;
+/**
+ * Relative current time from the start of the current node process
+ */
+export function now() {
+  return performance.now();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,25 @@
 import { runner } from './core';
 import { RunOptions } from './core/runner';
+import { setLogger } from './core/logger';
 import { parseArgs } from './parse_args';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 require('source-map-support').install();
 
 export async function run(options: RunOptions) {
+  const cliArgs = parseArgs();
   /**
    * Use the NODE_ENV variable to control the environment if its not explicity
    * passed from either CLI or through the API
    */
   options.environment = options.environment || process.env['NODE_ENV'];
+  /**
+   * set up logger with appropriate file descriptor
+   * to capture all the DEBUG logs when running from heartbeat
+   */
+  const outfd = options.outfd ?? cliArgs.outfd;
+  setLogger(outfd);
 
-  const cliArgs = parseArgs();
   try {
     await runner.run({
       ...options,
@@ -22,8 +29,8 @@ export async function run(options: RunOptions) {
       journeyName: options.journeyName ?? cliArgs.journeyName,
       network: options.network ?? cliArgs.network,
       pauseOnError: options.pauseOnError ?? cliArgs.pauseOnError,
-      outfd: options.outfd ?? cliArgs.outfd,
       reporter: cliArgs.json && !options.reporter ? 'json' : options.reporter,
+      outfd,
     });
   } catch (e) {
     console.error('Failed to run the test', e);

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -1,7 +1,7 @@
 import SonicBoom from 'sonic-boom';
 import Runner from '../core/runner';
 import { green, red, cyan } from 'kleur/colors';
-import { symbols, indent, getMilliSecs } from '../helpers';
+import { symbols, indent, now } from '../helpers';
 
 export type ReporterOptions = {
   fd?: number;
@@ -65,11 +65,7 @@ export default class BaseReporter {
       succeeded: 0,
       failed: 0,
       skipped: 0,
-      start: process.hrtime(),
     };
-    this.runner.on('start', () => {
-      result.start = process.hrtime();
-    });
 
     this.runner.on('journey:start', ({ journey }) => {
       this.write(`\nJourney: ${journey.options.name}`);
@@ -85,12 +81,12 @@ export default class BaseReporter {
     });
 
     this.runner.on('end', () => {
-      const { failed, succeeded, start, skipped } = result;
+      const { failed, succeeded, skipped } = result;
       let message = '\n';
       message += succeeded > 0 ? green(` ${succeeded} passed`) : '';
       message += failed > 0 ? red(` ${failed} failed`) : '';
       message += skipped > 0 ? cyan(` ${skipped} skipped`) : '';
-      message += ` (${getMilliSecs(start)} ms) \n`;
+      message += ` (${renderDuration(now())} ms) \n`;
       this.write(message);
     });
   }


### PR DESCRIPTION
+ Adds a logger which uses the same `fd` for enabling the debug logs
+ One can enable the debug mode using `process.env.DEBUG` or `-d`
+ Timestamps are based on high resolution timers which are relative to Node.js process start which has higher precision and should be the same as `Date.now * 1000` 
<img width="905" alt="Screenshot 2020-09-30 at 17 08 11" src="https://user-images.githubusercontent.com/3902525/94703807-8a1e5a00-033f-11eb-9de4-924de1a0ff78.png">
