### PR TITLE
fix: use filmstrips option for capturing trace

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -62,6 +62,7 @@ describe('run', () => {
       environment: 'debug',
       headless: true,
       screenshots: true,
+      filmstrips: false,
       dryRun: true,
       journeyName: 'There and Back Again',
       network: true,

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -61,10 +61,10 @@ export class Gatherer {
    */
   static async beginRecording(driver: Driver, options: RunOptions) {
     log('Gatherer: started recording');
-    const { screenshots, network, metrics } = options;
+    const { filmstrips, network, metrics } = options;
     const pluginManager = new PluginManager(driver);
     pluginManager.start('browserconsole');
-    screenshots && (await pluginManager.start('trace'));
+    filmstrips && (await pluginManager.start('trace'));
     network && (await pluginManager.start('network'));
     metrics && (await pluginManager.start('performance'));
     return pluginManager;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -47,6 +47,7 @@ export type RunOptions = {
   reporter?: 'default' | 'json';
   headless?: boolean;
   screenshots?: boolean;
+  filmstrips?: boolean;
   dryRun?: boolean;
   journeyName?: string;
   pauseOnError?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export async function run(options: RunOptions) {
       ...options,
       headless: options.headless ?? cliArgs.headless,
       screenshots: options.screenshots ?? cliArgs.screenshots,
+      filmstrips: options.filmstrips ?? cliArgs.filmstrips,
       dryRun: options.dryRun ?? cliArgs.dryRun,
       journeyName: options.journeyName ?? cliArgs.journeyName,
       network: options.network ?? cliArgs.network,

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -45,11 +45,9 @@ program
     '--pause-on-error',
     'pause on error until a keypress is made in the console. Useful during development'
   )
-  .option(
-    '--screenshots',
-    'take screenshots between steps (only shown in some reporters)'
-  )
-  .option('--network', 'capture all network information for all steps')
+  .option('--screenshots', 'take screenshot for each step')
+  .option('--filmstrips', 'record detailed filmstrip info for all journeys')
+  .option('--network', 'capture network information for all journeys')
   .option('--metrics', 'capture performance metrics for each step')
   .option(
     '--dry-run',


### PR DESCRIPTION
+ fix #143 
+ Use `filmstrips` view for capturing the screenshot trace events instead of using the `screenshot` event, This should speed up the run from heartbeat side. 