### PR TITLE
Base-64 encode screenshots

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -110,7 +110,7 @@ export default class Runner {
         data.metrics = await pluginManager.get(PerformanceManager).getMetrics();
       }
       if (screenshots) {
-        data.screenshot = (await driver.page.screenshot()).toString();
+        data.screenshot = (await driver.page.screenshot()).toString('base64');
       }
       data.url = driver.page.url();
     } catch (error) {


### PR DESCRIPTION
The expectation on the ES- and Kibana-side of this pipeline is that the screenshots are encoded as `base-64` strings; this patch modifies the `toString` call on screenshot buffers created by Playwright to specify b64 encoding.