### PR TITLE
chore: improve tracer time by consuming as events

### DIFF
--- a/__tests__/plugins/tracing.test.ts
+++ b/__tests__/plugins/tracing.test.ts
@@ -42,7 +42,6 @@ describe('tracing', () => {
     await tracer.start(driver.client);
     await driver.page.goto(server.TEST_PAGE);
     const events = await tracer.stop(driver.client);
-    expect(events.toString('utf-8')).toContain('screenshot');
     const filmstrips = filterFilmstrips(events);
     expect(filmstrips).toMatchObject([
       {

--- a/src/plugins/tracing.ts
+++ b/src/plugins/tracing.ts
@@ -43,8 +43,7 @@ export function filterFilmstrips(
     return (
       name === 'Screenshot' &&
       cat === 'disabled-by-default-devtools.screenshot' &&
-      args &&
-      args.snapshot
+      args?.snapshot
     );
   });
 
@@ -68,6 +67,10 @@ export class Tracing {
       'disabled-by-default-devtools.screenshot',
     ];
     await client.send('Tracing.start', {
+      /**
+       * Using `ReportEvents` makes gathering trace events
+       * much faster as opposed to using `ReturnAsStream` mode
+       */
       transferMode: 'ReportEvents',
       traceConfig: {
         includedCategories,

--- a/src/plugins/tracing.ts
+++ b/src/plugins/tracing.ts
@@ -26,7 +26,7 @@
 import { CDPSession } from 'playwright-chromium';
 import { FilmStrip } from '../common_types';
 
-type TraceEvents = {
+type TraceEvent = {
   cat: string;
   name: string;
   args?: {
@@ -35,37 +35,18 @@ type TraceEvents = {
   ts: number;
 };
 
-export async function readProtocolStream(
-  client: CDPSession,
-  handle: string
-): Promise<Buffer> {
-  let eof = false;
-  const chunks = [];
-  while (!eof) {
-    const response = await client.send('IO.read', { handle });
-    eof = response.eof;
-    const chunk = Buffer.from(
-      response.data,
-      response.base64Encoded ? 'base64' : 'utf-8'
+export function filterFilmstrips(
+  traceEvents: Array<TraceEvent>
+): Array<FilmStrip> {
+  const events = traceEvents.filter(event => {
+    const { args, cat, name } = event;
+    return (
+      name === 'Screenshot' &&
+      cat === 'disabled-by-default-devtools.screenshot' &&
+      args &&
+      args.snapshot
     );
-    chunks.push(chunk);
-  }
-  await client.send('IO.close', { handle });
-  return Buffer.concat(chunks);
-}
-
-export function filterFilmstrips(buffer: Buffer): Array<FilmStrip> {
-  const data = JSON.parse(buffer.toString('utf-8'));
-  const events = (data.traceEvents as TraceEvents[]).filter(
-    ({ args, cat, name }) => {
-      return (
-        name === 'Screenshot' &&
-        cat === 'disabled-by-default-devtools.screenshot' &&
-        args &&
-        args.snapshot
-      );
-    }
-  );
+  });
 
   return events.map(event => ({
     snapshot: event.args.snapshot,
@@ -80,26 +61,34 @@ export function filterFilmstrips(buffer: Buffer): Array<FilmStrip> {
  */
 export class Tracing {
   async start(client: CDPSession) {
-    const includedCategories = ['disabled-by-default-devtools.screenshot'];
-    const { categories } = await client.send('Tracing.getCategories');
-    const excludedCategories = categories.filter(
-      cat => !includedCategories.includes(cat)
-    );
-
+    const includedCategories = [
+      // exclude all default categories
+      '-*',
+      // capture screenshots
+      'disabled-by-default-devtools.screenshot',
+    ];
     await client.send('Tracing.start', {
-      transferMode: 'ReturnAsStream',
+      transferMode: 'ReportEvents',
       traceConfig: {
         includedCategories,
-        excludedCategories,
       },
     });
   }
 
   async stop(client: CDPSession) {
-    const [event] = await Promise.all([
-      new Promise(f => client.once('Tracing.tracingComplete', f)),
+    const events = [];
+    const collectListener = payload => events.push(...payload.value);
+    client.on('Tracing.dataCollected', collectListener);
+
+    const [traceEvents] = await Promise.all([
+      new Promise(resolve =>
+        client.once('Tracing.tracingComplete', () => {
+          client.off('Tracing.dataCollected', collectListener);
+          resolve(events);
+        })
+      ),
       client.send('Tracing.end'),
     ]);
-    return readProtocolStream(client, (event as any).stream);
+    return traceEvents as Array<TraceEvent>;
   }
 }


### PR DESCRIPTION
+ Changes the Tracing.start protocol command to use the `ReportEvents` instead of `ReturnAsStream`. This makes the trace gathering much faster, as observed in some automated run timings:

### Average timings - With filmstrips alone
Before - 3 seconds 
After -  2.5 seconds 

This would be useful as we add more categories to trace when we start doing this #120 

