### PR TITLE
fix: mock pkg version in json reporter

### DIFF
--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -29,6 +29,15 @@ import JSONReporter from '../../src/reporters/json';
 import * as helpers from '../../src/helpers';
 import Runner from '../../src/core/runner';
 
+/**
+ * Mock package version to avoid breaking JSON payload
+ * for every release
+ */
+jest.mock(
+  '../../package.json',
+  jest.fn(() => ({ version: '0.0.1' }))
+);
+
 describe('json reporter', () => {
   let dest: string;
   const j1 = journey('j1', async () => {});

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -28,7 +28,6 @@ import { formatError, getTimestamp } from '../helpers';
 import { Journey, Step } from '../dsl';
 import snakeCaseKeys from 'snakecase-keys';
 
-// we need this ugly require to get the program version
 /* eslint-disable @typescript-eslint/no-var-requires */
 const programVersion = require('../../package.json').version;
 


### PR DESCRIPTION
+ Keeps the version intact in tests to not break for every release. 

Check the snapshot here for details  - https://github.com/elastic/synthetics/blob/a276de731d0f000ca564c6a64b97d023c780004a/__tests__/reporters/__snapshots__/json.test.ts.snap#L4