### PR TITLE
feat: publish Docker images on the experimental namespace

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -144,11 +144,10 @@ pipeline {
           }
           stage('experimental'){
             when {
-              expression { return false } //Disabled until we have the namespace
-              //branch 'master'
+              branch 'master'
             }
             environment {
-              DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG_PUBLIC}:${env.BRANCH_NAME}-${env.STACK_VERSION}"
+              DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG_PUBLIC}:${env.STACK_VERSION}"
             }
             steps {
               withGithubNotify(context: "push ${DOCKER_IMG_TAG_BRANCH}") {


### PR DESCRIPTION
When this PR is merged we will start to publish Docker images on the experimental namespace of the docker.elasti.co registry
* docker.elastic.co/experimental/synthetics:7.10.0-synthetics
* docker.elastic.co/experimental/synthetics:8.0.0-synthetics