### PR TITLE
feat: add browser service to launch browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,6 +2324,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -2640,6 +2645,11 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2925,6 +2935,16 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -5060,6 +5080,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^6.0.0",
+    "http-proxy": "^1.18.1",
     "kleur": "^4.1.1",
     "playwright-chromium": "^1.5.2",
     "snakecase-keys": "^3.2.0",

--- a/src/browser-service.ts
+++ b/src/browser-service.ts
@@ -23,6 +23,7 @@
  *
  */
 
+import { URL } from 'url';
 import { createServer } from 'http';
 import { createProxyServer } from 'http-proxy';
 import { chromium } from 'playwright-chromium';
@@ -33,12 +34,10 @@ const proxyServer = createServer();
 proxyServer.on('upgrade', async function (req, socket, head) {
   const browserServer = await chromium.launchServer({ headless: true });
   const wsEndpoint = browserServer.wsEndpoint();
-  const parts = wsEndpoint.split('/');
-  const guid = parts.pop();
-  req.url = `/${guid}`;
-  const target = parts.join('/');
+  const { pathname, origin } = new URL(wsEndpoint);
+  req.url = pathname;
   console.log(`New browser: ${wsEndpoint}`);
-  proxy.ws(req, socket, head, { target });
+  proxy.ws(req, socket, head, { target: origin });
   const closeBrowser = async () => {
     await browserServer.close();
     console.log(`Socket closed: ${wsEndpoint}`);

--- a/src/browser-service.ts
+++ b/src/browser-service.ts
@@ -1,0 +1,53 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const httpProxy = require('http-proxy');
+const http = require('http');
+const { chromium } = require('playwright-chromium');
+
+const proxy = httpProxy.createProxyServer();
+const proxyServer = http.createServer();
+
+proxyServer.on('upgrade', async function (req, socket, head) {
+  const browserServer = await chromium.launchServer({ headless: true });
+  const wsEndpoint = browserServer.wsEndpoint();
+  const parts = wsEndpoint.split('/');
+  const guid = parts.pop();
+  req.url = `/${guid}`;
+  const target = parts.join('/');
+  console.log(`New browser: ${wsEndpoint}`);
+  proxy.ws(req, socket, head, { target });
+  socket.on('close', async () => {
+    await browserServer.close();
+    console.log(`Socket closed: ${wsEndpoint}`);
+  });
+});
+
+const port = 9322;
+proxyServer.listen(port, () => {
+  console.log(`Listening on port: ${port}`);
+});

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -46,9 +46,18 @@ export type Driver = {
  * related capabilities for the runner to run all journeys
  */
 export class Gatherer {
-  static async setupDriver(headless?: boolean): Promise<Driver> {
-    log('Gatherer: launching chrome');
-    const browser = await chromium.launch({ headless });
+  static async setupDriver(
+    headless?: boolean,
+    wsEndpoint?: string
+  ): Promise<Driver> {
+    let browser;
+    if (wsEndpoint) {
+      log(`Gatherer: connecting to WS endpoint: ${wsEndpoint}`);
+      browser = await chromium.connect({ wsEndpoint });
+    } else {
+      log('Gatherer: launching chrome');
+      browser = await chromium.launch({ headless });
+    }
     const context = await browser.newContext();
     const page = await context.newPage();
     const client = await context.newCDPSession(page);

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -50,7 +50,7 @@ export class Gatherer {
     headless?: boolean,
     wsEndpoint?: string
   ): Promise<Driver> {
-    let browser;
+    let browser: ChromiumBrowser;
     if (wsEndpoint) {
       log(`Gatherer: connecting to WS endpoint: ${wsEndpoint}`);
       browser = await chromium.connect({ wsEndpoint });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -53,6 +53,7 @@ export type RunOptions = {
   network?: boolean;
   outfd?: number;
   metrics?: boolean;
+  wsEndpoint?: string;
 };
 
 type BaseContext = {
@@ -120,7 +121,10 @@ export default class Runner {
 
   static async createContext(options: RunOptions): Promise<JourneyContext> {
     const start = getMonotonicTime();
-    const driver = await Gatherer.setupDriver(options.headless);
+    const driver = await Gatherer.setupDriver(
+      options.headless,
+      options.wsEndpoint
+    );
     const pluginManager = await Gatherer.beginRecording(driver, options);
     return {
       start,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export async function run(options: RunOptions) {
       network: options.network ?? cliArgs.network,
       pauseOnError: options.pauseOnError ?? cliArgs.pauseOnError,
       reporter: cliArgs.json && !options.reporter ? 'json' : options.reporter,
+      wsEndpoint: options.wsEndpoint ?? cliArgs.wsEndpoint,
       outfd,
     });
   } catch (e) {

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -57,6 +57,10 @@ program
   )
   .option('--journey-name <name>', 'only run the journey with the given name')
   .option(
+    '--ws-endpoint <endpoint>',
+    'Browser WebSocket endpoint to connect to'
+  )
+  .option(
     '--outfd <fd>',
     'specify a file descriptor for logs. Default is stdout',
     parseInt


### PR DESCRIPTION
This PR adds a browser service that can be used to launch browser on demand. It also adds `--ws-endpoint` option for the cli.

- To run the browser service simply run the JS file: `node dist/browser-service.js`
- To point the tests to use the browser service: `node dist/cli.js examples/todos/ --ws-endpoint=ws://localhost:9322`
