### PR TITLE
fix: generate timestamps when events are reported

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -84,14 +84,12 @@ describe('runner', () => {
       expect(event).toMatchObject({
         journey,
         step,
-        timestamp: expect.any(Number),
       });
     });
     runner.on('step:end', event => {
       expect(event).toMatchObject({
         journey,
         step,
-        timestamp: expect.any(Number),
         status: 'succeeded',
         url: 'about:blank',
         start: expect.any(Number),
@@ -101,7 +99,6 @@ describe('runner', () => {
     runner.on('journey:end', event => {
       expect(event).toMatchObject({
         journey,
-        timestamp: expect.any(Number),
         status: 'succeeded',
         start: expect.any(Number),
         end: expect.any(Number),

--- a/__tests__/reporters/base.test.ts
+++ b/__tests__/reporters/base.test.ts
@@ -64,7 +64,6 @@ describe('base reporter', () => {
       url: 'dummy',
       start: 0,
       end: 1,
-      timestamp,
     });
     runner.emit('end', 'done');
     /**

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -95,7 +95,6 @@ describe('json reporter', () => {
       step: step('s1', async () => {}),
       screenshot: 'dummy',
       url: 'dummy',
-      timestamp,
       start: 0,
       end: 10,
     });
@@ -105,7 +104,6 @@ describe('json reporter', () => {
       status: 'succeeded',
       start: 0,
       end: 11,
-      timestamp,
       filmstrips: [
         {
           snapshot: 'dummy',
@@ -135,7 +133,6 @@ describe('json reporter', () => {
       step: step('s2', async () => {}),
       screenshot: 'dummy2',
       url: 'dummy2',
-      timestamp: 1600300800000001,
       start: 11,
       end: 20,
       error: myErr,
@@ -152,7 +149,6 @@ describe('json reporter', () => {
 
     runner.emit('journey:end', {
       journey: j1,
-      timestamp: 1600300800000001,
       start: 0,
       end: 1,
       params: {},

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -56,7 +56,6 @@ export type RunOptions = {
 };
 
 type BaseContext = {
-  timestamp: number;
   params: RunParamaters;
   start: number;
   end?: number;
@@ -102,9 +101,8 @@ interface Events {
       networkinfo?: Array<NetworkInfo>;
       browserconsole?: Array<BrowserMessage>;
     };
-  'step:start': { journey: Journey; step: Step; timestamp: number };
+  'step:start': { journey: Journey; step: Step };
   'step:end': StepResult & {
-    timestamp: number;
     start: number;
     end: number;
     journey: Journey;
@@ -120,12 +118,10 @@ export default class Runner {
   hooks: SuiteHooks = { beforeAll: [], afterAll: [] };
 
   static async createContext(options: RunOptions): Promise<JourneyContext> {
-    const timestamp = getTimestamp();
     const start = getMonotonicTime();
     const driver = await Gatherer.setupDriver(options.headless);
     const pluginManager = await Gatherer.beginRecording(driver, options);
     return {
-      timestamp,
       start,
       params: options.params,
       driver,
@@ -211,8 +207,7 @@ export default class Runner {
     let skipStep = false;
     for (const step of journey.steps) {
       const start = getMonotonicTime();
-      const timestamp = getTimestamp();
-      this.emit('step:start', { timestamp, journey, step });
+      this.emit('step:start', { journey, step });
       let data: StepResult = { status: 'succeeded' };
       if (skipStep) {
         data.status = 'skipped';
@@ -224,12 +219,11 @@ export default class Runner {
         if (data.error) skipStep = true;
       }
       this.emit('step:end', {
-        timestamp,
         journey,
         step,
-        ...data,
         start,
         end: getMonotonicTime(),
+        ...data,
       });
       if (options.pauseOnError && data.error) {
         await new Promise(r => process.stdin.on('data', r));
@@ -241,7 +235,8 @@ export default class Runner {
 
   async registerJourney(journey: Journey, context: JourneyContext) {
     this.currentJourney = journey;
-    const { timestamp, params } = context;
+    const timestamp = getTimestamp();
+    const { params } = context;
     this.emit('journey:start', { journey, timestamp, params });
     /**
      * Load and register the steps for the current journey
@@ -250,14 +245,13 @@ export default class Runner {
   }
 
   async endJourney(journey, result: JourneyContext & JourneyResult) {
-    const { timestamp, pluginManager, start, params, status, error } = result;
+    const { pluginManager, start, params, status, error } = result;
     const {
       filmstrips,
       networkinfo,
       browserconsole,
     } = await pluginManager.output();
     this.emit('journey:end', {
-      timestamp,
       journey,
       status,
       error,

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -49,7 +49,6 @@ export default class JSONReporter extends BaseReporter {
       ({
         journey,
         step,
-        timestamp,
         start,
         end,
         error,
@@ -66,7 +65,6 @@ export default class JSONReporter extends BaseReporter {
         }
         this.writeJSON('step/end', journey, {
           step,
-          timestamp,
           url,
           error,
           payload: {
@@ -85,7 +83,6 @@ export default class JSONReporter extends BaseReporter {
       'journey:end',
       ({
         journey,
-        timestamp,
         start,
         end,
         filmstrips,
@@ -119,13 +116,13 @@ export default class JSONReporter extends BaseReporter {
         if (browserconsole) {
           browserconsole.forEach(({ timestamp, text, type, step }) => {
             this.writeJSON('journey/browserconsole', journey, {
+              timestamp,
               step,
-              payload: { timestamp, text, type },
+              payload: { text, type },
             });
           });
         }
         this.writeJSON('journey/end', journey, {
-          timestamp,
           error,
           payload: {
             start,


### PR DESCRIPTION
+ fix #118 
+ Timestamps are calculated for every event when the JSON is written to the FD for most of the events as we want the intermediately steps like `network`, `screenshot`, `filmstrips` timestamps to fall under their respective steps timestamps and does not extend beyond that. 

+ Way to test this works
```
node dist/cli.js examples/todos/basics.journey.ts -j --metrics --screenshots | jq '{t: .type, ts: .["@timestamp"]}'
```

We would still use the `start`  and `end` timings for other calculations which is based on the monotonic clock based on the devtools protocol. 
