### PR TITLE
feat: expose driver types from the agent

### DIFF
--- a/examples/todos/advanced.journey.ts
+++ b/examples/todos/advanced.journey.ts
@@ -7,7 +7,7 @@ import {
   destroyTaskStep,
 } from './helpers';
 
-journey('basic addition and completion of single task', async ({ page }) => {
+journey('addition and completion of single task', async ({ page }) => {
   const testText = "Don't put salt in your eyes";
 
   loadAppStep(page);
@@ -18,7 +18,7 @@ journey('basic addition and completion of single task', async ({ page }) => {
   assertTaskListSizeStep(page, 0);
 });
 
-journey('adding and removing a few tasks', async ({ page }) => {
+journey('adding and removing multiple tasks', async ({ page }) => {
   const testTasks = ['Task 1', 'Task 2', 'Task 3'];
 
   loadAppStep(page);

--- a/examples/todos/basic.journey.ts
+++ b/examples/todos/basic.journey.ts
@@ -2,25 +2,25 @@ import { journey, step } from '@elastic/synthetics';
 import { deepStrictEqual } from 'assert';
 import { join } from 'path';
 
-journey('check that title is present', async ({ page }) => {
-  step('go to app', async () => {
+journey('check if title is present', async ({ page }) => {
+  step('launch app', async () => {
     const path = 'file://' + join(__dirname, 'app', 'index.html');
     await page.goto(path);
   });
 
-  step('check title is present', async () => {
+  step('assert title', async () => {
     const header = await page.$('h1');
     deepStrictEqual(await header.textContent(), 'todos');
   });
 });
 
-journey('check that input placeholder is correct', async ({ page }) => {
-  step('go to app', async () => {
+journey('check if input placeholder is correct', async ({ page }) => {
+  step('launch app', async () => {
     const path = 'file://' + join(__dirname, 'app', 'index.html');
     await page.goto(path);
   });
 
-  step('check title is present', async () => {
+  step('assert placeholder value', async () => {
     const input = await page.$('input.new-todo');
     deepStrictEqual(
       await input.getAttribute('placeholder'),

--- a/examples/todos/helpers.ts
+++ b/examples/todos/helpers.ts
@@ -1,10 +1,9 @@
-import { step } from '@elastic/synthetics';
+import { step, Page } from '@elastic/synthetics';
 import * as assert from 'assert';
 import { join } from 'path';
-import { Page } from 'playwright-core';
 
 export const loadAppStep = (page: Page) => {
-  step('go to app', async () => {
+  step('launch app', async () => {
     const path = 'file://' + join(__dirname, 'app', 'index.html');
     await page.goto(path);
   });

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,6 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "*",
-    "playwright-core": "=1.6.2"
+    "@elastic/synthetics": "file:../../"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,3 +55,13 @@ export async function run(options: RunOptions) {
 }
 
 export { beforeAll, afterAll, journey, step, before, after } from './core';
+/**
+ * Export all the driver related types to be consumed
+ * and used by suites
+ */
+export type {
+  Page,
+  ChromiumBrowser,
+  ChromiumBrowserContext,
+  CDPSession,
+} from 'playwright-chromium';


### PR DESCRIPTION
+ Solves the problem specified in #158
+ Exposes all of the driver types that could be used from the suites
+ It solves the problem of users needing to import `playwright-core` or `playwright-*` for using types and eventually run in to problems of version mismatch. 
+ Once we add support for multiple browsers, we would expose the types from `playwright-core` instead and rest would look the same 