### PR TITLE
chore: use duration.us for trace events

### DIFF
--- a/__tests__/sdk/trace-metrics.test.ts
+++ b/__tests__/sdk/trace-metrics.test.ts
@@ -41,8 +41,8 @@ describe('Trace metrics', () => {
     expect(metrics).toMatchInlineSnapshot(`
       Array [
         Object {
-          "end": Object {
-            "us": 3069485988748,
+          "duration": Object {
+            "us": 1212635,
           },
           "name": "Next.js-before-hydration",
           "start": Object {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -41,7 +41,7 @@ export type TraceOutput = {
   name: string;
   type: string;
   start: MetricDuration;
-  end?: MetricDuration;
+  duration?: MetricDuration;
   score?: number;
 };
 

--- a/src/sdk/trace-metrics.ts
+++ b/src/sdk/trace-metrics.ts
@@ -72,8 +72,8 @@ export class UserTimings {
           start: {
             us: startTime,
           },
-          end: {
-            us: ts,
+          duration: {
+            us: ts - startTime,
           },
         });
       }


### PR DESCRIPTION
+ As a result of changes here - https://github.com/elastic/beats/pull/26248