### PR TITLE
fix: ensure we execute tests only once per run

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -114,6 +114,7 @@ interface Events {
 }
 
 export default class Runner {
+  active = false;
   eventEmitter = new EventEmitter();
   currentJourney?: Journey = null;
   journeys: Journey[] = [];
@@ -302,6 +303,10 @@ export default class Runner {
   }
 
   async run(options: RunOptions) {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
     log(`Runner: run ${this.journeys.length} journeys`);
     const result: RunResult = {};
     const { reporter = 'default', journeyName, outfd } = options;
@@ -337,5 +342,6 @@ export default class Runner {
     log('Runner: reset');
     this.currentJourney = null;
     this.journeys = [];
+    this.active = false;
   }
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -303,12 +303,12 @@ export default class Runner {
   }
 
   async run(options: RunOptions) {
+    const result: RunResult = {};
     if (this.active) {
-      return;
+      return result;
     }
     this.active = true;
     log(`Runner: run ${this.journeys.length} journeys`);
-    const result: RunResult = {};
     const { reporter = 'default', journeyName, outfd } = options;
     /**
      * Set up the corresponding reporter

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export async function run(options: RunOptions) {
   setLogger(outfd);
 
   try {
-    await runner.run({
+    return await runner.run({
       ...options,
       headless: options.headless ?? cliArgs.headless,
       screenshots: options.screenshots ?? cliArgs.screenshots,


### PR DESCRIPTION
+ fix #113 
+ It ensures if the current run is active, we don't schedule new runs even invoked via CLI or another programmatic run