### PR TITLE
feat: add support for capabilities flag

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -95,6 +95,19 @@ describe('CLI', () => {
       message: 'Cannot add property foo, object is not extensible',
     });
   });
+
+  it('support capabilities flag', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'example.journey.ts'),
+      '-j',
+      '--capabilities',
+      'metrics',
+    ]);
+    await cli.waitFor('step/end');
+    const output = JSON.parse(cli.output());
+    expect(output.payload.metrics).toBeDefined();
+    expect(await cli.exitCode).toBe(0);
+  });
 });
 
 class CLIMock {

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -96,11 +96,11 @@ describe('CLI', () => {
     });
   });
 
-  it('support capabilities flag', async () => {
+  it('support capability flag', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'example.journey.ts'),
       '-j',
-      '--capabilities',
+      '--capability',
       'metrics',
     ]);
     await cli.waitFor('step/end');
@@ -109,17 +109,17 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
-  it('show warn for unknown capabilities flag', async () => {
+  it('show warn for unknown capability flag', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'fake.journey.ts'),
       '-j',
-      '--capabilities',
+      '--capability',
       'unknown',
     ]);
     try {
       await cli.exitCode;
     } catch (e) {
-      expect(e.message).toMatch('Missing capability unknown');
+      expect(e.message).toMatch('Missing capability "unknown"');
     }
   });
 });

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -108,6 +108,20 @@ describe('CLI', () => {
     expect(output.payload.metrics).toBeDefined();
     expect(await cli.exitCode).toBe(0);
   });
+
+  it('show warn for unknown capabilities flag', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'fake.journey.ts'),
+      '-j',
+      '--capabilities',
+      'unknown',
+    ]);
+    try {
+      await cli.exitCode;
+    } catch (e) {
+      expect(e.message).toMatch('Missing capability unknown');
+    }
+  });
 });
 
 class CLIMock {

--- a/__tests__/fixtures/example.journey.ts
+++ b/__tests__/fixtures/example.journey.ts
@@ -1,0 +1,42 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { journey, step, beforeAll, afterAll } from '../../';
+import { Server } from '../utils/server';
+
+let server: Server;
+
+beforeAll(async () => {
+  server = await Server.create();
+});
+afterAll(async () => {
+  await server.close();
+});
+
+journey('example journey', ({ page }) => {
+  step('go to test page', async () => {
+    await page.goto(server.TEST_PAGE);
+  });
+});

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -114,7 +114,7 @@ export type PluginOutput = {
 };
 
 export type CliArgs = {
-  capabilities?: Array<string>;
+  capability?: Array<string>;
   config?: string;
   environment?: string;
   outfd?: number;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -114,6 +114,7 @@ export type PluginOutput = {
 };
 
 export type CliArgs = {
+  capabilities: ['trace', 'filmstrips', 'metrics'];
   config?: string;
   environment?: string;
   outfd?: number;
@@ -135,5 +136,5 @@ export type CliArgs = {
   require: string[];
   debug?: boolean;
   suiteParams?: string;
-  richEvents?: true;
+  richEvents?: boolean;
 };

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -114,7 +114,7 @@ export type PluginOutput = {
 };
 
 export type CliArgs = {
-  capabilities?: ['trace', 'filmstrips', 'metrics'];
+  capabilities?: Array<string>;
   config?: string;
   environment?: string;
   outfd?: number;
@@ -133,7 +133,7 @@ export type CliArgs = {
   json?: boolean;
   pattern?: string;
   inline: boolean;
-  require: string[];
+  require: Array<string>;
   debug?: boolean;
   suiteParams?: string;
   richEvents?: boolean;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -114,7 +114,7 @@ export type PluginOutput = {
 };
 
 export type CliArgs = {
-  capabilities: ['trace', 'filmstrips', 'metrics'];
+  capabilities?: ['trace', 'filmstrips', 'metrics'];
   config?: string;
   environment?: string;
   outfd?: number;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -51,6 +51,7 @@ export type RunOptions = Omit<
   | 'suiteParams'
   | 'reporter'
   | 'richEvents'
+  | 'capabilities'
 > & {
   params?: Params;
   reporter?: CliArgs['reporter'] | Reporter;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -51,7 +51,7 @@ export type RunOptions = Omit<
   | 'suiteParams'
   | 'reporter'
   | 'richEvents'
-  | 'capabilities'
+  | 'capability'
 > & {
   params?: Params;
   reporter?: CliArgs['reporter'] | Reporter;

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -29,7 +29,6 @@ import { reporters } from './reporters';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
-const allowedCapabilities = ['trace', 'filmstrips', 'metrics'];
 
 program
   .name(`npx ${name}`)
@@ -56,11 +55,9 @@ program
   .option('--no-headless', 'run browser in headful mode')
   .option('--sandbox', 'enable chromium sandboxing')
   .option('--rich-events', 'Mimics a heartbeat run')
-  .addOption(
-    new Option(
-      '--capabilities <features...>',
-      'Enable capabiltiites through feature flags'
-    ).choices(allowedCapabilities)
+  .option(
+    '--capabilities <features...>',
+    'Enable capabiltiites through feature flags'
   )
   .option('--screenshots', 'take screenshot for each step')
   .option('--network', 'capture network information for all journeys')
@@ -99,13 +96,20 @@ if (options.richEvents) {
 }
 
 if (options.capabilities) {
+  const supportedCapabilities = ['trace', 'filmstrips', 'metrics'];
   /**
    * trace - record chrome trace events(LCP, FCP, CLS, etc.) for all journeys
    * filmstrips - record detailed filmstrips for all journeys
    * metrics - capture performance metrics (DOM Nodes, Heap size, etc.) for each step
    */
-  for (const flags of options.capabilities) {
-    options[flags] = true;
+  for (const flag of options.capabilities) {
+    if (supportedCapabilities.includes(flag)) {
+      options[flag] = true;
+    } else {
+      console.warn(
+        `Missing capability ${flag}, current supported capabilities are ${supportedCapabilities.join()}`
+      );
+    }
   }
 }
 

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -56,8 +56,8 @@ program
   .option('--sandbox', 'enable chromium sandboxing')
   .option('--rich-events', 'Mimics a heartbeat run')
   .option(
-    '--capabilities <features...>',
-    'Enable capabiltiites through feature flags'
+    '--capability <features...>',
+    'Enable capabilities through feature flags'
   )
   .option('--screenshots', 'take screenshot for each step')
   .option('--network', 'capture network information for all journeys')
@@ -95,19 +95,21 @@ if (options.richEvents) {
   options.network = true;
 }
 
-if (options.capabilities) {
+if (options.capability) {
   const supportedCapabilities = ['trace', 'filmstrips', 'metrics'];
   /**
    * trace - record chrome trace events(LCP, FCP, CLS, etc.) for all journeys
    * filmstrips - record detailed filmstrips for all journeys
    * metrics - capture performance metrics (DOM Nodes, Heap size, etc.) for each step
    */
-  for (const flag of options.capabilities) {
+  for (const flag of options.capability) {
     if (supportedCapabilities.includes(flag)) {
       options[flag] = true;
     } else {
       console.warn(
-        `Missing capability ${flag}, current supported capabilities are ${supportedCapabilities.join()}`
+        `Missing capability "${flag}", current supported capabilities are ${supportedCapabilities.join(
+          ''
+        )}`
       );
     }
   }


### PR DESCRIPTION
+ fix #292 
+ Allows for a way to pass an variadic args to `--capability` flag that controls the features inside the agent. 
```
npx @elastic/synthetics examples/todos --capability metrics trace --capability filmstrips
```
+ Also deprecated the previous `--trace, --metrics, --filmstrips` flag which are not required anymore and not used by heartbeat currently. 