### PR TITLE
feat: remove duplicate payload fields

### DIFF
--- a/__tests__/fixtures/networkinfo.ts
+++ b/__tests__/fixtures/networkinfo.ts
@@ -23,7 +23,9 @@
  *
  */
 
-export const NETWORK_INFO = [
+import { NetworkInfo } from '../../src/common_types';
+
+export const NETWORK_INFO: Array<Partial<NetworkInfo>> = [
   {
     browser: { name: 'HeadlessChrome', version: '90.0.4392.0' },
     step: {
@@ -58,6 +60,7 @@ export const NETWORK_INFO = [
     responseReceivedTime: 2355505.4514,
     response: {
       url: 'https://vigneshh.in/',
+      headers: {},
       status: 200,
       statusText: '',
       mimeType: 'text/html',
@@ -79,7 +82,7 @@ export const NETWORK_INFO = [
         cipher: 'AES_128_GCM',
         certificateId: 0,
         subjectName: 'sni.cloudflaressl.com',
-        sanList: [Array],
+        sanList: [],
         issuer: 'Cloudflare Inc ECC CA-3',
         validFrom: 1595980800,
         validTo: 1627560000,
@@ -87,6 +90,8 @@ export const NETWORK_INFO = [
         certificateTransparencyCompliance: 'unknown',
       },
     },
+    transferSize: 3392,
+    resourceSize: 7634,
     timings: {
       blocked: 2.080999780446291,
       queueing: 2.145999576896429,
@@ -151,7 +156,7 @@ export const NETWORK_INFO = [
         cipher: 'AES_128_GCM',
         certificateId: 0,
         subjectName: 'sni.cloudflaressl.com',
-        sanList: [Array],
+        sanList: [],
         issuer: 'Cloudflare Inc ECC CA-3',
         validFrom: 1595980800,
         validTo: 1627560000,

--- a/__tests__/reporters/__snapshots__/json.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/json.test.ts.snap
@@ -7,206 +7,271 @@ exports[`json reporter captures number of journeys as metadata event 1`] = `
 
 exports[`json reporter formats network fields in ECS format 1`] = `
 Object {
-  "http": Object {
-    "request": Object {
-      "body": Object {
-        "bytes": 0,
-        "content": "",
-      },
-      "headers": Object {
-        "accept_encoding": "gzip, deflate, br",
+  "ecs": Object {
+    "http": Object {
+      "request": Object {
+        "body": Object {
+          "bytes": 0,
+          "content": "",
+        },
+        "headers": Object {
+          "accept_encoding": "gzip, deflate, br",
+          "method": "GET",
+          "path": "/",
+          "upgrade_insecure_requests": "1",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+        },
+        "initial_priority": "VeryHigh",
         "method": "GET",
-        "path": "/",
-        "upgrade_insecure_requests": "1",
-        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+        "mixed_content_type": "none",
+        "referrer": undefined,
+        "referrer_policy": "strict-origin-when-cross-origin",
+        "url": "https://vigneshh.in/",
       },
-      "initial_priority": "VeryHigh",
-      "method": "GET",
-      "mixed_content_type": "none",
-      "referrer": undefined,
-      "referrer_policy": "strict-origin-when-cross-origin",
-      "url": "https://vigneshh.in/",
-    },
-    "response": Object {
-      "body": Object {
-        "bytes": 3329,
-      },
-      "connection_id": 12,
-      "connection_reused": false,
-      "encoded_data_length": 3329,
-      "from_disk_cache": false,
-      "from_prefetch_cache": false,
-      "from_service_worker": false,
-      "mime_type": "text/html",
-      "protocol": "h2",
-      "remote_i_p_address": "[2606:4700:3035::ac43:83e0]",
-      "remote_port": 443,
-      "response_time": 1612482095476.922,
-      "security_details": Object {
-        "certificate_id": 0,
-        "certificate_transparency_compliance": "unknown",
-        "cipher": "AES_128_GCM",
-        "issuer": "Cloudflare Inc ECC CA-3",
-        "key_exchange": "",
-        "key_exchange_group": "X25519",
-        "protocol": "TLS 1.3",
-        "san_list": Array [
-          [Function],
-        ],
-        "signed_certificate_timestamp_list": Array [],
-        "subject_name": "sni.cloudflaressl.com",
-        "valid_from": 1595980800,
-        "valid_to": 1627560000,
-      },
-      "security_state": "secure",
-      "status": 200,
-      "status_code": 200,
-      "status_text": "",
-      "url": "https://vigneshh.in/",
-    },
-    "version": 2,
-  },
-  "tls": Object {
-    "cipher": "AES_128_GCM_X25519",
-    "server": Object {
-      "x509": Object {
-        "issuer": Object {
-          "common_name": "Cloudflare Inc ECC CA-3",
+      "response": Object {
+        "body": Object {
+          "bytes": 3329,
         },
-        "not_after": "2021-07-29T12:00:00.000Z",
-        "not_before": "2020-07-29T00:00:00.000Z",
-        "subject": Object {
-          "common_name": "sni.cloudflaressl.com",
+        "connection_id": 12,
+        "connection_reused": false,
+        "encoded_data_length": 3329,
+        "from_disk_cache": false,
+        "from_prefetch_cache": false,
+        "from_service_worker": false,
+        "headers": Object {},
+        "mime_type": "text/html",
+        "protocol": "h2",
+        "remote_i_p_address": "[2606:4700:3035::ac43:83e0]",
+        "remote_port": 443,
+        "response_time": 1612482095476.922,
+        "security_details": Object {
+          "certificate_id": 0,
+          "certificate_transparency_compliance": "unknown",
+          "cipher": "AES_128_GCM",
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "key_exchange": "",
+          "key_exchange_group": "X25519",
+          "protocol": "TLS 1.3",
+          "san_list": Array [],
+          "signed_certificate_timestamp_list": Array [],
+          "subject_name": "sni.cloudflaressl.com",
+          "valid_from": 1595980800,
+          "valid_to": 1627560000,
+        },
+        "security_state": "secure",
+        "status": 200,
+        "status_code": 200,
+        "status_text": "",
+        "url": "https://vigneshh.in/",
+      },
+      "version": 2,
+    },
+    "tls": Object {
+      "cipher": "AES_128_GCM_X25519",
+      "server": Object {
+        "x509": Object {
+          "issuer": Object {
+            "common_name": "Cloudflare Inc ECC CA-3",
+          },
+          "not_after": "2021-07-29T12:00:00.000Z",
+          "not_before": "2020-07-29T00:00:00.000Z",
+          "subject": Object {
+            "common_name": "sni.cloudflaressl.com",
+          },
         },
       },
+      "version": "1.3",
+      "version_protocol": "tls",
     },
-    "version": "1.3",
-    "version_protocol": "tls",
+    "url": "https://vigneshh.in/",
+    "user_agent": Object {
+      "name": "HeadlessChrome",
+      "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+      "version": "90.0.4392.0",
+    },
   },
-  "url": "https://vigneshh.in/",
-  "user_agent": Object {
-    "name": "HeadlessChrome",
-    "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
-    "version": "90.0.4392.0",
+  "payload": Object {
+    "browser": Object {
+      "name": "HeadlessChrome",
+      "version": "90.0.4392.0",
+    },
+    "is_navigation_request": true,
+    "load_end_time": 2355505.448326,
+    "method": "GET",
+    "request_sent_time": 2355505.10179,
+    "resource_size": 7634,
+    "response_received_time": 2355505.4514,
+    "status": 200,
+    "timings": Object {
+      "blocked": 2.080999780446291,
+      "connect": 78.5130001604557,
+      "dns": 45.81400007009506,
+      "proxy": -1,
+      "queueing": 2.145999576896429,
+      "receive": 3.9220000617206097,
+      "send": 0.5449997261166573,
+      "ssl": 61.003000009804964,
+      "total": 346.5359997935593,
+      "wait": 212.02100021764636,
+    },
+    "transfer_size": 3392,
+    "type": "Document",
   },
 }
 `;
 
 exports[`json reporter formats network fields in ECS format 2`] = `
 Object {
-  "http": Object {
-    "request": Object {
-      "body": Object {
-        "bytes": 0,
-        "content": "",
-      },
-      "headers": Object {
-        "referer": "https://vigneshh.in/",
-        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
-      },
-      "initial_priority": "Low",
-      "method": "GET",
-      "mixed_content_type": "none",
-      "referrer": "https://vigneshh.in/",
-      "referrer_policy": "strict-origin-when-cross-origin",
-      "url": "https://vigneshh.in/static/main.js",
-    },
-    "response": Object {
-      "body": Object {
-        "bytes": 425,
-      },
-      "connection_id": 12,
-      "connection_reused": true,
-      "encoded_data_length": 425,
-      "from_disk_cache": false,
-      "from_prefetch_cache": false,
-      "from_service_worker": false,
-      "headers": Object {},
-      "mime_type": "application/javascript",
-      "protocol": "h2",
-      "remote_i_p_address": "[2606:4700:3035::ac43:83e0]",
-      "remote_port": 443,
-      "response_time": 1612482095622.864,
-      "security_details": Object {
-        "certificate_id": 0,
-        "certificate_transparency_compliance": "unknown",
-        "cipher": "AES_128_GCM",
-        "issuer": "Cloudflare Inc ECC CA-3",
-        "key_exchange": "",
-        "key_exchange_group": "X25519",
-        "protocol": "TLS 1.3",
-        "san_list": Array [
-          [Function],
-        ],
-        "signed_certificate_timestamp_list": Array [],
-        "subject_name": "sni.cloudflaressl.com",
-        "valid_from": 1595980800,
-        "valid_to": 1627560000,
-      },
-      "security_state": "secure",
-      "status": 200,
-      "status_code": 200,
-      "status_text": "",
-      "url": "https://vigneshh.in/static/main.js",
-    },
-    "version": 2,
-  },
-  "tls": Object {
-    "cipher": "AES_128_GCM_X25519",
-    "server": Object {
-      "x509": Object {
-        "issuer": Object {
-          "common_name": "Cloudflare Inc ECC CA-3",
+  "ecs": Object {
+    "http": Object {
+      "request": Object {
+        "body": Object {
+          "bytes": 0,
+          "content": "",
         },
-        "not_after": "2021-07-29T12:00:00.000Z",
-        "not_before": "2020-07-29T00:00:00.000Z",
-        "subject": Object {
-          "common_name": "sni.cloudflaressl.com",
+        "headers": Object {
+          "referer": "https://vigneshh.in/",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+        },
+        "initial_priority": "Low",
+        "method": "GET",
+        "mixed_content_type": "none",
+        "referrer": "https://vigneshh.in/",
+        "referrer_policy": "strict-origin-when-cross-origin",
+        "url": "https://vigneshh.in/static/main.js",
+      },
+      "response": Object {
+        "body": Object {
+          "bytes": 425,
+        },
+        "connection_id": 12,
+        "connection_reused": true,
+        "encoded_data_length": 425,
+        "from_disk_cache": false,
+        "from_prefetch_cache": false,
+        "from_service_worker": false,
+        "headers": Object {},
+        "mime_type": "application/javascript",
+        "protocol": "h2",
+        "remote_i_p_address": "[2606:4700:3035::ac43:83e0]",
+        "remote_port": 443,
+        "response_time": 1612482095622.864,
+        "security_details": Object {
+          "certificate_id": 0,
+          "certificate_transparency_compliance": "unknown",
+          "cipher": "AES_128_GCM",
+          "issuer": "Cloudflare Inc ECC CA-3",
+          "key_exchange": "",
+          "key_exchange_group": "X25519",
+          "protocol": "TLS 1.3",
+          "san_list": Array [],
+          "signed_certificate_timestamp_list": Array [],
+          "subject_name": "sni.cloudflaressl.com",
+          "valid_from": 1595980800,
+          "valid_to": 1627560000,
+        },
+        "security_state": "secure",
+        "status": 200,
+        "status_code": 200,
+        "status_text": "",
+        "url": "https://vigneshh.in/static/main.js",
+      },
+      "version": 2,
+    },
+    "tls": Object {
+      "cipher": "AES_128_GCM_X25519",
+      "server": Object {
+        "x509": Object {
+          "issuer": Object {
+            "common_name": "Cloudflare Inc ECC CA-3",
+          },
+          "not_after": "2021-07-29T12:00:00.000Z",
+          "not_before": "2020-07-29T00:00:00.000Z",
+          "subject": Object {
+            "common_name": "sni.cloudflaressl.com",
+          },
         },
       },
+      "version": "1.3",
+      "version_protocol": "tls",
     },
-    "version": "1.3",
-    "version_protocol": "tls",
+    "url": "https://vigneshh.in/static/main.js",
+    "user_agent": Object {
+      "name": "HeadlessChrome",
+      "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+      "version": "90.0.4392.0",
+    },
   },
-  "url": "https://vigneshh.in/static/main.js",
-  "user_agent": Object {
-    "name": "HeadlessChrome",
-    "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
-    "version": "90.0.4392.0",
+  "payload": Object {
+    "browser": Object {
+      "name": "HeadlessChrome",
+      "version": "90.0.4392.0",
+    },
+    "load_end_time": 2355505.589043,
+    "method": "GET",
+    "request_sent_time": 2355505.472502,
+    "response_received_time": 2355505.603987,
+    "status": 200,
+    "timings": Object {
+      "blocked": 1.058999914675951,
+      "connect": -1,
+      "dns": -1,
+      "proxy": -1,
+      "queueing": 46.335999853909016,
+      "receive": 0.2009999006986618,
+      "send": 0.2100002020597458,
+      "ssl": -1,
+      "total": 116.54099961742759,
+      "wait": 68.73499974608421,
+    },
+    "type": "Script",
   },
 }
 `;
 
 exports[`json reporter formats network fields in ECS format 3`] = `
 Object {
-  "http": Object {
-    "request": Object {
-      "body": Object {
-        "bytes": 0,
-        "content": "",
+  "ecs": Object {
+    "http": Object {
+      "request": Object {
+        "body": Object {
+          "bytes": 0,
+          "content": "",
+        },
+        "has_post_data": true,
+        "headers": Object {
+          "content_type": "text/plain",
+          "referer": "https://vigneshh.in/",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+        },
+        "initial_priority": "High",
+        "method": "POST",
+        "mixed_content_type": "none",
+        "referrer": "https://vigneshh.in/",
+        "referrer_policy": "strict-origin-when-cross-origin",
+        "url": "https://www.google-analytics.com/",
       },
-      "has_post_data": true,
-      "headers": Object {
-        "content_type": "text/plain",
-        "referer": "https://vigneshh.in/",
-        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
-      },
-      "initial_priority": "High",
-      "method": "POST",
-      "mixed_content_type": "none",
-      "referrer": "https://vigneshh.in/",
-      "referrer_policy": "strict-origin-when-cross-origin",
-      "url": "https://www.google-analytics.com/",
+      "response": undefined,
+      "version": undefined,
     },
-    "response": undefined,
-    "version": undefined,
+    "tls": undefined,
+    "url": "https://www.google-analytics.com/",
+    "user_agent": Object {
+      "name": "HeadlessChrome",
+      "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
+      "version": "90.0.4392.0",
+    },
   },
-  "tls": undefined,
-  "url": "https://www.google-analytics.com/",
-  "user_agent": Object {
-    "name": "HeadlessChrome",
-    "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/90.0.4392.0 Safari/537.36",
-    "version": "90.0.4392.0",
+  "payload": Object {
+    "browser": Object {
+      "name": "HeadlessChrome",
+      "version": "90.0.4392.0",
+    },
+    "load_end_time": -1,
+    "method": "POST",
+    "request_sent_time": 2355505.677688,
+    "response_received_time": -1,
+    "type": "XHR",
   },
 }
 `;
@@ -216,7 +281,7 @@ exports[`json reporter writes each step as NDJSON to the FD 1`] = `
 {\\"type\\":\\"journey/start\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"root_fields\\":{\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"payload\\":{\\"params\\":{},\\"source\\":\\"async () => { }\\"},\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"step/screenshot\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"step\\":{\\"name\\":\\"s1\\",\\"index\\":1},\\"root_fields\\":{\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"blob\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"step/end\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"step\\":{\\"name\\":\\"s1\\",\\"index\\":1,\\"status\\":\\"succeeded\\"},\\"root_fields\\":{\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"payload\\":{\\"source\\":\\"async () => { }\\",\\"start\\":0,\\"end\\":10,\\"url\\":\\"dummy\\",\\"status\\":\\"succeeded\\"},\\"url\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
-{\\"type\\":\\"journey/network_info\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"root_fields\\":{\\"user_agent\\":{},\\"http\\":{\\"request\\":{\\"body\\":{\\"bytes\\":0,\\"content\\":\\"\\"}}},\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"payload\\":{\\"request\\":{},\\"is_navigation_request\\":true,\\"browser\\":{}},\\"package_version\\":\\"0.0.1\\"}
+{\\"type\\":\\"journey/network_info\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"root_fields\\":{\\"user_agent\\":{},\\"http\\":{\\"request\\":{\\"body\\":{\\"bytes\\":0,\\"content\\":\\"\\"}}},\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"payload\\":{\\"browser\\":{},\\"is_navigation_request\\":true},\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"journey/filmstrips\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\"},\\"root_fields\\":{\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"payload\\":{\\"index\\":0,\\"startTime\\":392583.998697,\\"ts\\":392583998697},\\"blob\\":\\"dummy\\",\\"package_version\\":\\"0.0.1\\"}
 {\\"type\\":\\"journey/end\\",\\"@timestamp\\":1600300800000000,\\"journey\\":{\\"name\\":\\"j1\\",\\"id\\":\\"j1\\",\\"status\\":\\"succeeded\\"},\\"root_fields\\":{\\"os\\":{\\"platform\\":\\"darwin\\"},\\"package\\":{\\"name\\":\\"@elastic/synthetics\\",\\"version\\":\\"0.0.1\\"}},\\"payload\\":{\\"start\\":0,\\"end\\":11,\\"status\\":\\"succeeded\\"},\\"package_version\\":\\"0.0.1\\"}
 "

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -140,9 +140,13 @@ describe('json reporter', () => {
 
   it('formats network fields in ECS format', async () => {
     for (const network of NETWORK_INFO) {
-      expect(
-        snakeCaseKeys(formatNetworkFields(network as any))
-      ).toMatchSnapshot();
+      const event = formatNetworkFields(network as any);
+      const ecsKeys = Object.keys(event.ecs);
+      const duplicates = Object.keys(event.payload).some(key =>
+        ecsKeys.includes(key)
+      );
+      expect(duplicates).toBe(false);
+      expect(snakeCaseKeys(event)).toMatchSnapshot();
     }
   });
 


### PR DESCRIPTION
+ fix #248 
+ This PR removes duplicate fields from the network timing data, all ecs compatible fields are moved to `root_fields` which heartbeat writes to the top level document and rest are inside `payload` which does not get any special treatment. 
