### PR TITLE
Add synthetics capabilities env var to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG STACK_VERSION=7.10.0-synthetics
+ENV ELASTIC_SYNTHETICS_CAPABLE=true
 FROM docker.elastic.co/observability-ci/heartbeat:${STACK_VERSION}
 USER root
 RUN yum -y install epel-release && \


### PR DESCRIPTION
As part of bringing synthetics to beta we want to merge the special heatbeat branch to master. We still, however, want to restrict synthetics usage to the synthetics docker image to prevent users from getting confusing errors running synthetics on a plain system. This env var can be checked by heartbeat before activating any synthetics monitors.

Goes toward #140 