### PR TITLE
fix: sync browser version in docker and examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN  cd /usr/share/heartbeat/.node \\
       && mkdir node \\
       && curl https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz | tar -xJ --strip 1 -C node
 ENV PATH="/usr/share/heartbeat/.node/node/bin:$PATH"
-# Install the latest version of @elastic/synthetics, so heartbeat can
-# call the executable directly
-RUN npm i -g @elastic/synthetics@alpha
+# Install the latest version of @elastic/synthetics forcefully ignoring the previously
+# cached node_modules, hearbeat then calls the global executable to run test suites
+RUN npm i -g -f @elastic/synthetics

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -2,6 +2,7 @@
 set -e
 set -x
 STACK_VERSION=${1:-7.10.0}
-echo "Building docker image based on ${STACK_VERSION}..."
+echo "Installing package dependencies for running local build"
 npm i
+echo "Building docker image based on ${STACK_VERSION}..."
 docker build . -t heartbeat-synthetics-local --build-arg STACK_VERSION=$STACK_VERSION-synthetics

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "^0.0.1-alpha.6",
+    "@elastic/synthetics": "*",
     "playwright-core": "^1.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "jest",
     "coverage": "jest --coverage",
-    "docker": "docker build . -t heartbeat-synthetics"
+    "docker": "./build-docker.sh"
   },
   "bin": {
     "@elastic/synthetics": "dist/cli.js",


### PR DESCRIPTION
+ fix #142 
+ Forcefully reinstalls our `@elastic/synthetics` package by ignoring the cache incase any versions have changed. We have not used the `docker build --no-cache` as it will also clear out other dependency caches
+ By having the latest version on both official docker image and examples pointing to the latest published version. We synchronise the playwright versions inside the docker image and do not have a broken state. 
+ We can also remove the intermin solution that is put inside the heartbeat code https://github.com/elastic/beats/blob/heartbeat-synthetics/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L57 as the problem is not related to playwright being available instead a broken state.  

Steps to test this flow. 

```sh
// remove the previous docker image if you want to test in a clean environment
docker rmi heartbeat-synthetics-local
npm run docker 
cd examples/docker
./run-build-local.sh -E output.console={}
```