### PR TITLE
Use 8.0.0-SNAPSHOT to run e2e tests

### DIFF
--- a/__tests__/e2e/docker-compose.yml
+++ b/__tests__/e2e/docker-compose.yml
@@ -19,7 +19,6 @@ services:
         hard: -1
     ports:
       - '9220:9200'
-      - '9320:9300'
     expose:
       - '9220'
     networks:

--- a/__tests__/e2e/docker-compose.yml
+++ b/__tests__/e2e/docker-compose.yml
@@ -18,7 +18,10 @@ services:
         soft: -1
         hard: -1
     ports:
-      - 127.0.0.1:9200:9200
+      - '9220:9200'
+      - '9320:9300'
+    expose:
+      - '9220'
     networks:
       - elastic
   kibana:
@@ -33,14 +36,16 @@ services:
       retries: 10
       start_period: 30s
     ports:
-      - 127.0.0.1:5601:5601
+      - 127.0.0.1:5620:5601
+    expose:
+      - '5620'
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
     networks:
       - elastic
   synthetic:
-    image: docker.elastic.co/experimental/synthetics:${STACK_VERSION}-synthetics
+    image: docker.elastic.co/experimental/synthetics:${SYNTHETICS_VERSION}-synthetics
     container_name: synthetics
     depends_on:
       - elasticsearch

--- a/__tests__/e2e/scripts/setup.sh
+++ b/__tests__/e2e/scripts/setup.sh
@@ -33,4 +33,4 @@ echo "" # newline
 echo "${bold}Starting elasticsearch , kibana and synthetics docker${normal}"
 echo "" # newline
 
-STACK_VERSION=7.10.0 docker-compose --file docker-compose.yml up --remove-orphans > ${TMP_DIR}/docker-logs.log 2>&1 &
+STACK_VERSION=8.0.0-SNAPSHOT SYNTHETICS_VERSION=8.0.0 docker-compose --file docker-compose.yml up --remove-orphans > ${TMP_DIR}/docker-logs.log 2>&1 &

--- a/__tests__/e2e/uptime.journey.ts
+++ b/__tests__/e2e/uptime.journey.ts
@@ -42,7 +42,7 @@ journey('E2e test synthetics', async ({ page }) => {
   }
 
   step('Go to kibana uptime app', async () => {
-    await page.goto('http://localhost:5601/app/uptime');
+    await page.goto('http://localhost:5620/app/uptime');
   });
 
   step('Check if there is table data', async () => {
@@ -67,7 +67,7 @@ async function waitForSyntheticsData() {
   while (!status) {
     try {
       const { data } = await axios.post(
-        'http://localhost:9200/heartbeat-*/_search',
+        'http://localhost:9220/heartbeat-*/_search',
         {
           query: {
             bool: {
@@ -100,7 +100,7 @@ async function waitForElasticSearch() {
 
   while (!esStatus) {
     try {
-      const { data } = await axios.get('http://localhost:9200/_cluster/health');
+      const { data } = await axios.get('http://localhost:9220/_cluster/health');
       esStatus = data?.status !== 'red';
     } catch (e) {}
   }
@@ -113,7 +113,7 @@ async function waitForKibana() {
 
   while (!esStatus) {
     try {
-      const { data } = await axios.get('http://localhost:5601/api/status');
+      const { data } = await axios.get('http://localhost:5620/api/status');
       esStatus = data?.status.overall.state === 'green';
     } catch (e) {}
   }

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@elastic/synthetics": "*",
+    "playwright-chromium": "^1.9.1",
     "playwright-core": "=1.6.2"
   }
 }

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "dependencies": {
     "@elastic/synthetics": "*",
-    "playwright-chromium": "^1.9.1",
     "playwright-core": "=1.6.2"
   }
 }


### PR DESCRIPTION
While doing poc e2e tests were setup using 7.10.0 , since we have 8.0.0-SNAPSHOT available, we should run tests against that version.

Also using 5620 and 9220 ports for kibana and ES. Since 5601 and 9200 are being used for local dev usually.

Fixes: https://github.com/elastic/synthetics/issues/197

