### PR TITLE
chore: publish under two names

### DIFF
--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -9,5 +9,5 @@ This suite tests the examples that ship with the open source Vue.js project.
 npm install
 
 // Invoke the Synthetics runner
-./node_modules/.bin/elastic-synthetics .
+npx @elastic/synthetics .
 ```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docker": "docker build . -t heartbeat-synthetics"
   },
   "bin": {
+    "@elastic/synthetics": "dist/cli.js",
     "elastic-synthetics": "dist/cli.js"
   },
   "files": [

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -26,9 +26,9 @@
 import { program } from 'commander';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
-const { version } = require('../package.json');
+const { name, version } = require('../package.json');
 program
-  .name('elastic-synthetics')
+  .name(`npx ${name}`)
   .usage('[options] [dir] [files] file')
   .option('-s, --suite-params <jsonstring>', 'Variables', '{}')
   .option('-e, --environment <envname>', 'e.g. production', 'development')


### PR DESCRIPTION
+ this should make the `npx @elastic/synthetics` work. We have decided to keep the executable available under two names. We will revisit during the beta phase 