### PR TITLE
chore: upgrade deps and fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,16 +39,16 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "commander": "^6.2.1",
+    "commander": "^7.0.0",
     "http-proxy": "^1.18.1",
     "kleur": "^4.1.3",
-    "playwright-chromium": "=1.6.2",
+    "playwright-chromium": "=1.8.0",
     "snakecase-keys": "^3.2.1",
     "sonic-boom": "^1.3.0",
     "source-map-support": "^0.5.19",
     "totalist": "^2.0.0",
-    "ts-node": "^8.10.2",
-    "typescript": "^3.9.7"
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,8 @@ import { stdin, cwd } from 'process';
 import { resolve } from 'path';
 import { step, journey } from './core';
 import { log } from './core/logger';
-import { parseArgs } from './parse_args';
+import program from './parse_args';
+import { CliArgs } from './common_types';
 import {
   findPkgJsonByTraversing,
   isDepInstalled,
@@ -38,15 +39,16 @@ import {
 } from './helpers';
 import { run } from './';
 
-const program = parseArgs();
+const options = program.opts() as CliArgs;
 const resolvedCwd = cwd();
 /**
  * Set debug based on DEBUG ENV and -d flags
  * namespace - synthetics
  */
 const namespace = 'synthetics';
-process.env.DEBUG = (process.env.DEBUG === namespace ||
-  (program.debug ? program.debug : '')) as string;
+if (process.env.DEBUG === namespace || Boolean(options.debug)) {
+  process.env.DEBUG = '1';
+}
 
 const loadInlineScript = source => {
   const scriptFn = new Function('step', 'page', 'browser', 'params', source);
@@ -85,8 +87,8 @@ async function prepareSuites(inputs: string[]) {
    * Match all files inside the directory with the
    * .journey.{mjs|cjs|js|ts) extensions
    */
-  const pattern = program.pattern
-    ? new RegExp(program.pattern, 'i')
+  const pattern = options.pattern
+    ? new RegExp(options.pattern, 'i')
     : /.+\.journey\.([mc]js|[jt]s?)$/;
   /**
    * Ignore node_modules by default when running suites
@@ -114,14 +116,14 @@ async function prepareSuites(inputs: string[]) {
 }
 
 (async () => {
-  if (program.inline) {
+  if (options.inline) {
     const source = await readStdin();
     loadInlineScript(source);
   } else {
     /**
      * Preload modules before running the suites
      */
-    const modules = [].concat(program.require || []).filter(Boolean);
+    const modules = [].concat(options.require || []).filter(Boolean);
     for (const name of modules) {
       if (isDepInstalled(name)) {
         require(name);
@@ -155,25 +157,24 @@ async function prepareSuites(inputs: string[]) {
     requireSuites(suites);
   }
 
-  const suiteParams = JSON.parse(program.suiteParams);
   /**
    * use JSON reporter if json flag is enabled
    */
-  const reporter = program.json ? 'json' : 'default';
+  const reporter = options.json ? 'json' : 'default';
 
   const results = await run({
-    params: suiteParams,
-    environment: program.environment,
+    params: JSON.parse(options.suiteParams),
+    environment: options.environment,
     reporter,
-    headless: program.headless,
-    screenshots: program.screenshots,
-    dryRun: program.dryRun,
-    journeyName: program.journeyName,
-    network: program.network,
-    pauseOnError: program.pauseOnError,
-    outfd: program.outfd,
-    metrics: program.metrics,
-    sandbox: program.sandbox,
+    headless: options.headless,
+    screenshots: options.screenshots,
+    dryRun: options.dryRun,
+    journeyName: options.journeyName,
+    network: options.network,
+    pauseOnError: options.pauseOnError,
+    outfd: options.outfd,
+    metrics: options.metrics,
+    sandbox: options.sandbox,
   });
 
   /**

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -25,7 +25,6 @@
 
 import { Protocol } from 'playwright-chromium/types/protocol';
 import { Step } from './dsl';
-import { program } from 'commander';
 
 export type VoidCallback = () => void;
 
@@ -67,9 +66,7 @@ export type NetworkInfo = {
   };
 } & DefaultPluginOutput;
 
-type CommandType = typeof program.Command;
-
-export interface CliArgs extends CommandType {
+export type CliArgs = {
   environment?: string;
   outfd?: number;
   headless?: boolean;
@@ -84,6 +81,9 @@ export interface CliArgs extends CommandType {
   wsEndpoint?: string;
   sandbox?: boolean;
   json?: boolean;
+  pattern?: string;
+  inline: boolean;
+  require: string[];
   debug?: boolean;
   suiteParams?: string;
-}
+};

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -24,7 +24,6 @@
  */
 
 import { program } from 'commander';
-import { CliArgs } from './common_types';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
@@ -68,7 +67,4 @@ program
   .version(version)
   .description('Run synthetic tests');
 
-export const parseArgs = () => {
-  program.parse(process.argv);
-  return (program as unknown) as CliArgs;
-};
+export default program.parse(process.argv);


### PR DESCRIPTION
+ Updated the required deps-> mostly for playwright newer versions
+ Fixed the types mismatch for CLIArgs
+ Got rid of the parse args function and getting it ready for the new commands like `record`, `perf`, etc. 