### PR TITLE
fix: use millisecond for timestamps

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -66,12 +66,9 @@ export function getMonotonicTime() {
   return hrTime[0] * 1 + hrTime[1] / 1e9;
 }
 
-/**
- * Timestamp at which the current node process began.
- */
-const processStart = performance.timeOrigin;
-export function getTimestamp() {
-  return (processStart + now()) * 1000;
+export type TimestampMs = number;
+export function getTimestamp(): TimestampMs {
+  return Date.now();
 }
 
 /**

--- a/src/plugins/browser-console.ts
+++ b/src/plugins/browser-console.ts
@@ -25,10 +25,11 @@
 
 import { Page } from 'playwright-chromium';
 import { Step } from '../dsl';
-import { getTimestamp } from '../helpers';
+import { getMonotonicTime, getTimestamp, TimestampMs } from '../helpers';
 
 export interface BrowserMessage {
-  timestamp: number;
+  timestamp: TimestampMs;
+  offset: number;
   text: string;
   type: string;
   step: { name: string; index: number };
@@ -46,6 +47,7 @@ export class BrowserConsole {
         const { name, index } = this.currentStep;
         this.messages.push({
           timestamp: getTimestamp(),
+          offset: getMonotonicTime(),
           text: msg.text(),
           type,
           step: { name, index },


### PR DESCRIPTION
@andrewvc , This is only a draft PR to start using millis for timestamp, let's discuss if this is the direction we want to go.

Fixes #119 