### PR TITLE
chore: fix todos example deps

### DIFF
--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,6 +5,6 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "file:../../"
+    "@elastic/synthetics": "*"
   }
 }


### PR DESCRIPTION
+ The new release is published with the types- we can safely use it now to refer types. https://github.com/elastic/synthetics/releases/tag/v0.0.1-alpha.11