### PR TITLE
Correction parse arg version for docker/bash.sh

### DIFF
--- a/examples/docker/bash.sh
+++ b/examples/docker/bash.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 VERSION=${1:-7.10.0}
-if [[ version =~ ^[0-9] ]]; then
+if [[ $VERSION =~ ^[0-9] ]]; then
 	IMAGE=docker.elastic.co/experimental/synthetics:$VERSION-synthetics
 else
 	IMAGE=$VERSION


### PR DESCRIPTION
Simple mistake in the bash script made it ignore the version arg