### PR TITLE
Handle absolute paths correctly (not as relative)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { stdin, cwd } from 'process';
-import { join, isAbsolute } from 'path';
+import { resolve } from 'path';
 import { stat } from 'fs';
 import { promisify } from 'util';
 import { totalist } from 'totalist';
@@ -60,7 +60,7 @@ async function prepareSuites(inputs: string[]) {
     ? new RegExp(program.pattern, 'i')
     : /.journey.([mc]js|[jt]s?)$/;
   for (const input of inputs) {
-    const absPath = isAbsolute(input) ? input : join(resolvedCwd, input);
+    const absPath = resolve(resolvedCwd, input);
     const stats = await statAsync(absPath);
     if (stats.isDirectory()) {
       await totalist(absPath, (rel, abs) => {


### PR DESCRIPTION
Heartbeat configs usually will specify abs paths, which we didn't handle.

I don't think we need tests here quite yet, this should be part of our e2e tests when we add those.