### PR TITLE
fix: disable chromium sandboxing by default

### DIFF
--- a/__tests__/core/browser-service.test.ts
+++ b/__tests__/core/browser-service.test.ts
@@ -41,7 +41,9 @@ describe('BrowserService', () => {
   });
 
   it('should create browser pages', async () => {
-    const driver = await Gatherer.setupDriver(true, 'ws://localhost:9323');
+    const driver = await Gatherer.setupDriver({
+      wsEndpoint: 'ws://localhost:9323',
+    });
     await driver.page.goto(server.TEST_PAGE);
     await Gatherer.dispose(driver);
   });

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -32,13 +32,13 @@ jest.mock('../../src/plugins/network');
 
 describe('Gatherer', () => {
   it('boot and dispose driver', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     expect(typeof driver.page.goto).toBe('function');
     await Gatherer.dispose(driver);
   });
 
   it('begin recording based on flags', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     const pluginManager = await Gatherer.beginRecording(driver, {
       network: true,
     });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -60,13 +60,6 @@ describe('Run', () => {
       .spyOn(runner, 'run')
       .mockImplementation(() => Promise.resolve({}));
 
-    await run({ params: {}, environment: 'debug' });
-    expect(runnerSpy.mock.calls[0][0]).toEqual({
-      environment: 'debug',
-      headless: true,
-      params: {},
-      sandbox: true,
-    });
     const runParams: RunOptions = {
       params: {},
       environment: 'debug',
@@ -81,6 +74,6 @@ describe('Run', () => {
       sandbox: true,
     };
     await run(runParams);
-    expect(runnerSpy.mock.calls[1][0]).toEqual(runParams);
+    expect(runnerSpy.mock.calls[0][0]).toEqual(runParams);
   });
 });

--- a/__tests__/plugins/browser-console.test.ts
+++ b/__tests__/plugins/browser-console.test.ts
@@ -38,7 +38,7 @@ describe('BrowserConsole', () => {
   });
 
   it('should capture browser console logs', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     const browserConsole = new BrowserConsole(driver.page);
     browserConsole.start();
     await driver.page.goto(server.TEST_PAGE);

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -38,7 +38,7 @@ describe('network', () => {
   });
 
   it('should capture network info', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     const network = new NetworkManager();
     await network.start(driver.client);
     await driver.page.goto(server.TEST_PAGE);
@@ -63,7 +63,7 @@ describe('network', () => {
   });
 
   it('produce distinct events for redirects', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     const network = new NetworkManager();
     await network.start(driver.client);
     /**

--- a/__tests__/plugins/performance.test.ts
+++ b/__tests__/plugins/performance.test.ts
@@ -38,7 +38,7 @@ describe('performance', () => {
   });
 
   it('should capture page metrics', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     const performance = new PerformanceManager(driver.client);
     await performance.start();
     await driver.page.goto(server.TEST_PAGE);

--- a/__tests__/plugins/tracing.test.ts
+++ b/__tests__/plugins/tracing.test.ts
@@ -38,7 +38,7 @@ describe('tracing', () => {
   });
 
   it('should capture filmstrips', async () => {
-    const driver = await Gatherer.setupDriver(true, wsEndpoint);
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     const tracer = new Tracing();
     await tracer.start(driver.client);
     await driver.page.goto(server.TEST_PAGE);

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -46,22 +46,17 @@ export type Driver = {
  * related capabilities for the runner to run all journeys
  */
 export class Gatherer {
-  static async setupDriver(
-    headless?: boolean,
-    wsEndpoint?: string,
-    sandbox = true
-  ): Promise<Driver> {
+  static async setupDriver(options: RunOptions): Promise<Driver> {
     let browser: ChromiumBrowser;
+    const { wsEndpoint, headless, sandbox = false } = options;
     if (wsEndpoint) {
       log(`Gatherer: connecting to WS endpoint: ${wsEndpoint}`);
       browser = await chromium.connect({ wsEndpoint });
     } else {
       log('Gatherer: launching chrome');
-
       if (!sandbox) {
-        log('Gatherer: chromium sandbox is disabled');
+        log('Gatherer: chromium sandboxing is disabled');
       }
-
       browser = await chromium.launch({
         headless,
         chromiumSandbox: sandbox,

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -123,11 +123,7 @@ export default class Runner {
 
   static async createContext(options: RunOptions): Promise<JourneyContext> {
     const start = getMonotonicTime();
-    const driver = await Gatherer.setupDriver(
-      options.headless,
-      options.wsEndpoint,
-      options.sandbox
-    );
+    const driver = await Gatherer.setupDriver(options);
     const pluginManager = await Gatherer.beginRecording(driver, options);
     return {
       start,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,7 @@ export async function run(options: RunOptions) {
   setLogger(options.outfd);
 
   try {
-    return await runner.run({
-      ...options,
-      headless: options.headless ?? true,
-      sandbox: options.sandbox ?? true,
-    });
+    return await runner.run(options);
   } catch (e) {
     console.error('Failed to run the test', e);
     process.exit(1);

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -41,6 +41,11 @@ program
   .option('--inline', 'Run inline journeys from heartbeat')
   .option('-r, --require <modules...>', 'module(s) to preload')
   .option('--no-headless', 'run browser in headful mode')
+  .option('--sandbox', 'enable chromium sandboxing')
+  .option(
+    '--ws-endpoint <endpoint>',
+    'Browser WebSocket endpoint to connect to'
+  )
   .option(
     '--pause-on-error',
     'pause on error until a keypress is made in the console. Useful during development'
@@ -55,15 +60,10 @@ program
   )
   .option('--journey-name <name>', 'only run the journey with the given name')
   .option(
-    '--ws-endpoint <endpoint>',
-    'Browser WebSocket endpoint to connect to'
-  )
-  .option(
     '--outfd <fd>',
     'specify a file descriptor for logs. Default is stdout',
     parseInt
   )
-  .option('--no-sandbox', 'disable chromium sandbox')
   .version(version)
   .description('Run synthetic tests');
 


### PR DESCRIPTION
+ fix #225
+ By default the chromium sanboxing is disabled and can be enabled with `--sandbox` CLI option or using our runner API.
+ Cleaned up the driver arguments. 
```ts
import { run } from "@elastic/synthetics";

await run({ sandbox: true })
```