### PR TITLE
fix: close fd after debug logs are written

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -328,8 +328,8 @@ export default class Runner {
       result[journey.name] = journeyResult;
     }
     await this.runAfterAllHook();
-    this.emit('end', {});
     this.reset();
+    this.emit('end', {});
     return result;
   }
 

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -73,7 +73,7 @@ export default class BaseReporter {
        * it as the last listener giving enough room for
        * other reporters to write to stream
        */
-      process.nextTick(() => this.stream.end());
+      setImmediate(() => this.stream.end());
     } else {
       /**
        * If the user has passed a custom FD we don't close the FD, but we do flush it


### PR DESCRIPTION
+ fix #110 
+ runner end should be called after reset since we are logging the output inside reset
+ Moved from `nextTick` to `setTimeout` as its called after all the micro tasks and ensure all log statements are printed before we end stream. 