### PR TITLE
add support for custom reporters

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -309,4 +309,60 @@ describe('runner', () => {
       'afterAll2',
     ]);
   });
+
+  it('run - supports custom reporters', async () => {
+    let reporter;
+    class Reporter {
+      messages: string[] = [];
+
+      constructor(
+        public readonly runner: Runner,
+        public readonly options: any
+      ) {
+        reporter = this;
+
+        this.runner.on('start', ({ numJourneys }) => {
+          this.messages.push(`numJourneys ${numJourneys}`);
+        });
+        this.runner.on('journey:start', ({ journey }) => {
+          this.messages.push(`journey:start ${journey.name}`);
+        });
+        this.runner.on('journey:end', ({ journey }) => {
+          this.messages.push(`journey:end ${journey.name}`);
+        });
+        this.runner.on('end', () => {
+          this.messages.push(`end`);
+        });
+      }
+    }
+
+    runner.addJourney(new Journey({ name: 'foo' }, noop));
+    const result = await runner.run({
+      reporter: Reporter,
+      wsEndpoint,
+      outfd: fs.openSync(dest, 'w'),
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "foo": Object {
+          "status": "succeeded",
+        },
+      }
+    `);
+    expect(reporter?.messages).toMatchInlineSnapshot(`
+      Array [
+        "numJourneys 1",
+        "journey:start foo",
+        "journey:end foo",
+        "end",
+      ]
+    `);
+    expect(reporter.runner).toBeInstanceOf(Runner);
+    expect(reporter.options).toMatchInlineSnapshot(`
+      Object {
+        "fd": 26,
+      }
+    `);
+  });
 });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -343,26 +343,20 @@ describe('runner', () => {
       outfd: fs.openSync(dest, 'w'),
     });
 
-    expect(result).toMatchInlineSnapshot(`
-      Object {
-        "foo": Object {
-          "status": "succeeded",
-        },
-      }
-    `);
-    expect(reporter?.messages).toMatchInlineSnapshot(`
-      Array [
-        "numJourneys 1",
-        "journey:start foo",
-        "journey:end foo",
-        "end",
-      ]
-    `);
+    expect(result).toEqual({
+      foo: {
+        status: 'succeeded',
+      },
+    });
+    expect(reporter?.messages).toEqual([
+      'numJourneys 1',
+      'journey:start foo',
+      'journey:end foo',
+      'end',
+    ]);
     expect(reporter.runner).toBeInstanceOf(Runner);
-    expect(reporter.options).toMatchInlineSnapshot(`
-      Object {
-        "fd": 26,
-      }
-    `);
+    expect(reporter.options).toEqual({
+      fd: expect.any(Number),
+    });
   });
 });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -26,7 +26,7 @@
 import { EventEmitter } from 'events';
 import { Journey } from '../dsl/journey';
 import { Step } from '../dsl/step';
-import { reporters } from '../reporters';
+import { reporters, Reporter } from '../reporters';
 import { getMonotonicTime, getTimestamp, runParallel } from '../helpers';
 import {
   StatusValue,
@@ -42,9 +42,16 @@ import { log } from './logger';
 
 export type RunOptions = Omit<
   CliArgs,
-  'debug' | 'json' | 'pattern' | 'inline' | 'require' | 'suiteParams'
+  | 'debug'
+  | 'json'
+  | 'pattern'
+  | 'inline'
+  | 'require'
+  | 'suiteParams'
+  | 'reporter'
 > & {
   params?: RunParamaters;
+  reporter?: CliArgs['reporter'] | Reporter;
 };
 
 type RunParamaters = Record<string, unknown>;
@@ -301,7 +308,10 @@ export default class Runner {
     /**
      * Set up the corresponding reporter and fallback
      */
-    const Reporter = reporters[reporter] || reporters['default'];
+    const Reporter =
+      typeof reporter === 'function'
+        ? reporter
+        : reporters[reporter] || reporters['default'];
     new Reporter(this, { fd: outfd });
     this.emit('start', { numJourneys: this.journeys.length });
     await this.runBeforeAllHook();

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,3 +65,9 @@ export type {
   ChromiumBrowserContext,
   CDPSession,
 } from 'playwright-chromium';
+
+/**
+ * Export the types necessary to write custom reporters
+ */
+export type { default as Runner } from './core/runner';
+export type { Reporter, ReporterOptions } from './reporters';

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -33,11 +33,7 @@ import {
   findPWLogsIndexes,
   rewriteErrorStack,
 } from '../helpers';
-
-export type ReporterOptions = {
-  fd?: number;
-  colors?: boolean;
-};
+import { ReporterOptions } from './reporter';
 
 function renderError(error) {
   let output = '';

--- a/src/reporters/reporter.ts
+++ b/src/reporters/reporter.ts
@@ -23,14 +23,13 @@
  *
  */
 
-import BaseReporter from './base';
-import JSONReporter from './json';
-import JUnitReporter from './junit';
-import Reporter, { ReporterOptions } from './reporter';
+import Runner from '../core/runner';
 
-export { Reporter, ReporterOptions };
-export const reporters = {
-  default: BaseReporter,
-  json: JSONReporter,
-  junit: JUnitReporter,
+export type ReporterOptions = {
+  fd?: number;
+  colors?: boolean;
 };
+
+export default interface Reporter {
+  new (runner: Runner, options: ReporterOptions): any;
+}


### PR DESCRIPTION
In order to support getting access to runner events from the standard `run()` API I think it would be good to support custom `Runner` classes. This PR adds support for a `Runner` class being passed as the `reporter` option, `new`s up this class when the runner starts, and passes the `Runner` instance as well as the `ReporterOptions` to the constructor, and then moves on.