### PR TITLE
fix: close underlying stream in logger test

### DIFF
--- a/__tests__/core/logger.test.ts
+++ b/__tests__/core/logger.test.ts
@@ -5,17 +5,16 @@ import { generateTempPath } from '../../src/helpers';
 describe('Logger', () => {
   const dest = generateTempPath();
   const message = 'wrote something';
-  setLogger(fs.openSync(dest, 'w'));
+  const stream = setLogger(fs.openSync(dest, 'w'));
   afterAll(() => {
     fs.unlinkSync(dest);
   });
-  // Test is flakey on my laptop (@andrewvc)
-  // The buffer flush may be the culprit? Tried flushSync, no luck
-  it.skip('log to specified fd', async () => {
+
+  it('log to specified fd', async () => {
     process.env.DEBUG = '1';
     log(message);
-    // wait one micro task to let the stream flush content
-    await Promise.resolve();
+    stream.end();
+    await new Promise(resolve => stream.once('finish', resolve));
     const buffer = fs.readFileSync(fs.openSync(dest, 'r'), 'utf-8');
     expect(buffer).toContain(message);
   });

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -4,10 +4,12 @@ import { now } from '../helpers';
 
 const defaultFd = process.stdout.fd;
 let logger = new SonicBoom({ fd: defaultFd });
+
 export const setLogger = (fd: number) => {
   if (fd && fd !== defaultFd) {
     logger = new SonicBoom({ fd });
   }
+  return logger;
 };
 
 export function log(msg) {


### PR DESCRIPTION
+ fix #69 