### PR TITLE
chore: use published version in examples

### DIFF
--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -1,3 +1,13 @@
 ## Test Vue.js Examples
 
 This suite tests the examples that ship with the open source Vue.js project.
+
+### Running Journeys via Synthetics CLI
+
+```
+// Install the dependencies
+npm install
+
+// Invoke the Synthetics runner
+./node_modules/.bin/elastic-synthetics .
+```

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "file:../../",
+    "@elastic/synthetics": "^0.0.1-alpha.2",
     "playwright-core": "^1.5.2"
   }
 }


### PR DESCRIPTION
+ Uses the published versions in examples to make sure the examples works out of the box without doing local builds. 
+ updated readme.md with steps to run. 