### PR TITLE
feat: add browser and context options support

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -76,10 +76,25 @@ describe('CLI', () => {
       'testing',
     ]);
     await cli.waitFor('journey/start');
-    expect(await cli.exitCode).toBe(0);
     const output = cli.output();
+    expect(await cli.exitCode).toBe(0);
     expect(JSON.parse(output).payload).toMatchObject({
       params: { url: 'non-dev' },
+    });
+  });
+
+  it('pass playwright options to runner', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'pwoptions.journey.ts'),
+      '--json',
+      '--config',
+      join(FIXTURES_DIR, 'synthetics.config.ts'),
+    ]);
+    await cli.waitFor('step/end');
+    const output = cli.output();
+    expect(await cli.exitCode).toBe(0);
+    expect(JSON.parse(output).step).toMatchObject({
+      status: 'succeeded',
     });
   });
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -24,6 +24,7 @@
  */
 
 import { join } from 'path';
+import { devices } from 'playwright-chromium';
 import { generateTempPath } from '../src/helpers';
 import { readConfig } from '../src/config';
 
@@ -36,8 +37,11 @@ describe('Config', () => {
       params: {
         url: 'dev',
       },
+      playwrightOptions: {
+        ...devices['Galaxy S9+'],
+      },
     });
-    expect(readConfig('testing', configPath)).toEqual({
+    expect(readConfig('testing', configPath)).toMatchObject({
       params: {
         url: 'non-dev',
       },

--- a/__tests__/fixtures/pwoptions.journey.ts
+++ b/__tests__/fixtures/pwoptions.journey.ts
@@ -23,20 +23,14 @@
  *
  */
 
-import { devices } from 'playwright-chromium';
-import type { SyntheticsConfig } from '../../src';
+import { journey, step, expect } from '../../dist';
 
-module.exports = env => {
-  const config: SyntheticsConfig = {
-    params: {
-      url: 'dev',
-    },
-    playwrightOptions: {
-      ...devices['Galaxy S9+'],
-    },
-  };
-  if (env !== 'development') {
-    config.params.url = 'non-dev';
-  }
-  return config;
-};
+journey('launch with viewport', ({ page }) => {
+  step('Ensure viewport width', () => {
+    expect(page.viewportSize()).toEqual({
+      height: 658,
+      width: 320,
+    });
+    expect(page.touchscreen).toBeDefined();
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -65,7 +65,6 @@ describe('Run', () => {
       params: {
         foo: 'bar',
       },
-      headless: false,
       screenshots: 'on',
       filmstrips: false,
       trace: false,
@@ -74,7 +73,6 @@ describe('Run', () => {
       network: true,
       pauseOnError: true,
       reporter: 'json',
-      sandbox: true,
     };
     await run(runParams);
     expect(runnerSpy.mock.calls[0][0]).toEqual(runParams);

--- a/examples/todos/advanced.journey.ts
+++ b/examples/todos/advanced.journey.ts
@@ -7,10 +7,10 @@ import {
   destroyTaskStep,
 } from './helpers';
 
-journey('addition and completion of single task', ({ page }) => {
+journey('addition and completion of single task', ({ page, params }) => {
   const testText = "Don't put salt in your eyes";
 
-  loadAppStep(page);
+  loadAppStep(page, params.url);
   addTaskStep(page, testText);
   assertTaskListSizeStep(page, 1);
   checkForTaskStep(page, testText);
@@ -18,10 +18,10 @@ journey('addition and completion of single task', ({ page }) => {
   assertTaskListSizeStep(page, 0);
 });
 
-journey('adding and removing multiple tasks', ({ page }) => {
+journey('adding and removing multiple tasks', ({ page, params }) => {
   const testTasks = ['Task 1', 'Task 2', 'Task 3'];
 
-  loadAppStep(page);
+  loadAppStep(page, params.url);
   testTasks.forEach(t => {
     addTaskStep(page, t);
   });

--- a/examples/todos/basic.journey.ts
+++ b/examples/todos/basic.journey.ts
@@ -1,10 +1,9 @@
 import { journey, step, expect } from '@elastic/synthetics';
 import { join } from 'path';
 
-journey('check if title is present', ({ page }) => {
+journey('check if title is present', ({ page, params }) => {
   step('launch app', async () => {
-    const path = 'file://' + join(__dirname, 'app', 'index.html');
-    await page.goto(path);
+    await page.goto(params.url);
   });
 
   step('assert title', async () => {
@@ -13,10 +12,9 @@ journey('check if title is present', ({ page }) => {
   });
 });
 
-journey('check if input placeholder is correct', ({ page }) => {
+journey('check if input placeholder is correct', ({ page, params }) => {
   step('launch app', async () => {
-    const path = 'file://' + join(__dirname, 'app', 'index.html');
-    await page.goto(path);
+    await page.goto(params.url);
   });
 
   step('assert placeholder value', async () => {

--- a/examples/todos/helpers.ts
+++ b/examples/todos/helpers.ts
@@ -1,10 +1,9 @@
 import { step, Page, expect } from '@elastic/synthetics';
 import { join } from 'path';
 
-export const loadAppStep = (page: Page) => {
+export const loadAppStep = (page: Page, url: string) => {
   step('launch app', async () => {
-    const path = 'file://' + join(__dirname, 'app', 'index.html');
-    await page.goto(path);
+    await page.goto(url);
   });
 };
 

--- a/examples/todos/hooks.journey.ts
+++ b/examples/todos/hooks.journey.ts
@@ -1,0 +1,29 @@
+import { beforeAll, afterAll } from '@elastic/synthetics';
+import { createServer, Server } from 'http';
+import { Server as StaticServer } from 'node-static';
+
+let srv: Server;
+
+beforeAll(async () => {
+  const loc = __dirname + '/app';
+  const ss = new StaticServer(loc);
+
+  return new Promise(isUp => {
+    console.log(`Serving static app from ${loc}`);
+    srv = createServer((req, res) => {
+      req
+        .addListener('end', () => {
+          ss.serve(req, res);
+        })
+        .resume();
+    }).listen(8080, undefined, undefined, () => {
+      isUp();
+    });
+  });
+});
+
+afterAll(async () => {
+  if (srv) {
+    await srv.close();
+  }
+});

--- a/examples/todos/hooks.journey.ts
+++ b/examples/todos/hooks.journey.ts
@@ -1,29 +1,17 @@
 import { beforeAll, afterAll } from '@elastic/synthetics';
+import { once } from 'events';
 import { createServer, Server } from 'http';
+import { join } from 'path';
 import { Server as StaticServer } from 'node-static';
 
 let srv: Server;
 
 beforeAll(async () => {
-  const loc = __dirname + '/app';
-  const ss = new StaticServer(loc);
-
-  return new Promise(isUp => {
-    console.log(`Serving static app from ${loc}`);
-    srv = createServer((req, res) => {
-      req
-        .addListener('end', () => {
-          ss.serve(req, res);
-        })
-        .resume();
-    }).listen(8080, undefined, undefined, () => {
-      isUp();
-    });
-  });
+  const file = new StaticServer(join(__dirname, 'app'));
+  srv = createServer(file.serve.bind(file)).listen(8080);
+  await once(srv, 'listening');
 });
 
 afterAll(async () => {
-  if (srv) {
-    await srv.close();
-  }
+  srv && (await srv.close());
 });

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,6 +5,9 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "^1.0.0-beta"
+    "@elastic/synthetics": "^1.0.0-beta.3"
+  },
+  "devDependencies": {
+    "node-static": "^0.7.11"
   }
 }

--- a/examples/todos/synthetics.config.ts
+++ b/examples/todos/synthetics.config.ts
@@ -1,0 +1,28 @@
+// note that `env` is the `env` argument passed to the synthetics program
+// the default being `development`
+export default env => {
+  const cfg = {
+    params: {
+      url: 'http://localhost:8080',
+    },
+    playwrightOptions: {
+      // Note, this is mostly equivalent to `...devices["iPhone 6"]` with import { devices } from 'playwright-chromium';
+      // Just expanded for illustration
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+      viewport: {
+        width: 375,
+        height: 667,
+      },
+      deviceScaleFactor: 2,
+      isMobile: true,
+      hasTouch: true,
+    },
+  };
+
+  if (env === 'production') {
+    cfg.params.url = 'https://elastic.github.io/synthetics-demo/';
+  }
+
+  return cfg;
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "prepublish": "npm run clean && npm run build",
     "build": "tsc",
     "watch": "tsc -w",
@@ -64,6 +64,7 @@
     "jest": "^26.6.3",
     "lint-staged": "^10.5.3",
     "prettier": "^2.2.1",
-    "ts-jest": "^26.4.4"
+    "ts-jest": "^26.4.4",
+    "rimraf": "^3.0.2"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -167,6 +167,10 @@ async function prepareSuites(inputs: string[]) {
    */
   const config = readConfig(environment, options.config);
   const params = merge(config.params, JSON.parse(options.suiteParams));
+  const playwrightOptions = merge(config.playwrightOptions, {
+    headless: options.headless,
+    chromiumSandbox: options.sandbox,
+  });
   /**
    * use JSON reporter if json flag is enabled
    */
@@ -176,6 +180,7 @@ async function prepareSuites(inputs: string[]) {
     params: Object.freeze(params),
     environment,
     reporter,
+    playwrightOptions,
     ...options,
   });
 

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -23,6 +23,7 @@
  *
  */
 
+import { BrowserContextOptions, LaunchOptions } from 'playwright-chromium';
 import { Protocol } from 'playwright-chromium/types/protocol';
 import { Step } from './dsl';
 import { reporters } from './reporters';
@@ -142,4 +143,10 @@ export type CliArgs = {
   debug?: boolean;
   suiteParams?: string;
   richEvents?: boolean;
+};
+
+export type PlaywrightOptions = LaunchOptions & BrowserContextOptions;
+export type SyntheticsConfig = {
+  params?: Params;
+  playwrightOptions?: PlaywrightOptions;
 };

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -29,7 +29,7 @@ import { Step } from './dsl';
 import { reporters } from './reporters';
 
 export type VoidCallback = () => void;
-export type Params = Record<string, unknown>;
+export type Params = Record<string, any>;
 export type HooksArgs = {
   env: string;
   params: Params;

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,13 +24,10 @@
  */
 
 import { isAbsolute, resolve, dirname } from 'path';
+import { SyntheticsConfig } from './common_types';
 import { isFile } from './helpers';
 
-interface Config {
-  params?: Record<string, unknown>;
-}
-
-export function readConfig(env: string, config?: string): Config {
+export function readConfig(env: string, config?: string): SyntheticsConfig {
   let options = {};
   const cwd = process.cwd();
   /**

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -49,19 +49,16 @@ export class Gatherer {
   static browser: ChromiumBrowser;
 
   static async setupDriver(options: RunOptions): Promise<Driver> {
+    const { wsEndpoint, playwrightOptions } = options;
     if (Gatherer.browser == null) {
-      const { wsEndpoint, headless, sandbox = false } = options;
       if (wsEndpoint) {
         log(`Gatherer: connecting to WS endpoint: ${wsEndpoint}`);
         Gatherer.browser = await chromium.connect({ wsEndpoint });
       } else {
-        Gatherer.browser = await chromium.launch({
-          headless,
-          chromiumSandbox: sandbox,
-        });
+        Gatherer.browser = await chromium.launch(playwrightOptions);
       }
     }
-    const context = await Gatherer.browser.newContext();
+    const context = await Gatherer.browser.newContext(playwrightOptions);
     const page = await context.newPage();
     const client = await context.newCDPSession(page);
     return { browser: Gatherer.browser, context, page, client };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -43,6 +43,7 @@ import {
   PluginOutput,
   CliArgs,
   HooksArgs,
+  PlaywrightOptions,
 } from '../common_types';
 import { PluginManager } from '../plugins';
 import { PerformanceManager, Metrics } from '../plugins';
@@ -60,8 +61,11 @@ export type RunOptions = Omit<
   | 'reporter'
   | 'richEvents'
   | 'capability'
+  | 'sandbox'
+  | 'headless'
 > & {
   params?: Params;
+  playwrightOptions?: PlaywrightOptions;
   reporter?: CliArgs['reporter'] | Reporter;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,5 @@ export type {
  */
 export type { default as Runner } from './core/runner';
 export type { Reporter, ReporterOptions } from './reporters';
+
+export type { SyntheticsConfig } from './common_types';

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -53,7 +53,7 @@ program
   .option('--inline', 'Run inline journeys from heartbeat')
   .option('-r, --require <modules...>', 'module(s) to preload')
   .option('--no-headless', 'run browser in headful mode')
-  .option('--sandbox', 'enable chromium sandboxing')
+  .option('--sandbox', 'enable chromium sandboxing', false)
   .option('--rich-events', 'Mimics a heartbeat run')
   .option(
     '--capability <features...>',


### PR DESCRIPTION
+ fixes #171 
+ fixes #169 
+ fixes #299 
+ fixes #198 
+ fixes #209 
+ Exposes all playwright `BrowserLaunch` options and `ContextOptions` through `playwrightOptions` using the `synthetics.config.ts` file. 
+ CLI params that exist today like `--headless` and `--sandbox` takes precedence over the playwrightOptions when launch in non headless mode and such. 
+ There is no validation right now as its mostly an escape hatch and will be added in the future to avoid `recordVideo` and `screenshot` capture as synthetics provides them out of the box. 

### Usage
**synthetics.config.ts**
```ts
import type { SyntheticsConfig } from '@elastic/synthetics';

const config: SyntheticsConfig = {
  playwrightOptions: {
    ignoreHTTPSErrors: true,
    extraHTTPHeaders: {
      "foo": "bar"
    },
    ...devices['Galaxy S9+'],
  },
}
export default config;
```