### PR TITLE
Publish 7.11.0 docker image

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
         axes {
           axis {
             name 'STACK_VERSION'
-            values '8.0.0-synthetics', '7.10.0-synthetics'
+            values '8.0.0-synthetics', '7.10.0-synthetics', '7.11.0-synthetics'
           }
         }
         stages {


### PR DESCRIPTION
This corresponds to https://github.com/elastic/beats/pull/23767 and should (I think?) publish a 7.11.0 docker image. 