### PR TITLE
[CI] Automate release process

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -228,7 +228,7 @@ pipeline {
                 prepareRelease() {
                   sh(script: "npm publish --otp=\${TOTP_CODE} --tag alpha", label: 'publish to NPM')
                   setEnvVar('VERSION', sh(script: '''node -p "require('./package.json').version"''', returnStdout: true).trim())
-                  sh(script: "npm dist-tag add @elastic/synthetics@${VERSION} latest", label: 'retag latest')
+                  sh(script: "npm dist-tag add elastic/synthetics@${VERSION} latest", label: 'retag latest')
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -14,9 +14,11 @@ pipeline {
     SECCOMP_FILE = "${env.WORKSPACE}/${env.BASE_DIR}/.ci/seccomp_profile.json"
     DOCKER_IMG = "${env.DOCKER_REGISTRY}/observability-ci/synthetics"
     DOCKER_IMG_PUBLIC = "${env.DOCKER_REGISTRY}/experimental/synthetics"
+    NPMRC_SECRET = 'secret/jenkins-ci/npmjs/elasticmachine'
+    TOTP_SECRET = 'totp/code/npmjs-elasticmachine'
   }
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 12, unit: 'HOURS')  // to support releases then we will add a timeout in each stage
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
@@ -31,12 +33,16 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'run_all_stages', defaultValue: false, description: 'Force to run all stages.')
+    booleanParam(name: 'release', defaultValue: false, description: 'Release. If so, all the other parameters will be ignored when releasing from master.')
   }
   stages {
     /**
      Checkout the code and stash it, to use it on other stages.
      */
     stage('Checkout') {
+      options {
+        timeout(5)
+      }
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
@@ -56,6 +62,9 @@ pipeline {
      Checks formatting / linting.
      */
     stage('Lint') {
+      options {
+        timeout(5)
+      }
       steps {
         withGithubNotify(context: 'Linting') {
           cleanup()
@@ -68,11 +77,13 @@ pipeline {
         }
       }
     }
-
     /**
      Build the main package
      */
     stage('Build') {
+      options {
+        timeout(5)
+      }
       steps {
         withGithubNotify(context: 'Build') {
           cleanup()
@@ -88,6 +99,9 @@ pipeline {
      Execute integration tests.
      */
     stage('Test') {
+      options {
+        timeout(5)
+      }
       steps {
         withGithubNotify(context: 'Test') {
           cleanup()
@@ -105,8 +119,10 @@ pipeline {
         }
       }
     }
-
     stage('E2e Test') {
+      options {
+        timeout(15)
+      }
       steps {
         withGithubNotify(context: 'E2e Test') {
           cleanup()
@@ -125,11 +141,13 @@ pipeline {
         }
       }
     }
-
     /**
      Publish Docker images.
      */
     stage('Publish Docker image'){
+      options {
+        timeout(15)
+      }
       matrix {
         agent { label 'ubuntu-18 && immutable' }
         axes {
@@ -176,6 +194,57 @@ pipeline {
               }
             }
           }
+        }
+      }
+    }
+    stage('Release') {
+      options {
+        skipDefaultCheckout()
+      }
+      when {
+        beforeAgent true
+        allOf {
+          branch 'master'
+          expression { return params.release }
+        }
+      }
+      stages {
+        stage('Notify') {
+          options { skipDefaultCheckout() }
+          steps {
+            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
+                         body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
+          }
+        }
+        stage('Release CI') {
+          options { skipDefaultCheckout() }
+          steps {
+            cleanup()
+            withNodeEnv(){
+              dir("${BASE_DIR}"){
+                prepareRelease() {
+                  sh(script: "npm publish --otp=\${TOTP_CODE} --tag alpha", label: 'publish to NPM')
+                  setEnvVar('VERSION', sh(script: '''node -p "require('./package.json').version"''', returnStdout: true).trim())
+                  sh(script: "npm dist-tag add @elastic/synthetics@${VERSION} latest", label: 'retag latest')
+                }
+              }
+            }
+          }
+          post {
+            success {
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://github.com/elastic/apm-agent-rum-js/releases|Here>)")
+            }
+            always {
+              script {
+                currentBuild.description = "${currentBuild.description?.trim() ? currentBuild.description : ''} released"
+              }
+            }
+          }
+        }
+      }
+      post {
+        failure {
+          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
         }
       }
     }
@@ -245,4 +314,36 @@ def pushDockerImage(){
         script: "docker push ${env.DOCKER_IMG_TAG_BRANCH}")
     }
   }
+}
+
+/**
+  This is the wrapper to prepare the release context, for such, it's required
+  to decouple the build environment preparation from the TOTP access, otherwise
+  the TOTP might expire if it takes too long.
+ */
+def prepareRelease(Closure body){
+  withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
+    withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
+      sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version')
+      sh(script: 'npm ci', label: 'prepare the ci environment')
+      gitPush()
+      gitPush(args: '--tags')
+      withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
+        body()
+      }
+    }
+  }
+}
+
+/**
+  This is the wrapper to send notifications for the release process through
+  slack and email, since it requires some formatting to support the same
+  message in both systems.
+ */
+def notifyStatus(def args = [:]) {
+  slackSend(channel: '#synthetics-user_experience-uptime', color: args.slackStatus, message: "${args.subject}. ${args.body}",
+            tokenCredentialId: 'jenkins-slack-integration-token')
+  // transform slack URL format '(<URL|description>)' to 'URL'.
+  def bodyEmail = args.body.replaceAll('\\(<', '').replaceAll('\\|.*>\\)', '')
+  emailext(subject: args.subject, to: 'synthrum@elastic.co', body: bodyEmail)
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -229,10 +229,20 @@ pipeline {
             cleanup()
             withNodeEnv(){
               dir("${BASE_DIR}"){
-                prepareRelease() {
-                  sh(script: "npm publish --otp=${env.TOTP_CODE} --tag alpha", label: 'publish to NPM')
-                  setEnvVar('VERSION', sh(script: '''node -p "require('./package.json').version"''', returnStdout: true).trim())
-                  sh(script: "npm dist-tag add elastic/synthetics@${env.VERSION} latest", label: 'retag latest')
+                withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
+                  withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
+                    sh(script: 'npm ci', label: 'prepare the ci environment')
+                    sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version')
+                    gitPush()
+                    gitPush(args: '--tags')
+                    setEnvVar('VERSION', sh(script: '''node -p "require('./package.json').version"''', returnStdout: true).trim())
+                    withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
+                      sh(script: "npm publish --otp=${env.TOTP_CODE} --tag alpha", label: 'publish to NPM')
+                    }
+                    withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
+                      sh(script: "npm dist-tag --otp=${env.TOTP_CODE} add elastic/synthetics@${env.VERSION} latest", label: 'retag latest')
+                    }
+                  }
                 }
               }
             }
@@ -319,25 +329,6 @@ def pushDockerImage(){
       }
       sh(label: 'Push Docker image name',
         script: "docker push ${env.DOCKER_IMG_TAG_BRANCH}")
-    }
-  }
-}
-
-/**
-  This is the wrapper to prepare the release context, for such, it's required
-  to decouple the build environment preparation from the TOTP access, otherwise
-  the TOTP might expire if it takes too long.
- */
-def prepareRelease(Closure body){
-  withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
-    withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
-      sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version')
-      sh(script: 'npm ci', label: 'prepare the ci environment')
-      gitPush()
-      gitPush(args: '--tags')
-      withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
-        body()
-      }
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -249,7 +249,7 @@ pipeline {
           }
           post {
             success {
-              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release '${env.VERSION}' published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://github.com/elastic/apm-agent-rum-js/releases|Here>)")
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release '${env.VERSION}' published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://preview.npmjs.com/package/@elastic/synthetics/v/${env.VERSION}|${env.VERSION}>)")
             }
             always {
               script {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -220,22 +220,26 @@ pipeline {
           options { skipDefaultCheckout() }
           input {
             message 'Should we release a new version?'
+            ok 'Yes, we should.'
+          }
+          environment {
+            VERSION = ''
           }
           steps {
             cleanup()
             withNodeEnv(){
               dir("${BASE_DIR}"){
                 prepareRelease() {
-                  sh(script: "npm publish --otp=\${TOTP_CODE} --tag alpha", label: 'publish to NPM')
+                  sh(script: "npm publish --otp=${env.TOTP_CODE} --tag alpha", label: 'publish to NPM')
                   setEnvVar('VERSION', sh(script: '''node -p "require('./package.json').version"''', returnStdout: true).trim())
-                  sh(script: "npm dist-tag add elastic/synthetics@${VERSION} latest", label: 'retag latest')
+                  sh(script: "npm dist-tag add elastic/synthetics@${env.VERSION} latest", label: 'retag latest')
                 }
               }
             }
           }
           post {
             success {
-              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://github.com/elastic/apm-agent-rum-js/releases|Here>)")
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release '${env.VERSION}' published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://github.com/elastic/apm-agent-rum-js/releases|Here>)")
             }
             always {
               script {
@@ -247,7 +251,7 @@ pipeline {
       }
       post {
         failure {
-          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release '${env.VERSION}' failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -223,7 +223,7 @@ pipeline {
             ok 'Yes, we should.'
           }
           environment {
-            VERSION = ''
+            NPM_PACKAGE = '@elastic/synthetics'
           }
           steps {
             cleanup()
@@ -235,12 +235,13 @@ pipeline {
                     sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version')
                     gitPush()
                     gitPush(args: '--tags')
-                    setEnvVar('VERSION', sh(script: '''node -p "require('./package.json').version"''', returnStdout: true).trim())
+                    setEnvVar('VERSION', sh(script: "npm view ${env.NPM_PACKAGE} version", returnStdout: true).trim())
+                    log(level: 'INFO', text: "Version to be published '${env.VERSION}'")
                     withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
                       sh(script: "npm publish --otp=${env.TOTP_CODE} --tag alpha", label: 'publish to NPM')
                     }
                     withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
-                      sh(script: "npm dist-tag --otp=${env.TOTP_CODE} add elastic/synthetics@${env.VERSION} latest", label: 'retag latest')
+                      sh(script: "npm dist-tag --otp=${env.TOTP_CODE} add ${env.NPM_PACKAGE}@${env.VERSION} latest", label: 'retag latest')
                     }
                   }
                 }
@@ -249,7 +250,7 @@ pipeline {
           }
           post {
             success {
-              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release '${env.VERSION}' published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://preview.npmjs.com/package/@elastic/synthetics/v/${env.VERSION}|${env.VERSION}>)")
+              notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release '${env.VERSION}' published", body: "Great news, the release has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>). \n Release URL: (<https://preview.npmjs.com/package/${env.NPM_PACKAGE}/v/${env.VERSION}|${env.VERSION}>)")
             }
             always {
               script {
@@ -261,7 +262,7 @@ pipeline {
       }
       post {
         failure {
-          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release '${env.VERSION}' failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+          notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] Release '${env.VERSION?.trim()}' failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -218,6 +218,9 @@ pipeline {
         }
         stage('Release CI') {
           options { skipDefaultCheckout() }
+          input {
+            message 'Should we release a new version?'
+          }
           steps {
             cleanup()
             withNodeEnv(){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -231,6 +231,7 @@ pipeline {
               dir("${BASE_DIR}"){
                 withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
                   withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
+                    sh(script: 'npm run clean', label: 'clean release')
                     sh(script: 'npm ci', label: 'prepare the ci environment')
                     sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version')
                     gitPush()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ If you have access to publish the package to NPM, the process is as follows:
 1. Bump the alpha version by running `npm version prerelease --preid=alpha`
 1. Push commits and tags upstream with `git push upstream master && git push upstream --tags`
 1. Publish to NPM using with `npm publish --tag alpha`
-1. Mark the last published alpha tags as latest using `npm dist-tag add @elastic/synthetics@<$VERSION> latest`
+1. Mark the last published alpha tags as latest using `npm dist-tag add elastic/synthetics@<$VERSION> latest`
 
 #### CI based
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ If you have access to publish the package to NPM, the process is as follows:
 1. Bump the alpha version by running `npm version prerelease --preid=alpha`
 1. Push commits and tags upstream with `git push upstream master && git push upstream --tags`
 1. Publish to NPM using with `npm publish --tag alpha`
-1. Mark the last published alpha tags as latest using `npm dist-tag add elastic/synthetics@<$VERSION> latest`
+1. Mark the last published alpha tags as latest using `npm dist-tag add @elastic/synthetics@<$VERSION> latest`
 
 #### CI based
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,8 @@ heartbeat locally
 
 **NOTE: This project is currently in Alpha phase**
 
+#### Manually
+
 If you have access to publish the package to NPM, the process is as follows:
 
 1. Be sure you have checked out the `master` branch and have pulled the latest changes
@@ -145,6 +147,21 @@ If you have access to publish the package to NPM, the process is as follows:
 1. Push commits and tags upstream with `git push upstream master && git push upstream --tags`
 1. Publish to NPM using with `npm publish --tag alpha`
 1. Mark the last published alpha tags as latest using `npm dist-tag add @elastic/synthetics@<$VERSION> latest`
+
+#### CI based
+
+The release process is also automated in the way any specific commit from the master branch can be potentially released, for such it's required the below steps:
+
+1. Login to apm-ci.elastic.co
+1. Go to the [master](https://apm-ci.elastic.co/job/apm-agent-rum/job/elastic-synthetics/job/master/) pipeline.
+1. Click on `Build with parameters` with the below checkbox:
+  * `release` to be selected.
+  * other checkboxes should be left as default.
+1. Click on `Build`.
+1. Wait for an email or slack message to confirm the release is ready to be approved, it might take roughly 20 minutes.
+1. Click on the URL from the email or slack.
+1. Click on approve or abort.
+1. Then you can go to the `https://www.npmjs.com/package/@elastic/synthetics` to validate that the bundles have been published.
 
 ## CI
 


### PR DESCRIPTION
### What

Release automation from the `master` branch, with the below support:
* UI based, so it's required to be login in the CI and trigger a build manually with the `release` parameter.
* Email/slack notifications when a new release is triggered.
* Input approval to confirm the release should be out with 12 hours waiting for.
* Release automation with 2FA.

In addition, I updated the docs regarding the release process with the CI.

### Issue

Closes https://github.com/elastic/synthetics/issues/107

### Actions

- [x] Tests pipeline locally
  * For such I used a new repo (https://github.com/v1v/test-2fa/tree/feature/synthetics) that contains these changes.
  * https://preview.npmjs.com/package/test-2fa is the package
  * See releases in https://preview.npmjs.com/package/test-2fa/v/0.0.1-alpha.13

### UI

The release process might look like the below steps/screenshots:

- Release from master:

![image](https://user-images.githubusercontent.com/2871786/106892984-cba38500-66e4-11eb-91fd-514b24d16748.png)

- Input approval:

![image](https://user-images.githubusercontent.com/2871786/106892093-80d53d80-66e3-11eb-92a0-c6ffd25304a8.png)

Then, there are two UIs (the traditional and the blue ocean one)

![image](https://user-images.githubusercontent.com/2871786/106892150-93e80d80-66e3-11eb-935b-dbb0c3b7cb2c.png)

![image](https://user-images.githubusercontent.com/2871786/106890914-e88a8900-66e1-11eb-9447-7c72591797dd.png)

- If approved then

  * Version bump will happen and the tag creation too
  * NPM publish too

![image](https://user-images.githubusercontent.com/2871786/106895498-33a79a80-66e8-11eb-859c-6a4cd0ca8c46.png)

- If something bad happened before during the release but it might not publsihed anything yet to npm

![image](https://user-images.githubusercontent.com/2871786/106892364-df022080-66e3-11eb-9326-c5ab30fa0849.png)

- If something bad happened after it was published to the npmjs registry:

![image](https://user-images.githubusercontent.com/2871786/106894429-e545cc00-66e6-11eb-9b72-089df7c77889.png)

