### PR TITLE
Fix broken overwrite of heartbeat args

### DIFF
--- a/examples/docker/run.sh
+++ b/examples/docker/run.sh
@@ -31,4 +31,4 @@ docker run \
   --volume="$(pwd)/../../:/opt/elastic-synthetics:rw" \
   "${IMAGE}" \
   --strict.perms=false -e \
-  "${HEARTBEAT_ARGS}"
+  ${HEARTBEAT_ARGS}


### PR DESCRIPTION
This was broken in https://github.com/elastic/synthetics/pull/189 which quoted this variable that should not have been quoted