### PR TITLE
fix: capture hook errors in base reporter

### DIFF
--- a/__tests__/reporters/__snapshots__/base.test.ts.snap
+++ b/__tests__/reporters/__snapshots__/base.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`base reporter render hook errors without steps 1`] = `
+"
+Journey: j1
+   ---
+      stack: |-
+        Error: before hook failed
+   ---
+
+No tests found! (0 ms) 
+
+"
+`;
+
 exports[`base reporter writes each step to the FD 1`] = `
 "
 Journey: j1

--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -108,16 +108,31 @@ export default class BaseReporter {
       result[status]++;
     });
 
+    this.runner.on('journey:end', ({ error }) => {
+      const { failed, succeeded, skipped } = result;
+      const total = failed + succeeded + skipped;
+
+      /**
+       * Render the error on the terminal only when no steps could
+       * be executed which means the error happened in one of the hooks
+       */
+      if (total === 0 && error) {
+        this.write(renderError(error));
+      }
+    });
+
     this.runner.on('end', () => {
       const { failed, succeeded, skipped } = result;
       const total = failed + succeeded + skipped;
 
+      let message = '\n';
       if (total === 0) {
-        this.write('No tests found!');
+        message = 'No tests found!';
+        message += ` (${renderDuration(now())} ms) \n`;
+        this.write(message);
         return;
       }
 
-      let message = '\n';
       message += succeeded > 0 ? green(` ${succeeded} passed`) : '';
       message += failed > 0 ? red(` ${failed} failed`) : '';
       message += skipped > 0 ? cyan(` ${skipped} skipped`) : '';


### PR DESCRIPTION
+ When there are errors thrown in any of the `before` and `after` hooks, the JSON reporter captures them, but we dont capture it on the base reporter which is a bug. Now we render the error and also print out the duration it took to run the journeys. 