### PR TITLE
fix: prioritize suite params over config

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -83,6 +83,23 @@ describe('CLI', () => {
     });
   });
 
+  it('suite params wins over config params', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'fake.journey.ts'),
+      '--json',
+      '--config',
+      join(FIXTURES_DIR, 'synthetics.config.ts'),
+      '-s',
+      '{"url": "suite-url"}',
+    ]);
+    await cli.waitFor('journey/start');
+    const output = cli.output();
+    expect(await cli.exitCode).toBe(0);
+    expect(JSON.parse(output).payload).toMatchObject({
+      params: { url: 'suite-url' },
+    });
+  });
+
   it('throw error on modifying params', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'params-error.journey.ts'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,8 +1899,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-property": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^7.0.0",
+    "deepmerge": "^4.2.2",
     "http-proxy": "^1.18.1",
     "kleur": "^4.1.3",
     "playwright-chromium": "=1.11.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@
 
 import { stdin, cwd } from 'process';
 import { resolve } from 'path';
+import merge from 'deepmerge';
 import { step, journey } from './core';
 import { log } from './core/logger';
 import program, { options } from './parse_args';
@@ -165,7 +166,7 @@ async function prepareSuites(inputs: string[]) {
    * Validate and handle configs
    */
   const config = readConfig(environment, options.config);
-  const params = config.params || JSON.parse(options.suiteParams);
+  const params = merge(config.params, JSON.parse(options.suiteParams));
   /**
    * use JSON reporter if json flag is enabled
    */


### PR DESCRIPTION
+ fix #297 
+ We now deep merge the params passed from both config and suite params and always prioritize suite params over config params when a key is specified in both. 