### PR TITLE
fix: handle exit code correctly

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -1,0 +1,84 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { ChildProcess, spawn } from 'child_process';
+import { join } from 'path';
+
+describe('CLI', () => {
+  it('run suites and exit with 0', async () => {
+    const cli = new CLIMock([join(__dirname, 'fixtures', 'fake.journey.ts')]);
+    await cli.waitFor('Journey: fake journey');
+    expect(cli.text()).toContain('fake journey');
+    expect(await cli.exitCode).toBe(0);
+  });
+
+  it('run suites and exit with 1', async () => {
+    const cli = new CLIMock([join(__dirname, 'fixtures', 'error.journey.ts')]);
+    await cli.waitFor('boom');
+    expect(await cli.exitCode).toBe(1);
+  });
+});
+
+class CLIMock {
+  private process: ChildProcess;
+  private data: string;
+  private waitForText: string;
+  private waitForPromise: () => void;
+  exitCode: Promise<number>;
+
+  constructor(args: string[]) {
+    this.data = '';
+    this.process = spawn(
+      'node',
+      [join(__dirname, '..', 'dist', 'cli.js'), ...args],
+      {
+        env: process.env,
+        stdio: 'pipe',
+      }
+    );
+    const dataListener = data => {
+      this.data = data.toString();
+      if (this.waitForPromise && this.data.includes(this.waitForText)) {
+        this.process.stdout.off('data', dataListener);
+        this.waitForPromise();
+      }
+    };
+    this.process.stdout.on('data', dataListener);
+
+    this.exitCode = new Promise((res, rej) => {
+      this.process.stderr.on('data', data => rej(new Error(data)));
+      this.process.on('exit', code => res(code));
+    });
+  }
+
+  async waitFor(text: string): Promise<void> {
+    this.waitForText = text;
+    return new Promise(r => (this.waitForPromise = r));
+  }
+
+  text() {
+    return this.data;
+  }
+}

--- a/__tests__/fixtures/error.journey.ts
+++ b/__tests__/fixtures/error.journey.ts
@@ -23,26 +23,10 @@
  *
  */
 
-import { BrowserService } from '../../src/core/browser-service';
-import { Gatherer } from '../../src/core/gatherer';
-import { Server } from '../utils/server';
+import { journey, step } from '../../';
 
-describe('BrowserService', () => {
-  let browserService: BrowserService;
-  let server: Server;
-  beforeAll(async () => {
-    server = await Server.create();
-    browserService = new BrowserService({ port: 9323 });
-    browserService.init();
-  });
-  afterAll(async () => {
-    await server.close();
-    await browserService.dispose();
-  });
-
-  it('should create browser pages', async () => {
-    const driver = await Gatherer.setupDriver(true, 'ws://localhost:9323');
-    await driver.page.goto(server.TEST_PAGE);
-    await Gatherer.dispose(driver);
+journey('error journey', async ({}) => {
+  step('throw error', async () => {
+    throw new Error('boom');
   });
 });

--- a/__tests__/fixtures/fake.journey.ts
+++ b/__tests__/fixtures/fake.journey.ts
@@ -23,26 +23,8 @@
  *
  */
 
-import { BrowserService } from '../../src/core/browser-service';
-import { Gatherer } from '../../src/core/gatherer';
-import { Server } from '../utils/server';
+import { journey, step } from '../../dist';
 
-describe('BrowserService', () => {
-  let browserService: BrowserService;
-  let server: Server;
-  beforeAll(async () => {
-    server = await Server.create();
-    browserService = new BrowserService({ port: 9323 });
-    browserService.init();
-  });
-  afterAll(async () => {
-    await server.close();
-    await browserService.dispose();
-  });
-
-  it('should create browser pages', async () => {
-    const driver = await Gatherer.setupDriver(true, 'ws://localhost:9323');
-    await driver.page.goto(server.TEST_PAGE);
-    await Gatherer.dispose(driver);
-  });
+journey('fake journey', async ({}) => {
+  step('step1', async () => {});
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -56,7 +56,7 @@ describe('Run', () => {
   });
 });
 
-describe('Run - cli args', () => {
+describe.skip('Run - cli args', () => {
   let runnerSpy: jest.SpyInstance;
   let parseArgsSpy: jest.SpyInstance;
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageProvider: 'v8',
   testPathIgnorePatterns: ['dist'],
-  modulePathIgnorePatterns: ['/e2e/', '/utils/'],
+  modulePathIgnorePatterns: ['/e2e/', '/utils/', '/fixtures/'],
   globalSetup: './__tests__/utils/jest-global-setup.ts',
   globalTeardown: './__tests__/utils/jest-global-teardown.ts',
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,7 +161,7 @@ async function prepareSuites(inputs: string[]) {
    */
   const reporter = program.json ? 'json' : 'default';
 
-  await run({
+  const results = await run({
     params: suiteParams,
     environment: program.environment,
     reporter,
@@ -175,6 +175,16 @@ async function prepareSuites(inputs: string[]) {
     metrics: program.metrics,
     sandbox: program.sandbox,
   });
+
+  /**
+   * Exit with error status if any journey fails
+   */
+  for (const result of Object.values(results)) {
+    if (result.status === 'failed') {
+      process.exit(1);
+    }
+  }
+  return results;
 })().catch(e => {
   console.error(e);
   process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,6 @@ async function prepareSuites(inputs: string[]) {
       process.exit(1);
     }
   }
-  return results;
 })().catch(e => {
   console.error(e);
   process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@
 import { runner } from './core';
 import { RunOptions } from './core/runner';
 import { setLogger } from './core/logger';
-import { parseArgs } from './parse_args';
 import sourceMapSupport from 'source-map-support';
 
 export async function run(options: RunOptions) {
@@ -36,8 +35,6 @@ export async function run(options: RunOptions) {
   sourceMapSupport.install({
     environment: 'node',
   });
-
-  const cliArgs = parseArgs();
   /**
    * Use the NODE_ENV variable to control the environment if its not explicity
    * passed from either CLI or through the API
@@ -45,25 +42,15 @@ export async function run(options: RunOptions) {
   options.environment = options.environment || process.env['NODE_ENV'];
   /**
    * set up logger with appropriate file descriptor
-   * to capture all the DEBUG logs when running from heartbeat
+   * to capture all the DEBUG logs when run through heartbeat
    */
-  const outfd = options.outfd ?? cliArgs.outfd;
-  setLogger(outfd);
+  setLogger(options.outfd);
 
   try {
     return await runner.run({
       ...options,
-      headless: options.headless ?? cliArgs.headless,
-      screenshots: options.screenshots ?? cliArgs.screenshots,
-      filmstrips: options.filmstrips ?? cliArgs.filmstrips,
-      dryRun: options.dryRun ?? cliArgs.dryRun,
-      journeyName: options.journeyName ?? cliArgs.journeyName,
-      network: options.network ?? cliArgs.network,
-      pauseOnError: options.pauseOnError ?? cliArgs.pauseOnError,
-      reporter: cliArgs.json && !options.reporter ? 'json' : options.reporter,
-      wsEndpoint: options.wsEndpoint ?? cliArgs.wsEndpoint,
-      sandbox: options.sandbox ?? cliArgs.sandbox,
-      outfd,
+      headless: options.headless ?? true,
+      sandbox: options.sandbox ?? true,
     });
   } catch (e) {
     console.error('Failed to run the test', e);


### PR DESCRIPTION
+ fix #191 
+ Handle the exit code from the CLI runs correctly, now we exit with >0 error codes when any of the journey fails which include steps as well. If any error is thrown via assertion or error - CLI will exit with 1 exit code
+ Added tests by creating a CLI mock that runs and waits for the exit code.
+ Cleaned up some unwanted CLI args parsing code which is not relevant for our run API.