### PR TITLE
feat: add expect assertion library

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/member-delimiter-style': 0,
     '@typescript-eslint/ban-ts-comment': 0,
+    '@typescript-eslint/no-namespace': 0,
     'require-license-header': [
       'error',
       {

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -209,3 +209,13 @@ Copyright 2017 The Lighthouse Authors. All Rights Reserved.
    See the License for the specific language governing permissions and
    limitations under the License.
 ---------------------------------------------------------------------------
+This product relies on `expect`
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+---------------------------------------------------------------------------

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -139,6 +139,14 @@ describe('CLI', () => {
       expect(e.message).toMatch('Missing capability "unknown"');
     }
   });
+
+  it('run expect assetions with type check', async () => {
+    // flag turns on type checking
+    process.env['TS_NODE_TYPE_CHECK'] = 'true';
+    const cli = new CLIMock([join(FIXTURES_DIR, 'expect.journey.ts')]);
+    expect(await cli.exitCode).toBe(0);
+    process.env['TS_NODE_TYPE_CHECK'] = 'false';
+  });
 });
 
 class CLIMock {

--- a/__tests__/fixtures/expect.journey.ts
+++ b/__tests__/fixtures/expect.journey.ts
@@ -1,0 +1,66 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { journey, step, expect } from '../../';
+
+declare global {
+  namespace synthetics {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+
+expect.extend({
+  toBeWithinRange(received, floor, ceiling) {
+    const pass = received >= floor && received <= ceiling;
+    if (pass) {
+      return {
+        message: () =>
+          `expected ${received} not to be within range ${floor} - ${ceiling}`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () =>
+          `expected ${received} to be within range ${floor} - ${ceiling}`,
+        pass: false,
+      };
+    }
+  },
+});
+
+journey('expect journey', ({}) => {
+  step('exports work', () => {
+    expect(100).toBe(100);
+    expect([1, 2, 3]).toEqual(expect.arrayContaining([1, 2, 3]));
+    expect({ foo: 'bar' }).toMatchObject({ foo: 'bar' });
+  });
+
+  step('extends work', () => {
+    expect(100).toBeWithinRange(90, 120);
+    expect(101).not.toBeWithinRange(0, 100);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,8 +206,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
-      "dev": true
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -230,7 +229,6 @@
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
       "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
@@ -241,7 +239,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -250,7 +247,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -261,7 +257,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -269,26 +264,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -667,6 +658,22 @@
         "@jest/environment": "^26.6.2",
         "@jest/types": "^26.6.2",
         "expect": "^26.6.2"
+      },
+      "dependencies": {
+        "expect": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+          "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.6.2",
+            "jest-message-util": "^26.6.2",
+            "jest-regex-util": "^26.0.0"
+          }
+        }
       }
     },
     "@jest/reporters": {
@@ -857,14 +864,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
-      "dev": true
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -873,7 +878,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
       "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
@@ -938,8 +942,7 @@
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
-      "dev": true
+      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -953,8 +956,7 @@
     "@types/yargs-parser": {
       "version": "20.2.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
-      "dev": true
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
     },
     "@types/yauzl": {
       "version": "2.9.1",
@@ -1126,14 +1128,12 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -1550,7 +1550,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1706,7 +1705,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -2429,17 +2427,115 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "expect": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
-      "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
-      "dev": true,
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
+      "integrity": "sha512-YJFNJe2+P2DqH+ZrXy+ydRQYO87oxRUonZImpDodR1G7qo3NYd3pL+NQ9Keqpez3cehczYwZDBC3A7xk3n7M/w==",
       "requires": {
-        "@jest/types": "^26.6.2",
-        "ansi-styles": "^4.0.0",
-        "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.6.2",
-        "jest-message-util": "^26.6.2",
-        "jest-regex-util": "^26.0.0"
+        "@jest/types": "^27.0.2",
+        "ansi-styles": "^5.0.0",
+        "jest-get-type": "^27.0.1",
+        "jest-matcher-utils": "^27.0.2",
+        "jest-message-util": "^27.0.2",
+        "jest-regex-util": "^27.0.1"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@jest/types": {
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.2.tgz",
+          "integrity": "sha512-XpjCtJ/99HB4PmyJ2vgmN7vT+JLP7RW1FBT9RgnMFS4Dt7cvIyBee8O3/j98aUZ34ZpenPZFqmaaObWSeL65dg==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^16.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "16.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.3.tgz",
+          "integrity": "sha512-YlFfTGS+zqCgXuXNV26rOIeETOkXnGQXP/pjjL9P0gO/EP9jTmc7pUBhx+jVEIxpq41RX33GQ7N3DzOSfZoglQ==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        },
+        "diff-sequences": {
+          "version": "27.0.1",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.1.tgz",
+          "integrity": "sha512-XPLijkfJUh/PIBnfkcSHgvD6tlYixmcMAn3osTk6jt+H0v/mgURto1XUiD9DKuGX5NDoVS6dSlA23gd9FUaCFg=="
+        },
+        "jest-diff": {
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.2.tgz",
+          "integrity": "sha512-BFIdRb0LqfV1hBt8crQmw6gGQHVDhM87SpMIZ45FPYKReZYG5er1+5pIn2zKqvrJp6WNox0ylR8571Iwk2Dmgw==",
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^27.0.1",
+            "jest-get-type": "^27.0.1",
+            "pretty-format": "^27.0.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "27.0.1",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.1.tgz",
+          "integrity": "sha512-9Tggo9zZbu0sHKebiAijyt1NM77Z0uO4tuWOxUCujAiSeXv30Vb5D4xVF4UR4YWNapcftj+PbByU54lKD7/xMg=="
+        },
+        "jest-matcher-utils": {
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz",
+          "integrity": "sha512-Qczi5xnTNjkhcIB0Yy75Txt+Ez51xdhOxsukN7awzq2auZQGPHcQrJ623PZj0ECDEMOk2soxWx05EXdXGd1CbA==",
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^27.0.2",
+            "jest-get-type": "^27.0.1",
+            "pretty-format": "^27.0.2"
+          }
+        },
+        "jest-message-util": {
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.0.2.tgz",
+          "integrity": "sha512-rTqWUX42ec2LdMkoUPOzrEd1Tcm+R1KfLOmFK+OVNo4MnLsEaxO5zPDb2BbdSmthdM/IfXxOZU60P/WbWF8BTw==",
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^27.0.2",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^27.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-regex-util": {
+          "version": "27.0.1",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.0.1.tgz",
+          "integrity": "sha512-6nY6QVcpTgEKQy1L41P4pr3aOddneK17kn3HJw6SdwGiKfgCGTvH02hVXL0GU8GEKtPH83eD2DIDgxHXOxVohQ=="
+        },
+        "pretty-format": {
+          "version": "27.0.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.2.tgz",
+          "integrity": "sha512-mXKbbBPnYTG7Yra9qFBtqj+IXcsvxsvOBco3QHxtxTl+hHKq6QdzMZ+q0CtL4ORHZgwGImRr2XZUX2EWzORxig==",
+          "requires": {
+            "@jest/types": "^27.0.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^17.0.1"
+          }
+        }
       }
     },
     "extend": {
@@ -2905,8 +3001,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -3655,6 +3750,22 @@
         "jest-util": "^26.6.2",
         "pretty-format": "^26.6.2",
         "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "expect": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+          "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.6.2",
+            "jest-message-util": "^26.6.2",
+            "jest-regex-util": "^26.0.0"
+          }
+        }
       }
     },
     "jest-leak-detector": {
@@ -3840,6 +3951,22 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^26.6.2",
         "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "expect": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
+          "integrity": "sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.6.2",
+            "jest-message-util": "^26.6.2",
+            "jest-regex-util": "^26.0.0"
+          }
+        }
       }
     },
     "jest-util": {
@@ -3912,8 +4039,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -4941,8 +5067,7 @@
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -5545,8 +5670,7 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -5920,7 +6044,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "commander": "^7.0.0",
     "deepmerge": "^4.2.2",
+    "expect": "^27.0.2",
     "http-proxy": "^1.18.1",
     "kleur": "^4.1.3",
     "micromatch": "^4.0.4",

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import expectLibrary from 'expect';
+import expectLib from 'expect';
 import type {
   AsymmetricMatcher,
   MatcherState,
@@ -184,4 +184,4 @@ declare global {
   }
 }
 
-export const expect: Expect = expectLibrary;
+export const expect: Expect = expectLib;

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -23,17 +23,16 @@
  *
  */
 
-import expectLib from 'expect';
-import type expectTypes from 'expect';
+import expectLibrary from 'expect';
 import type {
-  ExpectedAssertionsErrors,
   AsymmetricMatcher,
   MatcherState,
+  ExpectedAssertionsErrors,
 } from 'expect/build/types';
 
+// Copied source code from expect/build/types.d.ts
 export declare type Expect = {
-  <T = unknown>(actual: T): Matchers<T>;
-  // copied from expect types
+  <T = unknown>(actual: T): synthetics.Matchers<T>;
   assertions(arg0: number): void;
   extend(arg0: any): void;
   extractExpectedAssertionsErrors: () => ExpectedAssertionsErrors;
@@ -50,12 +49,139 @@ export declare type Expect = {
 
 /**
  * Override matchers from expect in our synthetic namespace to
- * reduuce support for spy and snapshot matchers
+ * reduce support for spy and snapshot matchers which is
+ * impelemed via jest matchers
+ *
+ * We declare the types in global synthetics namespace which allows
+ * users to extend expect functionality without type errors
  */
-export interface Matchers<R> extends expectTypes.Matchers<R> {
-  not: Matchers<R>;
-  resolves: Matchers<Promise<R>>;
-  rejects: Matchers<Promise<R>>;
+declare global {
+  export namespace synthetics {
+    export interface Matchers<R> {
+      /**
+       * If you know how to test something, `.not` lets you test its opposite.
+       */
+      not: Matchers<R>;
+      /**
+       * Use resolves to unwrap the value of a fulfilled promise so any other
+       * matcher can be chained. If the promise is rejected the assertion fails.
+       */
+      resolves: Matchers<Promise<R>>;
+      /**
+       * Unwraps the reason of a rejected promise so any other matcher can be chained.
+       * If the promise is fulfilled the assertion fails.
+       */
+      rejects: Matchers<Promise<R>>;
+      /**
+       * Checks that a value is what you expect. It uses `===` to check strict equality.
+       * Don't use `toBe` with floating-point numbers.
+       */
+      toBe(expected: unknown): R;
+      /**
+       * Using exact equality with floating point numbers is a bad idea.
+       * Rounding means that intuitive things fail.
+       * The default for numDigits is 2.
+       */
+      toBeCloseTo(expected: number, numDigits?: number): R;
+      /**
+       * Ensure that a variable is not undefined.
+       */
+      toBeDefined(): R;
+      /**
+       * When you don't care what a value is, you just want to
+       * ensure a value is false in a boolean context.
+       */
+      toBeFalsy(): R;
+      /**
+       * For comparing floating point numbers.
+       */
+      toBeGreaterThan(expected: number | bigint): R;
+      /**
+       * For comparing floating point numbers.
+       */
+      toBeGreaterThanOrEqual(expected: number | bigint): R;
+      /**
+       * Ensure that an object is an instance of a class.
+       * This matcher uses `instanceof` underneath.
+       */
+      /* eslint-disable-next-line */
+      toBeInstanceOf(expected: Function): R;
+      /**
+       * For comparing floating point numbers.
+       */
+      toBeLessThan(expected: number | bigint): R;
+      /**
+       * For comparing floating point numbers.
+       */
+      toBeLessThanOrEqual(expected: number | bigint): R;
+      /**
+       * This is the same as `.toBe(null)` but the error messages are a bit nicer.
+       * So use `.toBeNull()` when you want to check that something is null.
+       */
+      toBeNull(): R;
+      /**
+       * Use when you don't care what a value is, you just want to ensure a value
+       * is true in a boolean context. In JavaScript, there are six falsy values:
+       * `false`, `0`, `''`, `null`, `undefined`, and `NaN`. Everything else is truthy.
+       */
+      toBeTruthy(): R;
+      /**
+       * Used to check that a variable is undefined.
+       */
+      toBeUndefined(): R;
+      /**
+       * Used to check that a variable is NaN.
+       */
+      toBeNaN(): R;
+      /**
+       * Used when you want to check that an item is in a list.
+       * For testing the items in the list, this uses `===`, a strict equality check.
+       */
+      toContain(expected: unknown): R;
+      /**
+       * Used when you want to check that an item is in a list.
+       * For testing the items in the list, this  matcher recursively checks the
+       * equality of all fields, rather than checking for object identity.
+       */
+      toContainEqual(expected: unknown): R;
+      /**
+       * Used when you want to check that two objects have the same value.
+       * This matcher recursively checks the equality of all fields, rather than checking for object identity.
+       */
+      toEqual(expected: unknown): R;
+      /**
+       * Used to check that an object has a `.length` property
+       * and it is set to a certain numeric value.
+       */
+      toHaveLength(expected: number): R;
+      /**
+       * Use to check if property at provided reference keyPath exists for an object.
+       * For checking deeply nested properties in an object you may use dot notation or an array containing
+       * the keyPath for deep references.
+       *
+       * Optionally, you can provide a value to check if it's equal to the value present at keyPath
+       * on the target object. This matcher uses 'deep equality' (like `toEqual()`) and recursively checks
+       * the equality of all fields.
+       *
+       * @example
+       *
+       * expect(houseForSale).toHaveProperty('kitchen.area', 20);
+       */
+      toHaveProperty(keyPath: string | Array<string>, value?: unknown): R;
+      /**
+       * Check that a string matches a regular expression.
+       */
+      toMatch(expected: string | RegExp): R;
+      /**
+       * Used to check that a JavaScript object matches a subset of the properties of an object
+       */
+      toMatchObject(expected: Record<string, unknown> | Array<unknown>): R;
+      /**
+       * Use to test that objects have the same types as well as structure.
+       */
+      toStrictEqual(expected: unknown): R;
+    }
+  }
 }
 
-export const expect: Expect = expectLib;
+export const expect: Expect = expectLibrary;

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -23,47 +23,39 @@
  *
  */
 
-import { runner } from './core';
-import { RunOptions } from './core/runner';
-import { setLogger } from './core/logger';
-import sourceMapSupport from 'source-map-support';
+import expectLib from 'expect';
+import type expectTypes from 'expect';
+import type {
+  ExpectedAssertionsErrors,
+  AsymmetricMatcher,
+  MatcherState,
+} from 'expect/build/types';
 
-export async function run(options: RunOptions) {
-  /**
-   * Install source map support
-   */
-  sourceMapSupport.install({
-    environment: 'node',
-  });
-  /**
-   * set up logger with appropriate file descriptor
-   * to capture all the DEBUG logs when run through heartbeat
-   */
-  setLogger(options.outfd);
+export declare type Expect = {
+  <T = unknown>(actual: T): Matchers<T>;
+  // copied from expect types
+  assertions(arg0: number): void;
+  extend(arg0: any): void;
+  extractExpectedAssertionsErrors: () => ExpectedAssertionsErrors;
+  getState(): MatcherState;
+  hasAssertions(): void;
+  setState(state: Partial<MatcherState>): void;
+  any(expectedObject: any): AsymmetricMatcher;
+  anything(): AsymmetricMatcher;
+  arrayContaining(sample: Array<unknown>): AsymmetricMatcher;
+  objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
+  stringContaining(expected: string): AsymmetricMatcher;
+  stringMatching(expected: string | RegExp): AsymmetricMatcher;
+};
 
-  try {
-    return await runner.run(options);
-  } catch (e) {
-    console.error('Failed to run the test', e);
-    process.exit(1);
-  }
+/**
+ * Override matchers from expect in our synthetic namespace to
+ * reduuce support for spy and snapshot matchers
+ */
+export interface Matchers<R> extends expectTypes.Matchers<R> {
+  not: Matchers<R>;
+  resolves: Matchers<Promise<R>>;
+  rejects: Matchers<Promise<R>>;
 }
 
-export { beforeAll, afterAll, journey, step, before, after } from './core';
-export * from './core/expect';
-/**
- * Export all the driver related types to be consumed
- * and used by suites
- */
-export type {
-  Page,
-  ChromiumBrowser,
-  ChromiumBrowserContext,
-  CDPSession,
-} from 'playwright-chromium';
-
-/**
- * Export the types necessary to write custom reporters
- */
-export type { default as Runner } from './core/runner';
-export type { Reporter, ReporterOptions } from './reporters';
+export const expect: Expect = expectLib;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,8 +49,11 @@ export async function run(options: RunOptions) {
   }
 }
 
+/**
+ * Export all core module functions
+ */
 export { beforeAll, afterAll, journey, step, before, after } from './core';
-export * from './core/expect';
+export { expect } from './core/expect';
 /**
  * Export all the driver related types to be consumed
  * and used by suites


### PR DESCRIPTION
+ fix #201 
+ Uses the expect library with custom Matcher interface as some of the expect types are implemented by `jest` like Spy and Snapshot matcher. 
+ Types are namespaced under `synthetics` in global to allow `expect.extend` functionality work with Typescript without throwing any typings error.  Look at https://github.com/elastic/synthetics/blob/fa18f519d4d8488d49f5883b04d601f281aabdcc/__tests__/fixtures/expect.journey.ts for more details. 
+ Test coverage is done for both expect library and also for types with extensions. 