### PR TITLE
Report URL on errors

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -181,6 +181,7 @@ describe('runner', () => {
     expect(result).toEqual([
       {
         status: 'failed',
+        url: 'about:blank',
         error: expect.any(Error),
         screenshot: expect.any(String),
       },
@@ -209,6 +210,7 @@ describe('runner', () => {
     });
     expect(step2).toEqual({
       status: 'failed',
+      url: server.TEST_PAGE,
       error,
       screenshot: expect.any(String),
     });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -186,11 +186,11 @@ export default class Runner {
       if (metrics) {
         data.metrics = await pluginManager.get(PerformanceManager).getMetrics();
       }
-      data.url = driver.page.url();
     } catch (error) {
       data.status = 'failed';
       data.error = error;
     } finally {
+      data.url = driver.page.url();
       if (screenshots) {
         data.screenshot = (await driver.page.screenshot()).toString('base64');
       }


### PR DESCRIPTION
Prior to this patch we'd only report the URL in JSON output when the step passed.