### PR TITLE
ci: set the correct new version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -242,10 +242,9 @@ pipeline {
                   withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
                     sh(script: 'npm run clean', label: 'clean release')
                     sh(script: 'npm ci', label: 'prepare the ci environment')
-                    sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version')
+                    etEnvVar('VERSION', sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version', returnStdout: true).trim())
                     gitPush()
                     gitPush(args: '--tags')
-                    setEnvVar('VERSION', sh(script: "npm view ${env.NPM_PACKAGE} version", returnStdout: true).trim())
                     log(level: 'INFO', text: "Version to be published '${env.VERSION}'")
                     withTotpVault(secret: "${env.TOTP_SECRET}", code_var_name: 'TOTP_CODE'){
                       sh(script: "npm publish --otp=${env.TOTP_CODE} --tag alpha", label: 'publish to NPM')

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -242,7 +242,7 @@ pipeline {
                   withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
                     sh(script: 'npm run clean', label: 'clean release')
                     sh(script: 'npm ci', label: 'prepare the ci environment')
-                    etEnvVar('VERSION', sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version', returnStdout: true).trim())
+                    setEnvVar('VERSION', sh(script: 'npm version prerelease --preid=alpha', label: 'bump the alpha version', returnStdout: true).trim())
                     gitPush()
                     gitPush(args: '--tags')
                     log(level: 'INFO', text: "Version to be published '${env.VERSION}'")


### PR DESCRIPTION
### What

Set `VERSION` with the upcoming new release


![image](https://user-images.githubusercontent.com/2871786/110814512-6a417980-8281-11eb-9ea3-478bcf640c61.png)


### Question

In my local I had some notice traces when running the command `npm version prerelease --preid=alpha`

![image](https://user-images.githubusercontent.com/2871786/110814577-7af1ef80-8281-11eb-8397-2aa9a93b68f0.png)

Will this cause any issues? 
Is there any other command in npm to fetch the new version?


### Issues

Closes https://github.com/elastic/synthetics/issues/240