### PR TITLE
feat: adjust trace timestamps with internal clock

### DIFF
--- a/__tests__/helper.test.ts
+++ b/__tests__/helper.test.ts
@@ -32,6 +32,7 @@ import {
   generateTempPath,
   rewriteErrorStack,
   findPWLogsIndexes,
+  convertTraceTimestamp,
 } from '../src/helpers';
 
 it('indent message with seperator', () => {
@@ -43,10 +44,16 @@ it('indent message with seperator', () => {
 
 it('get monotonic clock time', () => {
   jest.spyOn(process, 'hrtime').mockImplementation(() => {
-    return [1, 1e7];
+    return [392583, 998697551];
   });
   const elapsedTime = getMonotonicTime();
-  expect(elapsedTime).toBe(1.01);
+  expect(elapsedTime).toBe(392583.998697551);
+});
+
+it('convert trace timestamp to internal time', () => {
+  const traceTimestamp = 392583998697;
+  const elapsedTime = convertTraceTimestamp(traceTimestamp);
+  expect(elapsedTime).toBe(392583.998697);
 });
 
 it('format errors', () => {

--- a/__tests__/plugins/tracing.test.ts
+++ b/__tests__/plugins/tracing.test.ts
@@ -46,8 +46,8 @@ describe('tracing', () => {
     expect(filmstrips).toMatchObject([
       {
         snapshot: expect.any(String),
-        name: 'Screenshot',
         ts: expect.any(Number),
+        startTime: expect.any(Number),
       },
     ]);
     await Gatherer.dispose(driver);

--- a/__tests__/reporters/__snapshots__/json.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/json.test.ts.snap
@@ -6,7 +6,7 @@ exports[`json reporter writes each step as NDJSON to the FD 1`] = `
 {\\"type\\":\\"step/screenshot\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"step\\":{\\"name\\":\\"s1\\",\\"index\\":1},\\"blob\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"step/end\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"step\\":{\\"name\\":\\"s1\\",\\"index\\":1},\\"payload\\":{\\"source\\":\\"async () => { }\\",\\"start\\":0,\\"end\\":10,\\"url\\":\\"dummy\\",\\"status\\":\\"succeeded\\"},\\"url\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"journey/network_info\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"payload\\":{\\"request\\":{},\\"response\\":{},\\"is_navigation_request\\":true},\\"package_version\\":\\"0.0.1\\"}
-{\\"type\\":\\"journey/filmstrips\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"payload\\":{\\"index\\":0,\\"name\\":\\"screenshot\\",\\"ts\\":1},\\"blob\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
+{\\"type\\":\\"journey/filmstrips\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"payload\\":{\\"index\\":0,\\"startTime\\":392583.998697,\\"ts\\":392583998697},\\"blob\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"journey/end\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"payload\\":{\\"start\\":0,\\"end\\":11,\\"status\\":\\"succeeded\\"},\\"package_version\\":\\"0.0.1\\"}
 "
 `;

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -107,8 +107,8 @@ describe('json reporter', () => {
       filmstrips: [
         {
           snapshot: 'dummy',
-          name: 'screenshot',
-          ts: 1,
+          ts: 392583998697,
+          startTime: 392583.998697,
         },
       ],
       networkinfo: [

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -31,8 +31,8 @@ export type StatusValue = 'succeeded' | 'failed' | 'skipped';
 
 export type FilmStrip = {
   snapshot: string;
-  name: string;
   ts: number;
+  startTime: number;
 };
 
 export type NetworkInfo = {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -52,12 +52,24 @@ export function generateTempPath() {
 }
 
 /**
- * As per the timings used in the Network Events from
- * Chrome devtools protocol
+ * We internally use the clock timing similar to the
+ * Chrome devtools protocol network events for
+ * journey and step start/end fields to make
+ * querying in the UI easier
  */
 export function getMonotonicTime() {
-  const hrTime = process.hrtime();
+  const hrTime = process.hrtime(); // [seconds, nanoseconds]
   return hrTime[0] * 1 + hrTime[1] / 1e9;
+}
+
+/**
+ * Converts the trace events timestamp field from the
+ * format -  hrTime[0] * 1e6 + Math.round(hrTime[1] / 1000) to
+ * the local internal timestamp similar to other event
+ * types (journey, step, etc)
+ */
+export function convertTraceTimestamp(ts: number) {
+  return ts / 1e6;
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -53,7 +53,7 @@ export function generateTempPath() {
 
 /**
  * We internally use the clock timing similar to the
- * Chrome devtools protocol network events for
+ * chrome devtools protocol network events for
  * journey and step start/end fields to make
  * querying in the UI easier
  */
@@ -65,8 +65,10 @@ export function getMonotonicTime() {
 /**
  * Converts the trace events timestamp field from the
  * format -  hrTime[0] * 1e6 + Math.round(hrTime[1] / 1000) to
- * the local internal timestamp similar to other event
- * types (journey, step, etc)
+ * the internal timestamp similar to other event types (journey, step, etc)
+ * Reference - https://github.com/samccone/chrome-trace-event/blob/d45bc8af3b5c53a3adfa2c5fc107b4fae054f579/lib/trace-event.ts#L21-L22
+ *
+ * Tested and verified on both Darwin and Linux
  */
 export function convertTraceTimestamp(ts: number) {
   return ts / 1e6;

--- a/src/plugins/tracing.ts
+++ b/src/plugins/tracing.ts
@@ -44,7 +44,10 @@ type TraceEvent = {
   args?: {
     snapshot: string;
   };
-  // monotonic clock timestamp of the event
+  /**
+   * Platform specific monotonic non decreasing clock time
+   * https://source.chromium.org/chromium/chromium/src/+/master:base/time/time.h;l=936;bpv=0;bpt=0
+   */
   ts: number;
 };
 

--- a/src/plugins/tracing.ts
+++ b/src/plugins/tracing.ts
@@ -25,13 +25,26 @@
 
 import { CDPSession } from 'playwright-chromium';
 import { FilmStrip } from '../common_types';
+import { convertTraceTimestamp } from '../helpers';
 
+/**
+ * Trace Event Format
+ * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+ */
 type TraceEvent = {
-  cat: string;
   name: string;
+  // event category
+  cat: string;
+  // process id
+  pid: number;
+  // thread id
+  tid: number;
+  // event phase
+  ph?: string;
   args?: {
     snapshot: string;
   };
+  // monotonic clock timestamp of the event
   ts: number;
 };
 
@@ -49,8 +62,8 @@ export function filterFilmstrips(
 
   return events.map(event => ({
     snapshot: event.args.snapshot,
-    name: event.name,
     ts: event.ts,
+    startTime: convertTraceTimestamp(event.ts),
   }));
 }
 

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -105,7 +105,7 @@ export default class JSONReporter extends BaseReporter {
               payload: {
                 index,
                 ...{
-                  name: strip.name,
+                  startTime: strip.startTime,
                   ts: strip.ts,
                 },
               },


### PR DESCRIPTION
+ Part of #85 
+ converts the trace timestamp used by the chrome devtools trace event format to the internally used monotonic clock which is based on the network events and also used on journey and step start/end timings.
+ This makes querying for filmstrips for each step easier as we can directly query for all `journey/filmstrip` events within the `start` and `end` time of the step. 