### PR TITLE
chore: update playwright to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4706,9 +4706,9 @@
       }
     },
     "playwright-chromium": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.5.2.tgz",
-      "integrity": "sha512-ihaA5q5xJ2b+ydRnGLrx13UKXeTAQl6mQdjeXj9k2nthnlkFeHq+qTQkbK+I3QrgsB237XEkc/a1jx+2QmkIpA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.6.2.tgz",
+      "integrity": "sha512-yE/NVrttkVz/NKxOcIT2/OVemcU8TUfH3uwnfClaREnF8DZevbjwCEY4cgVaj8Peq9NQA0mVGR+mvTGrvQJOvA==",
       "requires": {
         "debug": "^4.1.1",
         "extract-zip": "^2.0.1",
@@ -6669,9 +6669,9 @@
       }
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "commander": "^6.0.0",
     "kleur": "^4.1.1",
-    "playwright-chromium": "^1.5.2",
+    "playwright-chromium": "^1.6.2",
     "snakecase-keys": "^3.2.0",
     "sonic-boom": "^1.1.0",
     "source-map-support": "^0.5.19",


### PR DESCRIPTION
+ Allows running playwright on macOS Big Sur. Fails to launch browsers on older versions. 