### PR TITLE
Bump todos dep to use alpha6

### DIFF
--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "^0.0.1-alpha.2",
+    "@elastic/synthetics": "^0.0.1-alpha.6",
     "playwright-core": "^1.5.2"
   }
 }


### PR DESCRIPTION
This dep wasn't bumped with the last release. In the future we should automate this