### PR TITLE
fix: handle symlinks and make examples work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ RUN  cd /usr/share/heartbeat/.node \\
       && mkdir node \\
       && curl https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz | tar -xJ --strip 1 -C node
 ENV PATH="/usr/share/heartbeat/.node/node/bin:$PATH"
-# Install playwright first since it speeds up the install of elastic-synthetics*.tgz, since it doesn't need to re-download the
-# browsers every time the code there changes
-RUN npm i -g playwright-chromium
-COPY elastic-synthetics-*.tgz /opt/elastic-synthetics.tgz
-RUN npm install -g /opt/elastic-synthetics.tgz
-ENV HEARTBEAT_SYNTHETICS_TGZ=/opt/elastic-synthetics.tgz
+# Install the latest version of @elastic/synthetics, so heartbeat can
+# call the executable directly
+RUN npm i -g @elastic/synthetics

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -4,6 +4,4 @@ set -x
 STACK_VERSION=${1:-7.10.0}
 echo "Building docker image based on ${STACK_VERSION}..."
 npm i
-npm run build
-npm pack
 docker build . -t heartbeat-synthetics-local --build-arg STACK_VERSION=$STACK_VERSION-synthetics

--- a/examples/docker/bash-build-local.sh
+++ b/examples/docker/bash-build-local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build a local docker image using the latest source in this repo
-# and run a bash prompty on the container 
+# and run a bash prompty on the container
 pushd ../../
 ./build-docker.sh $1
 popd

--- a/examples/docker/bash.sh
+++ b/examples/docker/bash.sh
@@ -14,6 +14,6 @@ docker run \
   --net=host \
   --security-opt seccomp=seccomp_profile.json \
   --volume="$(pwd)/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
-  --volume="$(pwd)/../:/opt/examples:rw" \
+  --volume="$(pwd)/../../:/opt/elastic-synthetics:rw" \
   $IMAGE \
   bash

--- a/examples/docker/heartbeat.docker.yml
+++ b/examples/docker/heartbeat.docker.yml
@@ -7,7 +7,7 @@ heartbeat.config.monitors:
 
 heartbeat.synthetic_suites:
 - name: Todos
-  path: "/opt/examples/todos"
+  path: "/opt/elastic-synthetics/examples/todos"
   schedule: "@every 1m"
 
 processors:

--- a/examples/docker/run.sh
+++ b/examples/docker/run.sh
@@ -28,7 +28,7 @@ docker run \
   --net=host \
   --security-opt seccomp=seccomp_profile.json \
   --volume="$(pwd)/heartbeat.docker.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
-  --volume="$(pwd)/../:/opt/examples:rw" \
+  --volume="$(pwd)/../../:/opt/elastic-synthetics:rw" \
   $IMAGE \
   --strict.perms=false -e \
   $HEARTBEAT_ARGS

--- a/examples/todos/add-remove.journey.ts
+++ b/examples/todos/add-remove.journey.ts
@@ -1,5 +1,11 @@
 import { journey } from '@elastic/synthetics';
-import { loadAppStep, addTaskStep, assertTaskListSizeStep, checkForTaskStep, destroyTaskStep } from './helpers';
+import {
+  loadAppStep,
+  addTaskStep,
+  assertTaskListSizeStep,
+  checkForTaskStep,
+  destroyTaskStep,
+} from './helpers';
 
 journey('basic addition and completion of single task', async ({ page }) => {
   const testText = "Don't put salt in your eyes";
@@ -12,12 +18,8 @@ journey('basic addition and completion of single task', async ({ page }) => {
   assertTaskListSizeStep(page, 0);
 });
 
-journey("adding and removing a few tasks", async ({page}) => {
-  const testTasks = [
-    "Task 1",
-    "Task 2",
-    "Task 3",
-  ];
+journey('adding and removing a few tasks', async ({ page }) => {
+  const testTasks = ['Task 1', 'Task 2', 'Task 3'];
 
   loadAppStep(page);
   testTasks.forEach(t => {
@@ -25,12 +27,12 @@ journey("adding and removing a few tasks", async ({page}) => {
   });
 
   assertTaskListSizeStep(page, 3);
-  
+
   // remove the middle task and check that it worked
   destroyTaskStep(page, testTasks[1]);
   assertTaskListSizeStep(page, 2);
 
   // add a new task and check it exists
-  addTaskStep(page, "Task 4");
+  addTaskStep(page, 'Task 4');
   assertTaskListSizeStep(page, 3);
-})
+});

--- a/examples/todos/basics.journey.ts
+++ b/examples/todos/basics.journey.ts
@@ -1,28 +1,30 @@
 import { journey, step } from '@elastic/synthetics';
 import { deepStrictEqual } from 'assert';
-import { assert } from 'console';
 import { join } from 'path';
 
-journey("check that title is present", async ({page}) => {
-    step("go to app", async () => {
-        const path = "file://" + join(__dirname, "app", "index.html");
-        await page.goto(path);
-    })
+journey('check that title is present', async ({ page }) => {
+  step('go to app', async () => {
+    const path = 'file://' + join(__dirname, 'app', 'index.html');
+    await page.goto(path);
+  });
 
-    step("check title is present", async () => {
-        const header = await page.$('h1');
-        deepStrictEqual(await header.textContent(), "todos");
-    })
+  step('check title is present', async () => {
+    const header = await page.$('h1');
+    deepStrictEqual(await header.textContent(), 'todos');
+  });
 });
 
-journey("check that input placeholder is correct", async ({page}) => {
-    step("go to app", async () => {
-        const path = "file://" + join(__dirname, "app", "index.html");
-        await page.goto(path);
-    })
+journey('check that input placeholder is correct', async ({ page }) => {
+  step('go to app', async () => {
+    const path = 'file://' + join(__dirname, 'app', 'index.html');
+    await page.goto(path);
+  });
 
-    step("check title is present", async () => {
-        const input = await page.$('input.new-todo');
-        deepStrictEqual(await input.getAttribute('placeholder'), "What needs to be done?");
-    })
+  step('check title is present', async () => {
+    const input = await page.$('input.new-todo');
+    deepStrictEqual(
+      await input.getAttribute('placeholder'),
+      'What needs to be done?'
+    );
+  });
 });

--- a/examples/todos/helpers.ts
+++ b/examples/todos/helpers.ts
@@ -1,5 +1,5 @@
 import { step } from '@elastic/synthetics';
-import assert from 'assert';
+import * as assert from 'assert';
 import { join } from 'path';
 import { Page } from 'playwright-core';
 

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "file:../../elastic-synthetics.tgz",
+    "@elastic/synthetics": "file:../../",
     "playwright-core": "^1.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docker": "docker build . -t heartbeat-synthetics"
   },
   "bin": {
-    "@elastic/synthetics": "dist/cli.js"
+    "elastic-synthetics": "dist/cli.js"
   },
   "files": [
     "dist",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,7 +34,7 @@ export const journey = (
   options: JourneyOptions | string,
   callback: JourneyCallback
 ) => {
-  log(`register journey: ${options}`)
+  log(`register journey: ${options}`);
   if (typeof options === 'string') {
     options = { name: options, id: options };
   }
@@ -44,7 +44,7 @@ export const journey = (
 };
 
 export const step = (name: string, callback: VoidCallback) => {
-  log(`register step: ${name}`)
+  log(`register step: ${name}`);
   return runner.currentJourney?.addStep(name, callback);
 };
 

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -26,9 +26,9 @@
 import { program } from 'commander';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const { name, version } = require('../package.json');
+const { version } = require('../package.json');
 program
-  .name(name)
+  .name('elastic-synthetics')
   .usage('[options] [dir] [files] file')
   .option('-s, --suite-params <jsonstring>', 'Variables', '{}')
   .option('-e, --environment <envname>', 'e.g. production', 'development')


### PR DESCRIPTION
+ fix #124 #123 
This PR fixes multiple issues 
+ Handle symlinks and ignore them while running suites as it would crash the process by recursively searching for the same files
+ Ignore `node_modules` by default when running journey
+ Always install the latest version of synthetics package on the docker image and invoke from heartbeat side using `elastic-synthetics` executable without using the `npx` command as it would resolve the problem with local/global package collision
+ TS files are only compiled on the fly without type checking which is slower and not required for journey files from the users.

## Steps to run
+ `rm -rf node_modules`
+ `npm unlink` if you have linking before
+ `npm install` on the root folder

### To run examples locally, 
+ `cd examples/todos/ && npm install` 
+ `node dist/cli.js examples/todos` in the root or you can do `npm link` and run `elastic-synthetics examples/todos`


### For running inside heartbeat
**Note: heartbeat has to be changed to invoke the CLI through `elastic-synthetics`, but for testing purpose we can do this**
+ `cd examples/docker`
+ run `./bash-build-local.sh` which should give bash environment
+ `npm link` as we want the image to know about our unpublished new `elastic-synthetics` executable
+ `elastic-synthetics examples/todos`

 