### PR TITLE
fix: rewrite playwright logs from errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,9 +41,12 @@ import { run } from './';
 const program = parseArgs();
 const resolvedCwd = cwd();
 /**
- * Set debug based on flag
+ * Set debug based on DEBUG ENV and -d flags
+ * namespsace - es - elastic synthetics
  */
-process.env.DEBUG = program.debug || '';
+const namespace = 'es';
+process.env.DEBUG =
+  process.env.DEBUG === namespace || (program.debug ? program.debug : '');
 
 const loadInlineScript = source => {
   const scriptFn = new Function('step', 'page', 'browser', 'params', source);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,9 +42,9 @@ const program = parseArgs();
 const resolvedCwd = cwd();
 /**
  * Set debug based on DEBUG ENV and -d flags
- * namespsace - es - elastic synthetics
+ * namespace - synthetics
  */
-const namespace = 'es';
+const namespace = 'synthetics';
 process.env.DEBUG =
   process.env.DEBUG === namespace || (program.debug ? program.debug : '');
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,8 +50,8 @@ export function formatError(error: Error) {
   if (!(error instanceof Error)) {
     return;
   }
-  const { name, message, stack } = error;
-  return { name, message, stack };
+  const { name, stack } = error;
+  return { name, stack: rewriteErrorStack(stack) };
 }
 
 export function generateTempPath() {
@@ -155,4 +155,36 @@ export async function totalist(
       })
     );
   });
+}
+
+/**
+ * Playwright specific Error logs
+ * remove repetetive error log messages from Playwright custom errors
+ */
+export function rewriteErrorStack(stack: string) {
+  if (!stack) {
+    return stack;
+  }
+  const separator = '\n';
+  const lines = String(stack).split(separator);
+
+  const logStart = /[=]{3,} logs [=]{3,}/;
+  const logEnd = /[=]{10,}/;
+  let startIndex = 0;
+  let endIndex = lines.length;
+  lines.forEach((line, index) => {
+    if (logStart.test(line)) {
+      startIndex = index;
+    } else if (logEnd.test(line)) {
+      endIndex = index;
+    }
+  });
+  const linesToRemove = startIndex + 3;
+  if (startIndex > 0 && linesToRemove < endIndex) {
+    return lines
+      .slice(0, linesToRemove)
+      .concat(...lines.slice(endIndex))
+      .join(separator);
+  }
+  return lines.join(separator);
 }

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -26,7 +26,7 @@
 import SonicBoom from 'sonic-boom';
 import Runner from '../core/runner';
 import { green, red, cyan } from 'kleur/colors';
-import { symbols, indent, now } from '../helpers';
+import { symbols, indent, now, rewriteErrorStack } from '../helpers';
 
 export type ReporterOptions = {
   fd?: number;
@@ -39,16 +39,17 @@ function renderError(error) {
   const inner = indent(outer);
   const container = outer + '---\n';
   output += container;
-  const stack = error.stack;
+  let stack = error.stack;
   if (stack) {
-    const lines = String(stack).split('\n');
     output += inner + 'stack: |-\n';
+    stack = rewriteErrorStack(stack);
+    const lines = String(stack).split('\n');
     for (const line of lines) {
       output += inner + '  ' + line + '\n';
     }
   }
   output += container;
-  return output;
+  return red(output);
 }
 
 function renderDuration(durationMs) {

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -24,9 +24,15 @@
  */
 
 import SonicBoom from 'sonic-boom';
-import Runner from '../core/runner';
 import { green, red, cyan } from 'kleur/colors';
-import { symbols, indent, now, rewriteErrorStack } from '../helpers';
+import Runner from '../core/runner';
+import {
+  symbols,
+  indent,
+  now,
+  findPWLogsIndexes,
+  rewriteErrorStack,
+} from '../helpers';
 
 export type ReporterOptions = {
   fd?: number;
@@ -42,7 +48,7 @@ function renderError(error) {
   let stack = error.stack;
   if (stack) {
     output += inner + 'stack: |-\n';
-    stack = rewriteErrorStack(stack);
+    stack = rewriteErrorStack(stack, findPWLogsIndexes(stack));
     const lines = String(stack).split('\n');
     for (const line of lines) {
       output += inner + '  ' + line + '\n';


### PR DESCRIPTION
+ fix #88
+ Introduce a rewrite stack function that rewrites the playwright specific logs message and strips them to only two adjacent lines to keep the error meaningful instead of giving repetitive lines on every retries.
+ Also removed the message field from error as it contains the same repetetive message from the error stack. UI can only show stacktrace and skip showing errors.