### PR TITLE
feat: add filtering by tags and names

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -272,7 +272,7 @@ describe('runner', () => {
       await runner.run({
         wsEndpoint,
         outfd: fs.openSync(dest, 'w'),
-        match: ['j2'],
+        match: 'j2',
       })
     ).toEqual({
       j2: { status: 'succeeded' },
@@ -286,7 +286,7 @@ describe('runner', () => {
       await runner.run({
         wsEndpoint,
         outfd: fs.openSync(dest, 'w'),
-        match: ['j*'],
+        match: 'j*',
       })
     ).toEqual({
       j1: { status: 'succeeded' },
@@ -305,7 +305,7 @@ describe('runner', () => {
         wsEndpoint,
         outfd: fs.openSync(dest, 'w'),
         tags: ['foo*'],
-        match: ['j*'],
+        match: 'j*',
       })
     ).toEqual({
       j1: { status: 'succeeded' },

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -265,16 +265,51 @@ describe('runner', () => {
     });
   });
 
-  it('run api - only runs specified journeyName', async () => {
+  it('run api - match journey name explict', async () => {
     runner.addJourney(new Journey({ name: 'j1' }, noop));
     runner.addJourney(new Journey({ name: 'j2' }, noop));
-    const result = await runner.run({
-      wsEndpoint,
-      outfd: fs.openSync(dest, 'w'),
-      journeyName: 'j2',
-    });
-    expect(result).toEqual({
+    expect(
+      await runner.run({
+        wsEndpoint,
+        outfd: fs.openSync(dest, 'w'),
+        match: 'j2',
+      })
+    ).toEqual({
       j2: { status: 'succeeded' },
+    });
+  });
+
+  it('run api - match journey name globs', async () => {
+    runner.addJourney(new Journey({ name: 'j1' }, noop));
+    runner.addJourney(new Journey({ name: 'j2' }, noop));
+    expect(
+      await runner.run({
+        wsEndpoint,
+        outfd: fs.openSync(dest, 'w'),
+        match: 'j*',
+      })
+    ).toEqual({
+      j1: { status: 'succeeded' },
+      j2: { status: 'succeeded' },
+    });
+  });
+
+  it('run api - match journey tags globs', async () => {
+    runner.addJourney(new Journey({ name: 'j1', tag: 'foo' }, noop));
+    runner.addJourney(new Journey({ name: 'j2', tag: 'bar' }, noop));
+    runner.addJourney(new Journey({ name: 'j3', tag: 'foo:test' }, noop));
+    runner.addJourney(new Journey({ name: 'j4', tag: 'baz' }, noop));
+    runner.addJourney(new Journey({ name: 'h1', tag: 'foo' }, noop));
+    expect(
+      await runner.run({
+        wsEndpoint,
+        outfd: fs.openSync(dest, 'w'),
+        tags: ['foo*'],
+        match: 'j*',
+      })
+    ).toEqual({
+      j1: { status: 'succeeded' },
+      j3: { status: 'succeeded' },
     });
   });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -70,7 +70,7 @@ describe('Run', () => {
       filmstrips: false,
       trace: false,
       dryRun: true,
-      journeyName: 'There and Back Again',
+      match: 'check*',
       network: true,
       pauseOnError: true,
       reporter: 'json',

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -204,7 +204,7 @@ describe('json reporter', () => {
   });
 
   it('writes full journey info if present', async () => {
-    const journeyOpts = { name: 'name', id: 'id', tag: 'tag' };
+    const journeyOpts = { name: 'name', id: 'id', tags: ['tag1', 'tag2'] };
     runner.emit('journey:end', {
       journey: journey(journeyOpts, () => {}),
       start: 0,

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -203,6 +203,21 @@ describe('json reporter', () => {
     expect(journeyEnd.error).toEqual(helpers.formatError(myErr));
   });
 
+  it('writes full journey info if present', async () => {
+    const journeyOpts = { name: 'name', id: 'id', tag: 'tag' };
+    runner.emit('journey:end', {
+      journey: journey(journeyOpts, () => {}),
+      start: 0,
+      end: 1,
+      status: 'skipped',
+    });
+
+    const journeyEnd = (await readAndCloseStreamJson()).find(
+      json => json.type == 'journey/end'
+    );
+    expect(journeyEnd.journey).toEqual({ ...journeyOpts, status: 'skipped' });
+  });
+
   it('captures number of journeys as metadata event', async () => {
     runner.emit('start', {
       numJourneys: 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -833,6 +833,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/braces": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",
+      "integrity": "sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -887,6 +893,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
+    },
+    "@types/micromatch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.1.tgz",
+      "integrity": "sha512-my6fLBvpY70KattTNzYOK6KU1oR1+UCz9ug/JbcF5UrEmeCt9P7DV2t7L8+t18mMPINqGQCE4O8PLOPbI84gxw==",
+      "dev": true,
+      "requires": {
+        "@types/braces": "*"
+      }
     },
     "@types/node": {
       "version": "14.14.45",
@@ -1421,7 +1436,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -2603,7 +2617,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -3279,8 +3292,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -4263,7 +4275,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -4727,8 +4738,7 @@
     "picomatch": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
-      "dev": true
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
     },
     "pirates": {
       "version": "4.0.1",
@@ -6093,7 +6103,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "commander": "^7.0.0",
     "http-proxy": "^1.18.1",
     "kleur": "^4.1.3",
+    "micromatch": "^4.0.4",
     "playwright-chromium": "=1.11.0",
     "sharp": "^0.28.3",
     "snakecase-keys": "^3.2.1",
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
+    "@types/micromatch": "^4.0.1",
     "@types/node": "^14.14.14",
     "@types/sharp": "^0.28.2",
     "@typescript-eslint/eslint-plugin": "^3.10.1",

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -133,7 +133,7 @@ export type CliArgs = {
   json?: boolean;
   pattern?: string;
   inline: boolean;
-  match?: string;
+  match?: Array<string>;
   tags?: Array<string>;
   require: Array<string>;
   debug?: boolean;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -133,7 +133,7 @@ export type CliArgs = {
   json?: boolean;
   pattern?: string;
   inline: boolean;
-  match?: Array<string>;
+  match?: string;
   tags?: Array<string>;
   require: Array<string>;
   debug?: boolean;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -125,7 +125,6 @@ export type CliArgs = {
   filmstrips?: boolean;
   trace?: boolean;
   dryRun?: boolean;
-  journeyName?: string;
   network?: boolean;
   pauseOnError?: boolean;
   reporter?: Reporters;
@@ -134,6 +133,8 @@ export type CliArgs = {
   json?: boolean;
   pattern?: string;
   inline: boolean;
+  match?: string;
+  tags?: Array<string>;
   require: Array<string>;
   debug?: boolean;
   suiteParams?: string;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -24,6 +24,8 @@
  */
 
 import { once, EventEmitter } from 'events';
+import { join } from 'path';
+import { mkdirSync, rmdirSync, writeFileSync } from 'fs';
 import { Journey } from '../dsl/journey';
 import { Step } from '../dsl/step';
 import { reporters, Reporter } from '../reporters';
@@ -46,8 +48,6 @@ import { PluginManager } from '../plugins';
 import { PerformanceManager, Metrics } from '../plugins';
 import { Driver, Gatherer } from './gatherer';
 import { log } from './logger';
-import { mkdirSync, rmdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
 
 export type RunOptions = Omit<
   CliArgs,
@@ -369,8 +369,8 @@ export default class Runner extends EventEmitter {
       env: options.environment,
       params: options.params,
     });
+    const { dryRun, match, tags } = options;
     for (const journey of this.journeys) {
-      const { dryRun, journeyName } = options;
       /**
        * Used by heartbeat to gather all registered journeys
        */
@@ -378,8 +378,7 @@ export default class Runner extends EventEmitter {
         this.emit('journey:register', { journey });
         continue;
       }
-      // TODO: Replace functionality with journey.only
-      if (journeyName && journey.name != journeyName) {
+      if (!journey.isMatch(match, tags)) {
         continue;
       }
       const journeyResult = await this.runJourney(journey, options);

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -24,14 +24,14 @@
  */
 
 import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
-import { contains, isMatch } from 'micromatch';
+import micromatch, { isMatch } from 'micromatch';
 import { Step } from './step';
 import { VoidCallback, HooksCallback, Params } from '../common_types';
 
 export type JourneyOptions = {
   name: string;
   id?: string;
-  tag?: string;
+  tags?: string[];
 };
 
 type HookType = 'before' | 'after';
@@ -47,7 +47,7 @@ export type JourneyCallback = (options: {
 export class Journey {
   name: string;
   id?: string;
-  tag?: string;
+  tags?: string[];
   callback: JourneyCallback;
   steps: Step[] = [];
   hooks: Hooks = { before: [], after: [] };
@@ -55,7 +55,7 @@ export class Journey {
   constructor(options: JourneyOptions, callback: JourneyCallback) {
     this.name = options.name;
     this.id = options.id;
-    this.tag = options.tag;
+    this.tags = options.tags;
     this.callback = callback;
   }
 
@@ -68,10 +68,23 @@ export class Journey {
   addHook(type: HookType, callback: HooksCallback) {
     this.hooks[type].push(callback);
   }
+  /**
+   * Matches journeys based on the provided args. Proitize tags over match
+   * - tags pattern that matches only tags
+   * - match pattern that matches both name and tags
+   */
+  isMatch(matchPattern, tagsPattern) {
+    if (tagsPattern) {
+      return this.tagsMatch(tagsPattern);
+    }
+    if (matchPattern) {
+      return isMatch(this.name, matchPattern) || this.tagsMatch(matchPattern);
+    }
+    return true;
+  }
 
-  isMatch(namePattern = '**', tagsPattern = ['**']) {
-    return (
-      contains(this.name, namePattern) && isMatch(this.tag || '**', tagsPattern)
-    );
+  tagsMatch(pattern) {
+    const matchess = micromatch(this.tags || ['*'], pattern);
+    return matchess.length > 0;
   }
 }

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -73,7 +73,7 @@ export class Journey {
    * - tags pattern that matches only tags
    * - match pattern that matches both name and tags
    */
-  isMatch(matchPattern, tagsPattern) {
+  isMatch(matchPattern: string, tagsPattern: Array<string>) {
     if (tagsPattern) {
       return this.tagsMatch(tagsPattern);
     }

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -24,12 +24,14 @@
  */
 
 import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
+import { contains, isMatch } from 'micromatch';
 import { Step } from './step';
 import { VoidCallback, HooksCallback, Params } from '../common_types';
 
 export type JourneyOptions = {
   name: string;
   id?: string;
+  tag?: string;
 };
 
 type HookType = 'before' | 'after';
@@ -45,6 +47,7 @@ export type JourneyCallback = (options: {
 export class Journey {
   name: string;
   id?: string;
+  tag?: string;
   callback: JourneyCallback;
   steps: Step[] = [];
   hooks: Hooks = { before: [], after: [] };
@@ -52,6 +55,7 @@ export class Journey {
   constructor(options: JourneyOptions, callback: JourneyCallback) {
     this.name = options.name;
     this.id = options.id;
+    this.tag = options.tag;
     this.callback = callback;
   }
 
@@ -63,5 +67,11 @@ export class Journey {
 
   addHook(type: HookType, callback: HooksCallback) {
     this.hooks[type].push(callback);
+  }
+
+  isMatch(namePattern = '**', tagsPattern = ['**']) {
+    return (
+      contains(this.name, namePattern) && isMatch(this.tag || '**', tagsPattern)
+    );
   }
 }

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -66,7 +66,7 @@ program
     "don't actually execute anything, report only registered journeys"
   )
   .option(
-    '--match <name...>',
+    '--match <name>',
     'run only journeys with a name or tags that matches the glob'
   )
   .option(

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -66,8 +66,8 @@ program
     "don't actually execute anything, report only registered journeys"
   )
   .option(
-    '--match <name>',
-    'run only journeys with a name that matches the glob'
+    '--match <name...>',
+    'run only journeys with a name or tags that matches the glob'
   )
   .option(
     '--tags <name...>',

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -65,7 +65,14 @@ program
     '--dry-run',
     "don't actually execute anything, report only registered journeys"
   )
-  .option('--journey-name <name>', 'only run the journey with the given name')
+  .option(
+    '--match <name>',
+    'run only journeys with a name that matches the glob'
+  )
+  .option(
+    '--tags <name...>',
+    'run only journeys with the given tag(s), or globs'
+  )
   .option(
     '--outfd <fd>',
     'specify a file descriptor for logs. Default is stdout',

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -244,6 +244,7 @@ function journeyInfo(
   return {
     name: journey.name,
     id: journey.id,
+    tag: journey.tag,
     status: type === 'journey/end' ? status : undefined,
   };
 }

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -244,7 +244,7 @@ function journeyInfo(
   return {
     name: journey.name,
     id: journey.id,
-    tag: journey.tag,
+    tags: journey.tags,
     status: type === 'journey/end' ? status : undefined,
   };
 }


### PR DESCRIPTION
+ fix #26 
+ Added support for glob pattern matching for both journey name and tags. 
+ Names and tags can be matched with multiple journeys that has the same name and tags spawned across multiple files. 
```
elastic-synthetics examples/todos/* --match 'check*' 
// will match all the journey that has `check` in their name and tags. 
```
This aligns with `RegExp` or glob matching found in major libraries like jest, folio, mocha etc and we don't support variadiac options for name matching as majority of the cases can be solved with a mix of both.

+ Tags matching which is a variadic option meaning you can pass multiple options in the CLI to match a group of journeys.
```ts
// will run the journeys that are tagged with the respective teams in the kibana repo. 
elastic-synthetics <dir> --tags 'kibana:uptime*'  'kibana:apm*'

journey({ name: "elastic uptime app", tags: ["kibana:uptime", "kibana:apm" }, () => {})
```

**Note: `match` pattern that matches both name and tags, `tags` pattern that matches only tags**
