### PR TITLE
fix: isolate journeys with context

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -383,8 +383,8 @@ export default class Runner extends EventEmitter {
       }
       const journeyResult = await this.runJourney(journey, options);
       result[journey.name] = journeyResult;
-      await Gatherer.stop();
     }
+    await Gatherer.stop();
     await this.runAfterAllHook({
       env: options.environment,
       params: options.params,


### PR DESCRIPTION
+ The previous performance improvement https://github.com/elastic/synthetics/pull/274/files was undone by another commit while doing the screenshot post processing. 