### PR TITLE
feat: add support for rich events flag

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -52,6 +52,20 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
+  it('enables rich events on `--rich-events` flag', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'fake.journey.ts'),
+      '--rich-events',
+    ]);
+    await cli.waitFor('fake journey');
+    const output = cli.output();
+    expect(JSON.parse(output).journey).toEqual({
+      id: 'fake journey',
+      name: 'fake journey',
+    });
+    expect(await cli.exitCode).toBe(0);
+  });
+
   it('pass config to journey params', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'fake.journey.ts'),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,8 +29,7 @@ import { stdin, cwd } from 'process';
 import { resolve } from 'path';
 import { step, journey } from './core';
 import { log } from './core/logger';
-import program from './parse_args';
-import { CliArgs } from './common_types';
+import program, { options } from './parse_args';
 import {
   findPkgJsonByTraversing,
   isDepInstalled,
@@ -40,7 +39,6 @@ import {
 import { run } from './';
 import { readConfig } from './config';
 
-const options = program.opts() as CliArgs;
 const resolvedCwd = cwd();
 /**
  * Set debug based on DEBUG ENV and -d flags

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -102,4 +102,5 @@ export type CliArgs = {
   require: string[];
   debug?: boolean;
   suiteParams?: string;
+  richEvents?: true;
 };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -51,6 +51,7 @@ export type RunOptions = Omit<
   | 'require'
   | 'suiteParams'
   | 'reporter'
+  | 'richEvents'
 > & {
   params?: Params;
   reporter?: CliArgs['reporter'] | Reporter;

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -24,6 +24,7 @@
  */
 
 import { program } from 'commander';
+import { CliArgs } from './common_types';
 import { reporters } from './reporters';
 
 const availableReporters = Object.keys(reporters)
@@ -55,6 +56,7 @@ program
   .option('-r, --require <modules...>', 'module(s) to preload')
   .option('--no-headless', 'run browser in headful mode')
   .option('--sandbox', 'enable chromium sandboxing')
+  .option('--rich-events', 'Mimics a heartbeat run')
   .option(
     '--ws-endpoint <endpoint>',
     'Browser WebSocket endpoint to connect to'
@@ -80,4 +82,18 @@ program
   .version(version)
   .description('Run synthetic tests');
 
-export default program.parse(process.argv);
+const command = program.parse(process.argv);
+const options = command.opts() as CliArgs;
+
+/**
+ * Group all events that can be consumed by heartbeat and
+ * eventually by the Synthetics UI.
+ */
+if (options.richEvents) {
+  options.reporter = options.reporter ?? 'json';
+  options.screenshots = true;
+  options.network = true;
+}
+
+export { options };
+export default command;


### PR DESCRIPTION
+ fix #289 
+ Mimics the current heartbeat behaviour by introducing the `--rich-events` flag that will enable `Screenshots, Network, Default to JSON reporter`. 