### PR TITLE
keep journey class model consistent with step

### DIFF
--- a/__tests__/core/index.test.ts
+++ b/__tests__/core/index.test.ts
@@ -7,8 +7,8 @@ const name = 'journey';
 it('add journeys to runner', () => {
   const j = journey(name, noop);
 
-  expect(j.options.name).toBe(name);
-  expect(j.options.id).toBe(name);
+  expect(j.name).toBe(name);
+  expect(j.id).toBe(name);
   expect(runner.currentJourney).toEqual(j);
   expect(runner.journeys.length).toBe(1);
 });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -208,7 +208,7 @@ export default class Runner {
     const result: JourneyResult = {
       status: 'succeeded',
     };
-    log(`Runner: start journey(${journey.options.name})`);
+    log(`Runner: start journey(${journey.name})`);
     try {
       const context = await Runner.context(options);
       this.registerJourney(journey, context);
@@ -228,7 +228,7 @@ export default class Runner {
       result.status = 'failed';
       result.error = e;
     }
-    log(`Runner: end journey(${journey.options.name})`);
+    log(`Runner: end journey(${journey.name})`);
     return result;
   }
 
@@ -251,11 +251,11 @@ export default class Runner {
         continue;
       }
       // TODO: Replace functionality with journey.only
-      if (journeyName && journey.options.name != journeyName) {
+      if (journeyName && journey.name != journeyName) {
         continue;
       }
       const journeyResult = await this.runJourney(journey, options);
-      result[journey.options.name] = journeyResult;
+      result[journey.name] = journeyResult;
     }
     this.emit('end', {});
     this.reset();

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -15,12 +15,14 @@ export type JourneyCallback = (options: {
 }) => Promise<void>;
 
 export class Journey {
-  options: JourneyOptions;
+  name: string;
+  id?: string;
   callback: JourneyCallback;
   steps: Step[] = [];
 
   constructor(options: JourneyOptions, callback: JourneyCallback) {
-    this.options = options;
+    this.name = options.name;
+    this.id = options.id;
     this.callback = callback;
   }
 

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -68,7 +68,7 @@ export default class BaseReporter {
     };
 
     this.runner.on('journey:start', ({ journey }) => {
-      this.write(`\nJourney: ${journey.options.name}`);
+      this.write(`\nJourney: ${journey.name}`);
     });
 
     this.runner.on('step:end', ({ step, start, end, error, status }) => {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -132,8 +132,8 @@ export default class JSONReporter extends BaseReporter {
       type,
       '@timestamp': timestamp || getTimestamp(),
       journey: {
-        name: journey.options.name,
-        id: journey.options.id,
+        name: journey.name,
+        id: journey.id,
       },
       step: step
         ? {


### PR DESCRIPTION
+ Express journey related fields in their own instead of keeping it under options to keep in sync with step naming pattern and also makes it easier to model later on. 