### PR TITLE
feat: add request timing calculation for waterfall

### DIFF
--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -43,6 +43,12 @@ describe('network', () => {
     await driver.page.goto(server.TEST_PAGE);
     const netinfo = await network.stop();
     expect(netinfo.length).toBeGreaterThan(0);
+    expect(netinfo[0].timings).toMatchObject({
+      dns: expect.any(Number),
+      total: expect.any(Number),
+      wait: expect.any(Number),
+      receive: expect.any(Number),
+    });
     await Gatherer.dispose(driver);
   });
 });

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -50,5 +50,18 @@ export type NetworkInfo = {
   isNavigationRequest: boolean;
   requestSentTime: number;
   loadEndTime: number;
+  responseReceivedTime: number;
   status: number;
+  timings?: {
+    blocked: number;
+    queueing: number;
+    dns: number;
+    ssl: number;
+    proxy: number;
+    connect: number;
+    send: number;
+    wait: number;
+    receive: number;
+    total: number;
+  };
 } & DefaultPluginOutput;

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -149,10 +149,6 @@ export class NetworkManager {
       loadEndTime,
       responseReceivedTime,
     } = record;
-    const { timing } = response;
-    const issueTime = requestSentTime;
-    const startTime = timing.requestTime;
-
     const result: NetworkInfo['timings'] = {
       blocked: -1,
       queueing: -1,
@@ -165,6 +161,10 @@ export class NetworkManager {
       receive: -1,
       total: -1,
     };
+    if (response == null) {
+      return result;
+    }
+
     const toMilliseconds = (time: number) => (time === -1 ? -1 : time * 1000);
     const calculateDiffInMs = (
       name: keyof NetworkInfo['timings'],
@@ -200,10 +200,13 @@ export class NetworkManager {
         );
       }
     };
+    const timing = response.timing;
     const actResRcvdTime = this.getResponseReceivedTime(
-      response.timing,
+      timing,
       responseReceivedTime
     );
+    const issueTime = requestSentTime;
+    const startTime = timing == null ? -1 : timing.requestTime;
     const endTime = firstPositive([loadEndTime, actResRcvdTime]) || startTime;
 
     if (timing == null) {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -62,13 +62,15 @@ export class NetworkManager {
       requestSentTime: timestamp,
       isNavigationRequest,
       status: 0,
-      loadEndTime: 0,
+      loadEndTime: -1,
+      responseReceivedTime: -1,
       response: null,
+      timings: null,
     });
   }
 
   _onResponseReceived(event: Protocol.Network.responseReceivedPayload) {
-    const { requestId, response } = event;
+    const { requestId, response, timestamp } = event;
     const record = this.waterfallMap.get(requestId);
     if (!record) {
       return;
@@ -76,6 +78,7 @@ export class NetworkManager {
     Object.assign(record, {
       status: response.status,
       response,
+      responseReceivedTime: timestamp,
     });
     /**
      * Enhance request headers with additional information
@@ -89,12 +92,16 @@ export class NetworkManager {
   }
 
   _onLoadingFinished(event: Protocol.Network.loadingFinishedPayload) {
-    const { requestId, timestamp } = event;
+    const { requestId, timestamp, encodedDataLength } = event;
     const record = this.waterfallMap.get(requestId);
     if (!record) {
       return;
     }
+    if (record.response) {
+      record.response.encodedDataLength = encodedDataLength;
+    }
     record.loadEndTime = timestamp;
+    record.timings = this.calculateTimings(record);
   }
 
   _onLoadingFailed(event: Protocol.Network.loadingFailedPayload) {
@@ -104,6 +111,152 @@ export class NetworkManager {
       return;
     }
     record.loadEndTime = timestamp;
+    record.timings = this.calculateTimings(record);
+  }
+  /**
+   * Account for missing response received event and also adjust the
+   * response received event based on when first byte event was recorded
+   */
+  getResponseReceivedTime(
+    timing: Protocol.Network.Response['timing'],
+    responseReceivedTime: number
+  ) {
+    if (timing == null) {
+      return -1;
+    }
+    const startTime = timing.requestTime;
+    const headersReceivedTime = startTime + timing.receiveHeadersEnd / 1000;
+    if (
+      responseReceivedTime < 0 ||
+      responseReceivedTime > headersReceivedTime
+    ) {
+      responseReceivedTime = headersReceivedTime;
+    }
+    if (startTime > responseReceivedTime) {
+      responseReceivedTime = startTime;
+    }
+    return responseReceivedTime;
+  }
+
+  /**
+   * The timing calculations are based on the chrome devtools frontend
+   * https://github.com/ChromeDevTools/devtools-frontend/blob/7f5478d8ceb7586f23f4073ab5c2085dac1ec26a/front_end/network/RequestTimingView.js#L98-L193
+   */
+  calculateTimings(record: NetworkInfo) {
+    const {
+      response,
+      requestSentTime,
+      loadEndTime,
+      responseReceivedTime,
+    } = record;
+    const { timing } = response;
+    const issueTime = requestSentTime;
+    const startTime = timing.requestTime;
+
+    const result: NetworkInfo['timings'] = {
+      blocked: -1,
+      queueing: -1,
+      proxy: -1,
+      dns: -1,
+      ssl: -1,
+      connect: -1,
+      send: -1,
+      wait: -1,
+      receive: -1,
+      total: -1,
+    };
+    const toMilliseconds = (time: number) => (time === -1 ? -1 : time * 1000);
+    const calculateDiffInMs = (
+      name: keyof NetworkInfo['timings'],
+      start: number,
+      end: number
+    ) => {
+      if (start < Number.MAX_VALUE && start <= end) {
+        result[name] = toMilliseconds(end - start);
+      }
+    };
+    const firstPositive = (numbers: number[]) => {
+      for (let i = 0; i < numbers.length; ++i) {
+        if (numbers[i] > 0) {
+          return numbers[i];
+        }
+      }
+      return null;
+    };
+    /**
+     * requestTime is baseline in seconds, rest of the timing data are ticks in milliseconds
+     * from the requestTime, so we calculate the offset from that
+     */
+    const addOffsetRange = (
+      name: keyof NetworkInfo['timings'],
+      start: number,
+      end: number
+    ) => {
+      if (start >= 0 && end >= 0) {
+        calculateDiffInMs(
+          name,
+          startTime + start / 1000,
+          startTime + end / 1000
+        );
+      }
+    };
+    const actResRcvdTime = this.getResponseReceivedTime(
+      response.timing,
+      responseReceivedTime
+    );
+    const endTime = firstPositive([loadEndTime, actResRcvdTime]) || startTime;
+
+    if (timing == null) {
+      const start =
+        issueTime !== -1 ? issueTime : startTime !== -1 ? startTime : 0;
+      const middle = actResRcvdTime === -1 ? Number.MAX_VALUE : actResRcvdTime;
+      const end = endTime === -1 ? Number.MAX_VALUE : endTime;
+      calculateDiffInMs('total', start, end);
+      calculateDiffInMs('blocked', start, middle);
+      calculateDiffInMs('receive', middle, end);
+      return result;
+    }
+    calculateDiffInMs(
+      'total',
+      issueTime < startTime ? issueTime : startTime,
+      endTime
+    );
+    if (issueTime < startTime) {
+      calculateDiffInMs('queueing', issueTime, startTime);
+    }
+    const responseReceived = toMilliseconds(actResRcvdTime - startTime);
+
+    if (response.fromServiceWorker) {
+      addOffsetRange('blocked', 0, timing.workerStart);
+      addOffsetRange('wait', timing.sendEnd, responseReceived);
+    } else if (!timing.pushStart) {
+      const blockingEnd =
+        firstPositive([
+          timing.dnsStart,
+          timing.connectStart,
+          timing.sendStart,
+          responseReceived,
+        ]) || 0;
+      addOffsetRange('blocked', 0, blockingEnd);
+      addOffsetRange('proxy', timing.proxyStart, timing.proxyEnd);
+      addOffsetRange('dns', timing.dnsStart, timing.dnsEnd);
+      addOffsetRange('connect', timing.connectStart, timing.connectEnd);
+      addOffsetRange('ssl', timing.sslStart, timing.sslEnd);
+      addOffsetRange('send', timing.sendStart, timing.sendEnd);
+      addOffsetRange(
+        'wait',
+        Math.max(
+          timing.sendEnd,
+          timing.connectEnd,
+          timing.dnsEnd,
+          timing.proxyEnd,
+          blockingEnd
+        ),
+        responseReceived
+      );
+    }
+    calculateDiffInMs('receive', actResRcvdTime, endTime);
+    return result;
   }
 
   stop() {


### PR DESCRIPTION
+ fix #166 
+ part of #152 
+ Adds the request timing calculations for all network events when `--network` flag is enabled. The output is expected to be in the format

```
{
  blocked: 0.8809999562799931,
  queueing: 0.49599993508309126,
  proxy: -1,
  dns: -1,
  ssl: -1,
  connect: -1,
  send: 0.1300000585615635,
  wait: 60.22300000768155,
  receive: 0.9560000617057085,
  total: 62.686000019311905
}
```
**All of the data is in `milliseconds` and any missing data will be denoted with `-1`**

