### PR TITLE
fix: rewrite playwright logs from errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,9 +41,12 @@ import { run } from './';
 const program = parseArgs();
 const resolvedCwd = cwd();
 /**
- * Set debug based on flag
+ * Set debug based on DEBUG ENV and -d flags
+ * namespsace - es - elastic synthetics
  */
-process.env.DEBUG = program.debug || '';
+const namespace = 'es';
+process.env.DEBUG =
+  process.env.DEBUG === namespace || (program.debug ? program.debug : '');
 
 const loadInlineScript = source => {
   const scriptFn = new Function('step', 'page', 'browser', 'params', source);

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -26,7 +26,7 @@
 import SonicBoom from 'sonic-boom';
 import Runner from '../core/runner';
 import { green, red, cyan } from 'kleur/colors';
-import { symbols, indent, now } from '../helpers';
+import { symbols, indent, now, rewriteErrorStack } from '../helpers';
 
 export type ReporterOptions = {
   fd?: number;
@@ -39,16 +39,17 @@ function renderError(error) {
   const inner = indent(outer);
   const container = outer + '---\n';
   output += container;
-  const stack = error.stack;
+  let stack = error.stack;
   if (stack) {
-    const lines = String(stack).split('\n');
     output += inner + 'stack: |-\n';
+    stack = rewriteErrorStack(stack);
+    const lines = String(stack).split('\n');
     for (const line of lines) {
       output += inner + '  ' + line + '\n';
     }
   }
   output += container;
-  return output;
+  return red(output);
 }
 
 function renderDuration(durationMs) {


### PR DESCRIPTION
+ fix #88 
+ Introduce a rewrite stack function that rewrites the playwright specific logs message and strips them to only two adjacent  lines to keep the error meaningful instead of giving repetitive lines on every retries. 
+ Also removed the message field from error as it contains the same repetetive message from the error stack. UI can only show stacktrace and skip showing errors. 