### PR TITLE
feat: expose params in all hooks

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -61,12 +61,12 @@ describe('CLI', () => {
       '-e',
       'testing',
     ]);
-    await cli.waitFor('fake journey');
+    await cli.waitFor('journey/start');
     const output = cli.output();
+    expect(await cli.exitCode).toBe(0);
     expect(JSON.parse(output).payload).toMatchObject({
       params: { url: 'non-dev' },
     });
-    expect(await cli.exitCode).toBe(0);
   });
 
   it('throw error on modifying params', async () => {

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -68,6 +68,19 @@ describe('CLI', () => {
     });
     expect(await cli.exitCode).toBe(0);
   });
+
+  it('throw error on modifying params', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'params-error.journey.ts'),
+      '-j',
+    ]);
+    expect(await cli.exitCode).toBe(1);
+    const output = cli.output();
+    expect(JSON.parse(output).error).toMatchObject({
+      name: 'TypeError',
+      message: 'Cannot add property foo, object is not extensible',
+    });
+  });
 });
 
 class CLIMock {

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -64,7 +64,7 @@ describe('CLI', () => {
     await cli.waitFor('fake journey');
     const output = cli.output();
     expect(JSON.parse(output).payload).toMatchObject({
-      params: { url: 'non-dev', environment: 'testing' },
+      params: { url: 'non-dev' },
     });
     expect(await cli.exitCode).toBe(0);
   });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -349,6 +349,42 @@ describe('runner', () => {
     ]);
   });
 
+  it('run - expose params in all hooks', async () => {
+    const result = [];
+    runner.addHook('beforeAll', ({ params }) =>
+      result.push({ name: 'beforeAll', params })
+    );
+    runner.addHook('afterAll', ({ params }) =>
+      result.push({ name: 'afterAll', params })
+    );
+    const j1 = new Journey({ name: 'j1' }, noop);
+    j1.addHook('before', ({ params }) => {
+      result.push({ name: 'before', params });
+    });
+    j1.addHook('after', ({ params }) => {
+      result.push({ name: 'after', params });
+    });
+    j1.addStep('s1', () => result.push('step1'));
+    runner.addJourney(j1);
+
+    const suiteParams = {
+      environment: 'testing',
+    };
+    await runner.run({
+      wsEndpoint,
+      params: suiteParams,
+      outfd: fs.openSync(dest, 'w'),
+    });
+
+    expect(result).toEqual([
+      { name: 'beforeAll', params: suiteParams },
+      { name: 'before', params: suiteParams },
+      'step1',
+      { name: 'after', params: suiteParams },
+      { name: 'afterAll', params: suiteParams },
+    ]);
+  });
+
   it('run - supports custom reporters', async () => {
     let reporter;
     class Reporter {

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -351,8 +351,8 @@ describe('runner', () => {
 
   it('run - expose params in all hooks', async () => {
     const result = [];
-    runner.addHook('beforeAll', ({ params }) =>
-      result.push({ name: 'beforeAll', params })
+    runner.addHook('beforeAll', ({ params, env }) =>
+      result.push({ name: 'beforeAll', params, env })
     );
     runner.addHook('afterAll', ({ params }) =>
       result.push({ name: 'afterAll', params })
@@ -361,27 +361,28 @@ describe('runner', () => {
     j1.addHook('before', ({ params }) => {
       result.push({ name: 'before', params });
     });
-    j1.addHook('after', ({ params }) => {
-      result.push({ name: 'after', params });
+    j1.addHook('after', ({ params, env }) => {
+      result.push({ name: 'after', params, env });
     });
     j1.addStep('s1', () => result.push('step1'));
     runner.addJourney(j1);
 
-    const suiteParams = {
-      environment: 'testing',
+    const params = {
+      url: 'http://local.dev',
     };
     await runner.run({
       wsEndpoint,
-      params: suiteParams,
+      params,
+      environment: 'testing',
       outfd: fs.openSync(dest, 'w'),
     });
 
     expect(result).toEqual([
-      { name: 'beforeAll', params: suiteParams },
-      { name: 'before', params: suiteParams },
+      { name: 'beforeAll', params, env: 'testing' },
+      { name: 'before', params },
       'step1',
-      { name: 'after', params: suiteParams },
-      { name: 'afterAll', params: suiteParams },
+      { name: 'after', params, env: 'testing' },
+      { name: 'afterAll', params },
     ]);
   });
 

--- a/__tests__/fixtures/params-error.journey.ts
+++ b/__tests__/fixtures/params-error.journey.ts
@@ -23,45 +23,11 @@
  *
  */
 
-import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
-import { Step } from './step';
-import { VoidCallback, HooksCallback, RunParamaters } from '../common_types';
+import { journey, step, before } from '../../src';
 
-export type JourneyOptions = {
-  name: string;
-  id?: string;
-};
-
-type HookType = 'before' | 'after';
-export type Hooks = Record<HookType, Array<HooksCallback>>;
-export type JourneyCallback = (options: {
-  page: Page;
-  context: BrowserContext;
-  browser: Browser;
-  client: CDPSession;
-  params: RunParamaters;
-}) => void;
-
-export class Journey {
-  name: string;
-  id?: string;
-  callback: JourneyCallback;
-  steps: Step[] = [];
-  hooks: Hooks = { before: [], after: [] };
-
-  constructor(options: JourneyOptions, callback: JourneyCallback) {
-    this.name = options.name;
-    this.id = options.id;
-    this.callback = callback;
-  }
-
-  addStep(name: string, callback: VoidCallback) {
-    const step = new Step(name, this.steps.length + 1, callback);
-    this.steps.push(step);
-    return step;
-  }
-
-  addHook(type: HookType, callback: HooksCallback) {
-    this.hooks[type].push(callback);
-  }
-}
+journey('journey 1', ({}) => {
+  before(({ params }) => {
+    params.foo = 'bar';
+  });
+  step('step1', () => {});
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -61,8 +61,9 @@ describe('Run', () => {
       .mockImplementation(() => Promise.resolve({}));
 
     const runParams: RunOptions = {
+      environment: 'debug',
       params: {
-        environment: 'debug',
+        foo: 'bar',
       },
       headless: false,
       screenshots: true,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -174,7 +174,8 @@ async function prepareSuites(inputs: string[]) {
   const reporter = options.json ? 'json' : options.reporter;
 
   const results = await run({
-    params: Object.freeze({ ...params, environment }),
+    params: Object.freeze(params),
+    environment,
     reporter,
     headless: options.headless,
     screenshots: options.screenshots,

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -28,8 +28,13 @@ import { Step } from './dsl';
 import { reporters } from './reporters';
 
 export type VoidCallback = () => void;
+export type HooksCallback = (args: { params: RunParamaters }) => void;
 export type StatusValue = 'succeeded' | 'failed' | 'skipped';
 export type Reporters = keyof typeof reporters;
+
+export type RunParamaters = {
+  environment: string;
+} & Record<string, unknown>;
 
 export type FilmStrip = {
   snapshot: string;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -28,13 +28,14 @@ import { Step } from './dsl';
 import { reporters } from './reporters';
 
 export type VoidCallback = () => void;
-export type HooksCallback = (args: { params: RunParams }) => void;
+export type Params = Record<string, unknown>;
+export type HooksArgs = {
+  env: string;
+  params: Params;
+};
+export type HooksCallback = (args: HooksArgs) => void;
 export type StatusValue = 'succeeded' | 'failed' | 'skipped';
 export type Reporters = keyof typeof reporters;
-
-export type RunParams = {
-  environment: string;
-} & Record<string, unknown>;
 
 export type FilmStrip = {
   snapshot: string;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -28,11 +28,11 @@ import { Step } from './dsl';
 import { reporters } from './reporters';
 
 export type VoidCallback = () => void;
-export type HooksCallback = (args: { params: RunParamaters }) => void;
+export type HooksCallback = (args: { params: RunParams }) => void;
 export type StatusValue = 'succeeded' | 'failed' | 'skipped';
 export type Reporters = keyof typeof reporters;
 
-export type RunParamaters = {
+export type RunParams = {
   environment: string;
 } & Record<string, unknown>;
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -25,7 +25,7 @@
 
 import { Journey, JourneyCallback, JourneyOptions } from '../dsl';
 import Runner from './runner';
-import { VoidCallback } from '../common_types';
+import { VoidCallback, HooksCallback } from '../common_types';
 import { log } from './logger';
 
 /**
@@ -57,22 +57,22 @@ export const step = (name: string, callback: VoidCallback) => {
   return runner.currentJourney?.addStep(name, callback);
 };
 
-export const beforeAll = (callback: VoidCallback) => {
+export const beforeAll = (callback: HooksCallback) => {
   runner.addHook('beforeAll', callback);
 };
 
-export const afterAll = (callback: VoidCallback) => {
+export const afterAll = (callback: HooksCallback) => {
   runner.addHook('afterAll', callback);
 };
 
-export const before = (callback: VoidCallback) => {
+export const before = (callback: HooksCallback) => {
   if (!runner.currentJourney) {
     throw new Error('before is called outside of the journey context');
   }
   return runner.currentJourney.addHook('before', callback);
 };
 
-export const after = (callback: VoidCallback) => {
+export const after = (callback: HooksCallback) => {
   if (!runner.currentJourney) {
     throw new Error('after is called outside of the journey context');
   }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -33,7 +33,7 @@ import {
   FilmStrip,
   NetworkInfo,
   HooksCallback,
-  RunParamaters,
+  RunParams,
   CliArgs,
 } from '../common_types';
 import { BrowserMessage, PluginManager } from '../plugins';
@@ -52,12 +52,12 @@ export type RunOptions = Omit<
   | 'reporter'
   | 'environment'
 > & {
-  params?: RunParamaters;
+  params?: RunParams;
   reporter?: CliArgs['reporter'] | Reporter;
 };
 
 type BaseContext = {
-  params?: RunParamaters;
+  params?: RunParams;
   start: number;
   end?: number;
 };
@@ -93,7 +93,7 @@ interface Events {
   'journey:start': {
     journey: Journey;
     timestamp: number;
-    params: RunParamaters;
+    params: RunParams;
   };
   'journey:end': BaseContext &
     JourneyResult & {
@@ -149,22 +149,22 @@ export default class Runner {
     this.eventEmitter.on(e, cb);
   }
 
-  async runBeforeAllHook(params: RunParamaters) {
+  async runBeforeAllHook(params: RunParams) {
     log(`Runner: beforeAll hooks`);
     await runParallel(this.hooks.beforeAll, params);
   }
 
-  async runAfterAllHook(params: RunParamaters) {
+  async runAfterAllHook(params: RunParams) {
     log(`Runner: afterAll hooks`);
     await runParallel(this.hooks.afterAll, params);
   }
 
-  async runBeforeHook(journey: Journey, params: RunParamaters) {
+  async runBeforeHook(journey: Journey, params: RunParams) {
     log(`Runner: before hooks for (${journey.name})`);
     await runParallel(journey.hooks.before, params);
   }
 
-  async runAfterHook(journey: Journey, params: RunParamaters) {
+  async runAfterHook(journey: Journey, params: RunParams) {
     log(`Runner: after hooks for (${journey.name})`);
     await runParallel(journey.hooks.after, params);
   }

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -25,7 +25,7 @@
 
 import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
 import { Step } from './step';
-import { VoidCallback, HooksCallback, RunParamaters } from '../common_types';
+import { VoidCallback, HooksCallback, RunParams } from '../common_types';
 
 export type JourneyOptions = {
   name: string;
@@ -39,7 +39,7 @@ export type JourneyCallback = (options: {
   context: BrowserContext;
   browser: Browser;
   client: CDPSession;
-  params: RunParamaters;
+  params: RunParams;
 }) => void;
 
 export class Journey {

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -25,7 +25,7 @@
 
 import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
 import { Step } from './step';
-import { VoidCallback, HooksCallback, RunParams } from '../common_types';
+import { VoidCallback, HooksCallback, Params } from '../common_types';
 
 export type JourneyOptions = {
   name: string;
@@ -39,7 +39,7 @@ export type JourneyCallback = (options: {
   context: BrowserContext;
   browser: Browser;
   client: CDPSession;
-  params: RunParams;
+  params: Params;
 }) => void;
 
 export class Journey {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,7 @@ import { resolve, join, dirname } from 'path';
 import fs, { statSync } from 'fs';
 import { promisify } from 'util';
 import { performance } from 'perf_hooks';
-import { HooksCallback, RunParams } from './common_types';
+import { HooksArgs, HooksCallback } from './common_types';
 
 const statAsync = promisify(fs.lstat);
 const readAsync = promisify(fs.readdir);
@@ -95,9 +95,9 @@ export function now() {
  */
 export async function runParallel(
   callbacks: Array<HooksCallback>,
-  params: RunParams
+  args: HooksArgs
 ) {
-  const promises = callbacks.map(cb => cb({ params }));
+  const promises = callbacks.map(cb => cb(args));
   return await Promise.all(promises);
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,6 +29,7 @@ import { resolve, join, dirname } from 'path';
 import fs, { statSync } from 'fs';
 import { promisify } from 'util';
 import { performance } from 'perf_hooks';
+import { HooksCallback, RunParamaters } from './common_types';
 
 const statAsync = promisify(fs.lstat);
 const readAsync = promisify(fs.readdir);
@@ -90,10 +91,13 @@ export function now() {
 }
 
 /**
- * Execute all the callbacks in parallel using Promise.all
+ * Execute all the hooks callbacks in parallel using Promise.all
  */
-export async function runParallel(callbacks) {
-  const promises = callbacks.map(cb => cb());
+export async function runParallel(
+  callbacks: Array<HooksCallback>,
+  params: RunParamaters
+) {
+  const promises = callbacks.map(cb => cb({ params }));
   return await Promise.all(promises);
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,7 @@ import { resolve, join, dirname } from 'path';
 import fs, { statSync } from 'fs';
 import { promisify } from 'util';
 import { performance } from 'perf_hooks';
-import { HooksCallback, RunParamaters } from './common_types';
+import { HooksCallback, RunParams } from './common_types';
 
 const statAsync = promisify(fs.lstat);
 const readAsync = promisify(fs.readdir);
@@ -95,7 +95,7 @@ export function now() {
  */
 export async function runParallel(
   callbacks: Array<HooksCallback>,
-  params: RunParamaters
+  params: RunParams
 ) {
   const promises = callbacks.map(cb => cb({ params }));
   return await Promise.all(promises);


### PR DESCRIPTION
+ Exposes the suite params and params passed via `--config` flag to all our hooks `before, beforeAll, after, afterAll`
+ Params in hooks cannot be modified, throws error otherwise - added a test in `cli.test.ts`. 

+ Follow up of the config support PR #271 