### PR TITLE
fix: associate network info with each step

### DIFF
--- a/__tests__/plugins/browser-console.test.ts
+++ b/__tests__/plugins/browser-console.test.ts
@@ -41,7 +41,7 @@ describe('BrowserConsole', () => {
     const browserConsole = new BrowserConsole(driver.page);
     browserConsole.start();
     await driver.page.goto(server.TEST_PAGE);
-    browserConsole.currentStep = { name: 'step-name', index: 0 };
+    browserConsole._currentStep = { name: 'step-name', index: 0 };
     await driver.page.evaluate(() =>
       console.warn('test-message', 1, { test: 'test' })
     );

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -24,6 +24,7 @@
  */
 
 import { Protocol } from 'playwright-chromium/types/protocol';
+import { Step } from './dsl';
 
 export type VoidCallback = () => void;
 
@@ -35,6 +36,11 @@ export type FilmStrip = {
   ts: number;
 };
 
+export type DefaultPluginOutput = {
+  step?: Partial<Step>;
+  timestamp: number;
+};
+
 export type NetworkInfo = {
   url: string;
   method: string;
@@ -42,7 +48,7 @@ export type NetworkInfo = {
   request: Protocol.Network.Request;
   response: Protocol.Network.Response;
   isNavigationRequest: boolean;
-  start: number;
-  end: number;
+  requestSentTime: number;
+  loadEndTime: number;
   status: number;
-};
+} & DefaultPluginOutput;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -34,7 +34,7 @@ import {
   NetworkInfo,
   VoidCallback,
 } from '../common_types';
-import { BrowserConsole, BrowserMessage, PluginManager } from '../plugins';
+import { BrowserMessage, PluginManager } from '../plugins';
 import { PerformanceManager, Metrics } from '../plugins';
 import { Driver, Gatherer } from './gatherer';
 import { log } from './logger';
@@ -181,7 +181,7 @@ export default class Runner {
     const { metrics, screenshots } = options;
     const { driver, pluginManager } = context;
     try {
-      pluginManager.get(BrowserConsole).currentStep = step;
+      pluginManager.onStep(step);
       await step.callback();
       await driver.page.waitForLoadState('load');
       if (metrics) {

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -33,6 +33,7 @@ import {
   filterFilmstrips,
 } from './';
 import { Driver } from '../core/gatherer';
+import { Step } from '../dsl';
 
 type PluginType = 'network' | 'trace' | 'performance' | 'browserconsole';
 
@@ -76,6 +77,11 @@ export class PluginManager {
 
   get<T extends Plugin>(Type: new (...args: any[]) => T): T {
     return this.plugins.get(Type.name) as T;
+  }
+
+  onStep(step: Step) {
+    this.get(BrowserConsole) && (this.get(BrowserConsole)._currentStep = step);
+    this.get(NetworkManager) && (this.get(NetworkManager)._currentStep = step);
   }
 
   async output(): Promise<PluginOutput> {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -94,6 +94,8 @@ export default class JSONReporter extends BaseReporter {
         if (networkinfo) {
           networkinfo.forEach(ni => {
             this.writeJSON('journey/network_info', journey, {
+              timestamp: ni.timestamp,
+              step: ni.step,
               payload: snakeCaseKeys(ni),
             });
           });


### PR DESCRIPTION
+ part of #152 
+ Associate the network information with each step as its required for the waterfall chart creation
+ fix the timestamp information as it was pointing to the journey end timestamp as opposed to the step start/end timestamp
+ Move `start/end` in favor of `requestSentTime/loadEndTime` as its when events are written and not the actual duration. 
/cc @Kerry350 