### PR TITLE
chore: disallow auto update of chrome browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "commander": "^6.0.0",
     "kleur": "^4.1.1",
-    "playwright-chromium": "^1.6.2",
+    "playwright-chromium": "=1.6.2",
     "snakecase-keys": "^3.2.0",
     "sonic-boom": "^1.1.0",
     "source-map-support": "^0.5.19",


### PR DESCRIPTION
+ This is a follow up of #142 and allows us to control the update of playwright effectively browsers to tie it with the proper version. Having `^` or `~` would allow minor/patch versions to be installed on user's machine/test environments if lockfiles are not taken in to account.