### PR TITLE
feat: report number of journeys in json

### DIFF
--- a/__tests__/reporters/__snapshots__/json.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/json.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`json reporter captures number of journeys as metadata event 1`] = `
+"{\\"type\\":\\"synthetics/metadata\\",\\"@timestamp\\":1600300800000000,\\"root_fields\\":{\\"num_journeys\\":10,\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"package_version\\":\\"0.0.1\\"}
+"
+`;
+
 exports[`json reporter formats network fields in ECS format 1`] = `
 Object {
   "http": Object {

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -46,6 +46,19 @@ describe('json reporter', () => {
   let stream;
   let runner: Runner;
   const timestamp = 1600300800000000;
+  const originalProcess = global.process;
+
+  beforeAll(() => {
+    // Mocking the process in node environment
+    global.process = {
+      ...originalProcess,
+      platform: 'darwin',
+    };
+  });
+
+  afterAll(() => {
+    global.process = originalProcess;
+  });
 
   beforeEach(() => {
     runner = new Runner();
@@ -83,13 +96,6 @@ describe('json reporter', () => {
   };
 
   it('writes each step as NDJSON to the FD', async () => {
-    // Mocking the process in node environment
-    const originalProcess = global.process;
-    global.process = {
-      ...originalProcess,
-      platform: 'darwin',
-    };
-
     runner.emit('journey:register', {
       journey: j1,
     });
@@ -129,7 +135,6 @@ describe('json reporter', () => {
       ],
     });
     runner.emit('end', 'done');
-    global.process = originalProcess;
     expect((await readAndCloseStream()).toString()).toMatchSnapshot();
   });
 

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -177,4 +177,12 @@ describe('json reporter', () => {
     );
     expect(journeyEnd.error).toEqual(helpers.formatError(myErr));
   });
+
+  it('captures number of journeys as metadata event', async () => {
+    runner.emit('start', {
+      numJourneys: 10,
+    });
+
+    expect((await readAndCloseStream()).toString()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
+ Reports the number of journeys as `synthetics/metadata` event which would be potentially used in the `--dry-run` command which reports this event as well registered journeys via `journey/register` command. 


Dry run in todos basic example 
```
{"type":"synthetics/metadata","@timestamp":1616806791018720,"root_fields":{"num_journeys":2,"os":{"platform":"darwin"},"package":{"name":"@elastic/synthetics","version":"0.0.1-alpha.11"}},"package_version":"0.0.1-alpha.11"}
{"type":"journey/register","@timestamp":1616806791019158,"journey":{"name":"check if title is present","id":"check if title is present"},"root_fields":{"os":{"platform":"darwin"},"package":{"name":"@elastic/synthetics","version":"0.0.1-alpha.11"}},"package_version":"0.0.1-alpha.11"}
{"type":"journey/register","@timestamp":1616806791019203.2,"journey":{"name":"check if input placeholder is correct","id":"check if input placeholder is correct"},"root_fields":{"os":{"platform":"darwin"},"package":{"name":"@elastic/synthetics","version":"0.0.1-alpha.11"}},"package_version":"0.0.1-alpha.11"}

```