### PR TITLE
perf: use context isolation for inidividual journeys

### DIFF
--- a/__tests__/core/browser-service.test.ts
+++ b/__tests__/core/browser-service.test.ts
@@ -41,10 +41,10 @@ describe('BrowserService', () => {
   });
 
   it('should create browser pages', async () => {
-    const driver = await Gatherer.setupDriver({
+    const { page } = await Gatherer.setupDriver({
       wsEndpoint: 'ws://localhost:9323',
     });
-    await driver.page.goto(server.TEST_PAGE);
-    await Gatherer.dispose(driver);
+    await page.goto(server.TEST_PAGE);
+    await Gatherer.stop();
   });
 });

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -31,10 +31,18 @@ import { wsEndpoint } from '../utils/test-config';
 jest.mock('../../src/plugins/network');
 
 describe('Gatherer', () => {
-  it('boot and dispose driver', async () => {
+  it('boot and close browser', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     expect(typeof driver.page.goto).toBe('function');
+    await Gatherer.stop();
+  });
+
+  it('setup and dispose driver', async () => {
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
     await Gatherer.dispose(driver);
+    expect(Gatherer.browser).toBeDefined();
+    await Gatherer.stop();
+    expect(Gatherer.browser).toBeNull();
   });
 
   it('begin recording based on flags', async () => {
@@ -45,6 +53,6 @@ describe('Gatherer', () => {
     expect(pluginManager).toBeInstanceOf(PluginManager);
     const network = pluginManager.get(NetworkManager);
     expect(network.start).toHaveBeenCalled();
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -157,7 +157,7 @@ describe('runner', () => {
     const context = await Runner.createContext(runOptions);
     await runner.registerJourney(j1, context);
     const result = await runner.runSteps(j1, context, runOptions);
-    await Gatherer.dispose(context.driver);
+    await Gatherer.stop();
     expect(result).toEqual([
       {
         status: 'succeeded',
@@ -178,7 +178,7 @@ describe('runner', () => {
     const context = await Runner.createContext(runOptions);
     await runner.registerJourney(j1, context);
     const result = await runner.runSteps(j1, context, runOptions);
-    await Gatherer.dispose(context.driver);
+    await Gatherer.stop();
     expect(result).toEqual([
       {
         status: 'failed',
@@ -199,7 +199,7 @@ describe('runner', () => {
     const context = await Runner.createContext({});
     await runner.registerJourney(j1, context);
     const result = await runner.runSteps(j1, context, {});
-    await Gatherer.dispose(context.driver);
+    await Gatherer.stop();
     expect(result).toEqual([
       {
         status: 'failed',
@@ -218,7 +218,7 @@ describe('runner', () => {
     const context = await Runner.createContext({});
     await runner.registerJourney(j1, context);
     const result = await runner.runSteps(j1, context, {});
-    await Gatherer.dispose(context.driver);
+    await Gatherer.stop();
     expect(result).toEqual([
       {
         status: 'failed',
@@ -242,7 +242,7 @@ describe('runner', () => {
     const context = await Runner.createContext(runOptions);
     await runner.registerJourney(j1, context);
     const [step1, step2] = await runner.runSteps(j1, context, runOptions);
-    await Gatherer.dispose(context.driver);
+    await Gatherer.stop();
     expect(step1).toEqual({
       status: 'succeeded',
       url: server.TEST_PAGE,

--- a/__tests__/plugins/browser-console.test.ts
+++ b/__tests__/plugins/browser-console.test.ts
@@ -38,12 +38,12 @@ describe('BrowserConsole', () => {
   });
 
   it('should capture browser console logs', async () => {
-    const driver = await Gatherer.setupDriver({ wsEndpoint });
-    const browserConsole = new BrowserConsole(driver.page);
+    const { page } = await Gatherer.setupDriver({ wsEndpoint });
+    const browserConsole = new BrowserConsole(page);
     browserConsole.start();
-    await driver.page.goto(server.TEST_PAGE);
+    await page.goto(server.TEST_PAGE);
     browserConsole._currentStep = { name: 'step-name', index: 0 };
-    await driver.page.evaluate(() =>
+    await page.evaluate(() =>
       console.warn('test-message', 1, { test: 'test' })
     );
 
@@ -53,6 +53,6 @@ describe('BrowserConsole', () => {
     expect(testMessage.type).toEqual('warning');
     expect(testMessage.timestamp).toBeDefined();
     expect(testMessage.step).toEqual({ name: 'step-name', index: 0 });
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 });

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -61,7 +61,7 @@ describe('network', () => {
       responseReceivedTime: expect.any(Number),
       timings: expect.any(Object),
     });
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 
   it('not include data URL in network info', async () => {
@@ -72,7 +72,7 @@ describe('network', () => {
     const netinfo = await network.stop();
     expect(await driver.page.content()).toContain('Data URI test');
     expect(netinfo).toEqual([]);
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 
   it('produce distinct events for redirects', async () => {
@@ -93,7 +93,7 @@ describe('network', () => {
     expect(netinfo[0].status).toBe(302);
     expect(netinfo[1].status).toBe(302);
     expect(netinfo[2].status).toBe(200);
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 
   it('measure resource and transfer size', async () => {
@@ -109,7 +109,7 @@ describe('network', () => {
       resourceSize: 10,
       transferSize: expect.any(Number),
     });
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 
   it('timings for aborted requests', async () => {
@@ -129,7 +129,7 @@ describe('network', () => {
 
     await driver.page.goto(server.PREFIX + '/index');
     await driver.page.waitForLoadState();
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
     const netinfo = await network.stop();
     expect(netinfo.length).toBe(2);
     expect(netinfo[1]).toMatchObject({
@@ -163,8 +163,9 @@ describe('network', () => {
       res.end(`<script src=${server.PREFIX}/chunked />`);
     });
 
+    await driver.page.waitForLoadState();
     await driver.page.goto(server.PREFIX + '/index');
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
     const netinfo = await network.stop();
     expect(netinfo.length).toBe(2);
     expect(netinfo[1]).toMatchObject({

--- a/__tests__/plugins/performance.test.ts
+++ b/__tests__/plugins/performance.test.ts
@@ -59,6 +59,6 @@ describe('performance', () => {
       'JSHeapTotalSize',
     ]);
     await performance.stop();
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
   });
 });

--- a/__tests__/plugins/tracing.test.ts
+++ b/__tests__/plugins/tracing.test.ts
@@ -48,7 +48,7 @@ describe('tracing', () => {
      */
     await driver.page.waitForTimeout(100);
     const events = await tracer.stop(driver.client);
-    await Gatherer.dispose(driver);
+    await Gatherer.stop();
     const filmstrips = filterFilmstrips(events);
     expect(filmstrips.length).toBeGreaterThan(0);
     expect(filmstrips[0]).toMatchObject({

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -348,6 +348,7 @@ export default class Runner {
       const journeyResult = await this.runJourney(journey, options);
       result[journey.name] = journeyResult;
     }
+    await Gatherer.stop();
     await this.runAfterAllHook();
     this.reset();
     this.emit('end', {});


### PR DESCRIPTION
+ This PR improves the test execution time when there are multiple journeys involved while running the test suites. Previously  we relied on spawning browser instance for every journey execution which is not required as context already provides enough isolation and each context is fresh (does not share any state or cache) used for each journey runs

+ This removes the time that is required for spawning browser for each run which is in order of ~100ms. 

### Results (Approx)

1. For todos directory with 4 journeys
```
Before - 3600ms
After - 2400ms
```
2. Custom with increased number of journeys to showcase the impact.

```
// 20 journeys
Before - 11200ms
After - 5800ms

// 50 journeys
Before - 28700ms
After - 14800ms
```
