### PR TITLE
fix: calculate blocking time properly for missing timing data

### DIFF
--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -43,12 +43,23 @@ describe('network', () => {
     await driver.page.goto(server.TEST_PAGE);
     const netinfo = await network.stop();
     expect(netinfo.length).toBeGreaterThan(0);
-    expect(netinfo[0].timings).toMatchObject({
-      dns: expect.any(Number),
-      total: expect.any(Number),
-      wait: expect.any(Number),
-      receive: expect.any(Number),
-    });
+    expect(netinfo[0]).toEqual(
+      jasmine.objectContaining({
+        step: null,
+        timestamp: expect.any(Number),
+        url: server.TEST_PAGE,
+        request: expect.any(Object),
+        response: expect.any(Object),
+        type: 'Document',
+        method: 'GET',
+        requestSentTime: expect.any(Number),
+        isNavigationRequest: true,
+        status: 200,
+        loadEndTime: expect.any(Number),
+        responseReceivedTime: expect.any(Number),
+        timings: expect.any(Object),
+      })
+    );
     await Gatherer.dispose(driver);
   });
 
@@ -71,5 +82,90 @@ describe('network', () => {
     expect(netinfo[1].status).toBe(302);
     expect(netinfo[2].status).toBe(200);
     await Gatherer.dispose(driver);
+  });
+
+  describe('waterfall timing calculation', () => {
+    const getEvent = () => {
+      return {
+        response: {
+          // requestTime is in seconds, rest of the timing.* is in milliseconds
+          timing: {
+            requestTime: 1,
+            proxyStart: -1,
+            proxyEnd: -1,
+            dnsStart: 0.1,
+            dnsEnd: 26,
+            connectStart: 26,
+            connectEnd: 92.669,
+            sslStart: 40,
+            sslEnd: 92,
+            sendStart: 94,
+            sendEnd: 95,
+            receiveHeadersEnd: 2350,
+          },
+        },
+        requestSentTime: 1,
+        loadEndTime: 3,
+        responseReceivedTime: 2,
+      };
+    };
+    it('calculate timings for a request event', () => {
+      const network = new NetworkManager();
+      const record = getEvent();
+      const timings = network.calculateTimings(record as any);
+      expect(timings).toEqual({
+        blocked: 0.09999999999998899,
+        queueing: -1,
+        proxy: -1,
+        dns: 25.900000000000034,
+        ssl: 52.00000000000004,
+        connect: 66.66899999999987,
+        send: 0.9999999999998899,
+        wait: 905,
+        receive: 1000,
+        total: 2000,
+      });
+    });
+
+    it('when some resource timing data is unavailable', () => {
+      const network = new NetworkManager();
+      const record = getEvent();
+      Object.assign(record.response.timing, {
+        connectEnd: -1,
+        dnsStart: -1,
+      });
+      const timings = network.calculateTimings(record as any);
+      expect(timings).toEqual({
+        blocked: 26.00000000000002,
+        connect: -1,
+        dns: -1,
+        proxy: -1,
+        queueing: -1,
+        receive: 1000,
+        send: 0.9999999999998899,
+        ssl: 52.00000000000004,
+        total: 2000,
+        wait: 905,
+      });
+    });
+
+    it('when complete resource timing is not available', () => {
+      const network = new NetworkManager();
+      const record = getEvent();
+      record.response.timing = null;
+      const timings = network.calculateTimings(record as any);
+      expect(timings).toEqual({
+        blocked: 1000,
+        connect: -1,
+        dns: -1,
+        proxy: -1,
+        queueing: -1,
+        receive: 1000,
+        send: -1,
+        ssl: -1,
+        total: 2000,
+        wait: -1,
+      });
+    });
   });
 });

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -160,7 +160,7 @@ export class NetworkManager {
     responseReceivedTime: number
   ) {
     if (timing == null) {
-      return -1;
+      return responseReceivedTime;
     }
     const startTime = timing.requestTime;
     const headersReceivedTime = startTime + timing.receiveHeadersEnd / 1000;


### PR DESCRIPTION
+ Blocking time was set to `Infinity` when timing data was unavailable. Found it while adding tests, I have added more descriptive tests for timing calculation. 
+ fix #185 