### PR TITLE
chore: use different selector to pick banner

### DIFF
--- a/examples/docker/heartbeat.docker.yml
+++ b/examples/docker/heartbeat.docker.yml
@@ -11,7 +11,7 @@ heartbeat.monitors:
               await page.goto('https://www.elastic.co');
           });
           step("hover over products menu", async () => {
-              const [cookieBanner] = await page.$$('#iubenda-cs-banner');
+              const cookieBanner = await page.$('#iubenda-cs-banner');
               if (cookieBanner) {
                 await page.click('.iubenda-cs-accept-btn');
               }

--- a/examples/inline/short.js
+++ b/examples/inline/short.js
@@ -2,7 +2,7 @@ step('load homepage', async () => {
   await page.goto('https://www.elastic.co');
 });
 step('hover over products menu', async () => {
-  const [cookieBanner] = await page.$$('#iubenda-cs-banner');
+  const cookieBanner = await page.$('#iubenda-cs-banner');
   if (cookieBanner) {
     await page.click('.iubenda-cs-accept-btn');
   }


### PR DESCRIPTION
+ When the element is null, the returned collection will not be iterable. So we use the single element instead of using the list.  