### PR TITLE
feat: add junit reporter

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -136,9 +136,7 @@ pipeline {
                 chmod -R ugo+rw examples
               ''')
               dir("${E2E_FOLDER}"){
-                timeout(time: 10, unit: 'MINUTES') {
-                  sh(label: 'run e2e tests',script: 'npm run test')
-                }
+                sh(label: 'run e2e tests',script: 'npm run test')
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -121,6 +121,9 @@ pipeline {
       }
     }
     stage('E2e Test') {
+      environment {
+        E2E_FOLDER = "__tests__/e2e"
+      }
       options {
         timeout(15)
       }
@@ -132,13 +135,18 @@ pipeline {
               sh(label: 'set permissions', script: '''
                 chmod -R ugo+rw examples
               ''')
-              dir("__tests__/e2e"){
+              dir("${E2E_FOLDER}"){
                 timeout(time: 10, unit: 'MINUTES') {
                   sh(label: 'run e2e tests',script: 'npm run test')
                 }
               }
             }
           }
+        }
+      }
+      post {
+        always {
+          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/${E2E_FOLDER}/**/junit.xml")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -144,7 +144,9 @@ pipeline {
       }
       post {
         always {
-          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/${E2E_FOLDER}/**/junit.xml")
+          sh(label: 'debug purposes',script: "ls -ltr ${BASE_DIR}/${E2E_FOLDER}")
+          archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${E2E_FOLDER}/junit.xml")
+          junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/${E2E_FOLDER}/junit.xml")
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -144,7 +144,6 @@ pipeline {
       }
       post {
         always {
-          sh(label: 'debug purposes',script: "ls -ltr ${BASE_DIR}/${E2E_FOLDER}")
           archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/${E2E_FOLDER}/junit.xml")
           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/${E2E_FOLDER}/junit.xml")
         }

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ tmp
 *.swp
 
 __tests__/e2e/tmp/
+__tests__/e2e/junit.xml
 
 .idea/
 seccomp/build

--- a/__tests__/e2e/docker-compose.yml
+++ b/__tests__/e2e/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - elasticsearch
       - synthetic
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5601/api/status"]
+      test: ["CMD", "curl", "-s", "-f", "http://localhost:5601/api/status"]
       interval: 30s
       retries: 10
       start_period: 30s

--- a/__tests__/e2e/scripts/setup.sh
+++ b/__tests__/e2e/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xe
+set -e
 
 # variables
 

--- a/__tests__/e2e/scripts/test.sh
+++ b/__tests__/e2e/scripts/test.sh
@@ -30,6 +30,6 @@ errorLevel=$?
 #
 # transform reporter to junit only format
 ##################################################
-grep -v "Waiting" tmp/reporter.out > tmp/junit.xml
+grep -v "Waiting" tmp/reporter.out > junit.xml
 
 exit ${errorLevel}

--- a/__tests__/e2e/scripts/test.sh
+++ b/__tests__/e2e/scripts/test.sh
@@ -24,4 +24,3 @@ echo "✅ Setup completed successfully. Running e2e tests..."
 # run e2e tests journey
 ##################################################
 SYNTHETICS_JUNIT_FILE='junit.xml' npx @elastic/synthetics uptime.journey.ts --reporter junit
-errorLevel=$?

--- a/__tests__/e2e/scripts/test.sh
+++ b/__tests__/e2e/scripts/test.sh
@@ -23,13 +23,5 @@ echo "✅ Setup completed successfully. Running e2e tests..."
 #
 # run e2e tests journey
 ##################################################
-set +e
-npx @elastic/synthetics uptime.journey.ts --reporter junit | tee tmp/reporter.out
+SYNTHETICS_JUNIT_FILE='junit.xml' npx @elastic/synthetics uptime.journey.ts --reporter junit
 errorLevel=$?
-
-#
-# transform reporter to junit only format
-##################################################
-grep -v "Waiting" tmp/reporter.out > junit.xml
-
-exit ${errorLevel}

--- a/__tests__/e2e/uptime.journey.ts
+++ b/__tests__/e2e/uptime.journey.ts
@@ -43,10 +43,13 @@ journey('E2e test synthetics', async ({ page }) => {
 
   step('Go to kibana uptime app', async () => {
     await page.goto('http://localhost:5620/app/uptime');
+    await page.waitForTimeout(30 * 1000);
   });
 
   step('Check if there is table data', async () => {
-    await page.click('[data-test-subj=uptimeOverviewPage]');
+    await page.click('[data-test-subj=uptimeOverviewPage]', {
+      timeout: 60 * 1000,
+    });
     await refreshUptimeApp();
     await page.click('div.euiBasicTable', { timeout: 60 * 1000 });
   });

--- a/__tests__/reporters/__snapshots__/junit.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/junit.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`base reporter writes each step to the FD 1`] = `
+"<testsuites name=\\"\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\" time=\\"0\\">
+   <testsuite name=\\"j1\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\">
+      <testcase name=\\"s1\\" classname=\\"j1 s1\\" time=\\"1\\">
+         <failure message=\\"Boom\\" type=\\"Error\\">
+         Error: Boom
+         </failure>
+      </testcase>
+      <testcase name=\\"s2\\" classname=\\"j1 s2\\" time=\\"1\\">
+         <skipped message=\\"previous step failed\\">
+         </skipped>
+      </testcase>
+   </testsuite>
+</testsuites>
+"
+`;

--- a/__tests__/reporters/__snapshots__/junit.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/junit.test.ts.snap
@@ -5,13 +5,7 @@ exports[`base reporter writes each step to the FD 1`] = `
    <testsuite name=\\"j1\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\">
       <testcase name=\\"s1\\" classname=\\"j1 s1\\" time=\\"1\\">
          <failure message=\\"Boom\\" type=\\"Error\\">
-         Error: Boom
-             at Object.&lt;anonymous&gt; (/Users/vigneshh/elastic/synthetic-monitoring/__tests__/reporters/junit.test.ts:50:14)
-             at Object.asyncJestTest (/Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:106:37)
-             at /Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/queueRunner.js:45:12
-             at new Promise (&lt;anonymous&gt;)
-             at mapper (/Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
-             at /Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/queueRunner.js:75:41
+         at /__tests/reporters/junit.test.ts
          </failure>
       </testcase>
       <testcase name=\\"s2\\" classname=\\"j1 s2\\" time=\\"1\\">

--- a/__tests__/reporters/__snapshots__/junit.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/junit.test.ts.snap
@@ -6,6 +6,12 @@ exports[`base reporter writes each step to the FD 1`] = `
       <testcase name=\\"s1\\" classname=\\"j1 s1\\" time=\\"1\\">
          <failure message=\\"Boom\\" type=\\"Error\\">
          Error: Boom
+             at Object.&lt;anonymous&gt; (/Users/vigneshh/elastic/synthetic-monitoring/__tests__/reporters/junit.test.ts:50:14)
+             at Object.asyncJestTest (/Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/jasmineAsyncInstall.js:106:37)
+             at /Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/queueRunner.js:45:12
+             at new Promise (&lt;anonymous&gt;)
+             at mapper (/Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/queueRunner.js:28:19)
+             at /Users/vigneshh/elastic/synthetic-monitoring/node_modules/jest-jasmine2/build/queueRunner.js:75:41
          </failure>
       </testcase>
       <testcase name=\\"s2\\" classname=\\"j1 s2\\" time=\\"1\\">

--- a/__tests__/reporters/__snapshots__/junit.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/junit.test.ts.snap
@@ -1,6 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`base reporter writes each step to the FD 1`] = `
+exports[`junit reporter writes the output to a file 1`] = `
+"<testsuites name=\\"\\" tests=\\"1\\" failures=\\"0\\" skipped=\\"1\\" errors=\\"0\\" time=\\"0\\">
+   <testsuite name=\\"j1\\" tests=\\"1\\" failures=\\"0\\" skipped=\\"1\\" errors=\\"0\\">
+      <testcase name=\\"s1\\" classname=\\"j1 s1\\" time=\\"1\\">
+         <skipped message=\\"previous step failed\\">
+         </skipped>
+      </testcase>
+   </testsuite>
+</testsuites>"
+`;
+
+exports[`junit reporter writes the output to fd 1`] = `
 "<testsuites name=\\"\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\" time=\\"0\\">
    <testsuite name=\\"j1\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\">
       <testcase name=\\"s1\\" classname=\\"j1 s1\\" time=\\"1\\">

--- a/__tests__/reporters/junit.test.ts
+++ b/__tests__/reporters/junit.test.ts
@@ -1,0 +1,77 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import fs from 'fs';
+import { runner, step, journey } from '../../src/core';
+import JUnitReporter from '../../src/reporters/junit';
+import * as helpers from '../../src/helpers';
+
+describe('base reporter', () => {
+  const dest = helpers.generateTempPath();
+  afterAll(() => fs.unlinkSync(dest));
+
+  it('writes each step to the FD', async () => {
+    const timestamp = 1600300800000000;
+    jest.spyOn(helpers, 'now').mockImplementation(() => 0);
+    const { stream } = new JUnitReporter(runner, {
+      fd: fs.openSync(dest, 'w'),
+    });
+    const j1 = journey('j1', async () => {});
+    runner.emit('journey:start', {
+      journey: j1,
+      params: {},
+      timestamp,
+    });
+    runner.emit('step:end', {
+      journey: j1,
+      status: 'failed',
+      error: new Error('Boom'),
+      step: step('s1', async () => {}),
+      start: 0,
+      end: 1,
+    });
+    runner.emit('step:end', {
+      journey: j1,
+      status: 'skipped',
+      step: step('s2', async () => {}),
+      start: 0,
+      end: 1,
+    });
+    runner.emit('journey:end', {
+      journey: j1,
+      start: 0,
+      status: 'failed',
+    });
+    runner.emit('end', 'done');
+    /**
+     * Close the underyling stream writing to FD to read all its contents
+     */
+    stream.end();
+    await new Promise(resolve => stream.once('finish', resolve));
+    const fd = fs.openSync(dest, 'r');
+    const buffer = fs.readFileSync(fd);
+    expect(buffer.toString()).toMatchSnapshot();
+  });
+});

--- a/__tests__/reporters/junit.test.ts
+++ b/__tests__/reporters/junit.test.ts
@@ -44,10 +44,16 @@ describe('base reporter', () => {
       params: {},
       timestamp,
     });
+    const error = new Error('Boom');
+    /**
+     * Snapshots would be different for everyone
+     * so keep it simple
+     */
+    error.stack = 'at /__tests/reporters/junit.test.ts';
     runner.emit('step:end', {
       journey: j1,
       status: 'failed',
-      error: new Error('Boom'),
+      error,
       step: step('s1', async () => {}),
       start: 0,
       end: 1,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,7 +160,7 @@ async function prepareSuites(inputs: string[]) {
   /**
    * use JSON reporter if json flag is enabled
    */
-  const reporter = options.json ? 'json' : 'default';
+  const reporter = options.json ? 'json' : options.reporter;
 
   const results = await run({
     params: JSON.parse(options.suiteParams),

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -25,10 +25,11 @@
 
 import { Protocol } from 'playwright-chromium/types/protocol';
 import { Step } from './dsl';
+import { reporters } from './reporters';
 
 export type VoidCallback = () => void;
-
 export type StatusValue = 'succeeded' | 'failed' | 'skipped';
+export type Reporters = keyof typeof reporters;
 
 export type FilmStrip = {
   snapshot: string;
@@ -83,7 +84,7 @@ export type CliArgs = {
   journeyName?: string;
   network?: boolean;
   pauseOnError?: boolean;
-  reporter?: string;
+  reporter?: Reporters;
   wsEndpoint?: string;
   sandbox?: boolean;
   json?: boolean;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -33,30 +33,21 @@ import {
   FilmStrip,
   NetworkInfo,
   VoidCallback,
+  CliArgs,
 } from '../common_types';
 import { BrowserMessage, PluginManager } from '../plugins';
 import { PerformanceManager, Metrics } from '../plugins';
 import { Driver, Gatherer } from './gatherer';
 import { log } from './logger';
 
-type RunParamaters = Record<string, any>;
-
-export type RunOptions = {
+export type RunOptions = Omit<
+  CliArgs,
+  'debug' | 'json' | 'pattern' | 'inline' | 'require' | 'suiteParams'
+> & {
   params?: RunParamaters;
-  environment?: string;
-  reporter?: 'default' | 'json';
-  headless?: boolean;
-  screenshots?: boolean;
-  filmstrips?: boolean;
-  dryRun?: boolean;
-  journeyName?: string;
-  pauseOnError?: boolean;
-  network?: boolean;
-  outfd?: number;
-  metrics?: boolean;
-  wsEndpoint?: string;
-  sandbox?: boolean;
 };
+
+type RunParamaters = Record<string, unknown>;
 
 type BaseContext = {
   params?: RunParamaters;
@@ -306,11 +297,11 @@ export default class Runner {
     }
     this.active = true;
     log(`Runner: run ${this.journeys.length} journeys`);
-    const { reporter = 'default', journeyName, outfd } = options;
+    const { reporter, journeyName, outfd } = options;
     /**
-     * Set up the corresponding reporter
+     * Set up the corresponding reporter and fallback
      */
-    const Reporter = reporters[reporter];
+    const Reporter = reporters[reporter] || reporters['default'];
     new Reporter(this, { fd: outfd });
     this.emit('start', { numJourneys: this.journeys.length });
     await this.runBeforeAllHook();

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -24,6 +24,11 @@
  */
 
 import { program } from 'commander';
+import { reporters } from './reporters';
+
+const availableReporters = Object.keys(reporters)
+  .map(r => String(r))
+  .join();
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
@@ -33,6 +38,10 @@ program
   .option('-s, --suite-params <jsonstring>', 'Variables', '{}')
   .option('-e, --environment <envname>', 'e.g. production', 'development')
   .option('-j, --json', 'output newline delimited JSON')
+  .option(
+    '--reporter <reporter>',
+    `output repoter format, can be one of ${availableReporters}`
+  )
   .option('-d, --debug', 'print debug logs info')
   .option(
     '--pattern <pattern>',

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -65,8 +65,8 @@ function renderDuration(durationMs) {
 export default class BaseReporter {
   stream: SonicBoom;
   fd: number;
-  constructor(public runner: Runner, public options: ReporterOptions = {}) {
-    this.runner = runner;
+
+  constructor(public runner: Runner, options: ReporterOptions = {}) {
     this.fd = options.fd || process.stdout.fd;
     this.stream = new SonicBoom({ fd: this.fd, sync: true });
     this._registerListeners();

--- a/src/reporters/index.ts
+++ b/src/reporters/index.ts
@@ -25,8 +25,10 @@
 
 import BaseReporter from './base';
 import JSONReporter from './json';
+import JUnitReporter from './junit';
 
 export const reporters = {
   default: BaseReporter,
   json: JSONReporter,
+  junit: JUnitReporter,
 };

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -1,0 +1,161 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { formatError, now } from '../helpers';
+import BaseReporter from './base';
+
+type XMLEntry = {
+  name: string;
+  attributes?: {
+    name: string;
+    timestamp?: number;
+    classname?: string;
+    time?: number;
+    tests?: number;
+    failures?: number;
+    skipped?: number;
+    errors?: number;
+  };
+  children?: XMLEntry[];
+  text?: string;
+};
+
+export default class JUnitReporter extends BaseReporter {
+  private totalTests = 0;
+  private totalFailures = 0;
+  private totalSkipped = 0;
+
+  _registerListeners() {
+    const journeyMap = new Map<string, XMLEntry>();
+
+    this.runner.on('journey:start', ({ journey }) => {
+      if (!journeyMap.has(journey.name)) {
+        const entry = {
+          name: 'testsuite',
+          attributes: {
+            name: journey.name,
+            tests: 0,
+            failures: 0,
+            skipped: 0,
+            errors: 0,
+          },
+          children: [],
+        };
+        journeyMap.set(journey.name, entry);
+      }
+    });
+
+    this.runner.on(
+      'step:end',
+      ({ journey, step, status, error, start, end }) => {
+        if (!journeyMap.has(journey.name)) {
+          return;
+        }
+        const entry = journeyMap.get(journey.name);
+        const caseEntry = {
+          name: 'testcase',
+          attributes: {
+            name: step.name,
+            classname: step.name + ' ' + journey.name,
+            time: end - start,
+          },
+          children: [],
+        };
+
+        entry.attributes.tests++;
+        if (status === 'failed') {
+          const { name, message, stack } = formatError(error);
+          caseEntry.children.push({
+            name: 'failure',
+            attributes: {
+              message,
+              type: name,
+            },
+            text: stack,
+          });
+          entry.attributes.failures++;
+        } else if (status === 'skipped') {
+          caseEntry.children.push({
+            name: 'skipped',
+            message: 'previous step failed',
+          });
+          entry.attributes.skipped++;
+        }
+        entry.children.push(caseEntry);
+      }
+    );
+
+    this.runner.on('journey:end', ({ journey }) => {
+      if (!journeyMap.has(journey.name)) {
+        return;
+      }
+      const { attributes } = journeyMap.get(journey.name);
+      this.totalTests += attributes.tests;
+      this.totalFailures += attributes.failures;
+      this.totalSkipped += attributes.skipped;
+    });
+
+    this.runner.on('end', () => {
+      const root: XMLEntry = {
+        name: 'testsuites',
+        attributes: {
+          name: '',
+          tests: this.totalTests,
+          failures: this.totalFailures,
+          skipped: this.totalSkipped,
+          errors: 0,
+          time: parseInt(String(now())) / 1000,
+        },
+        children: [...journeyMap.values()],
+      };
+      const tokens = serializeXML(root);
+      const output = tokens.join('\n');
+      this.write(output);
+    });
+  }
+}
+
+function escape(text: string): string {
+  return text
+    .replace(/"/g, '&quot;')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function serializeXML(entry: XMLEntry, tokens: string[] = []) {
+  const xmlAttributes: string[] = [];
+  for (const name of Object.keys(entry.attributes || {})) {
+    xmlAttributes.push(`${name}="${escape(String(entry.attributes[name]))}"`);
+  }
+  tokens.push(`<${entry.name} ${xmlAttributes.join(' ')}>`);
+  for (const child of entry.children || []) {
+    serializeXML(child, tokens);
+  }
+  if (entry.text) tokens.push(escape(entry.text));
+  tokens.push(`</${entry.name}>`);
+
+  return tokens;
+}

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -89,14 +89,14 @@ export default class JUnitReporter extends BaseReporter {
 
         entry.attributes.tests++;
         if (status === 'failed') {
-          const { name, message } = formatError(error);
+          const { name, message, stack } = formatError(error);
           caseEntry.children.push({
             name: 'failure',
             attributes: {
               message,
               type: name,
             },
-            text: `${name}: ${message}`,
+            text: stack,
           });
           entry.attributes.failures++;
         } else if (status === 'skipped') {

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -23,6 +23,8 @@
  *
  */
 
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
 import { formatError, indent, now } from '../helpers';
 import BaseReporter from './base';
 
@@ -136,7 +138,16 @@ export default class JUnitReporter extends BaseReporter {
         children: [...journeyMap.values()],
       };
       const output = serializeEntries(root).join('\n');
-      this.write(output);
+      /**
+       * write the xml output to a file if specified via env flag
+       */
+      const fileName = process.env['SYNTHETICS_JUNIT_FILE'];
+      if (fileName) {
+        mkdirSync(dirname(fileName), { recursive: true });
+        writeFileSync(fileName, output);
+      } else {
+        this.write(output);
+      }
     });
   }
 }


### PR DESCRIPTION
+ fix #149 
+ Can be invoked via the `reporter flag` from CLI
```sh
npx @elastic/synthetics suites --reporter=junit
// OR
npx @elastic/synthetics suites --reporter junit
```

```xml
<testsuites name=\\"\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\" time=\\"0\\">
   <testsuite name=\\"j1\\" tests=\\"2\\" failures=\\"1\\" skipped=\\"1\\" errors=\\"0\\">
      <testcase name=\\"s1\\" classname=\\"j1 s1\\" time=\\"1\\">
         <failure message=\\"Boom\\" type=\\"Error\\">
         Error: Boom
         </failure>
      </testcase>
      <testcase name=\\"s2\\" classname=\\"j1 s2\\" time=\\"1\\">
         <skipped message=\\"previous step failed\\">
         </skipped>
      </testcase>
   </testsuite>
</testsuites>

```

+ Extract the test case to a separate file using the env flag

```
SYNTHETICS_JUNIT_FILE='/path/to/junit.xml' npx @elastic/synthetics suites --reporter junit
```