### PR TITLE
Use tini init daemon (correctly) in Docker (#134)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ RUN yum -y install epel-release && \
 	  xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
 	  yum clean all && \
     rm -rf /var/cache/yum
+
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+# or docker run your-image /your/program ...
 RUN echo /usr/share/heartbeat/.node \\
       /usr/share/heartbeat/.npm \\
       /usr/share/heartbeat/.cache \\

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN yum -y install epel-release && \
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/docker-entrypoint"]
 
 # or docker run your-image /your/program ...
 RUN echo /usr/share/heartbeat/.node \\


### PR DESCRIPTION
Without this chrome zombies sometimes appear. We should use an init daemon since we spawn subprocesses.

This is a redo of #134 which was reverted due to a bug. This should be tested with `./run-build-local.sh` and .`./bash-build-local.sh` (you can run `ps` in bash to check for `tini`)