### PR TITLE
BREAKING CHANGE: remove -e in favor of NODE_ENV

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -66,21 +66,29 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
-  it('pass config to journey params', async () => {
-    const cli = new CLIMock([
-      join(FIXTURES_DIR, 'fake.journey.ts'),
-      '--json',
-      '--config',
-      join(FIXTURES_DIR, 'synthetics.config.ts'),
-      '-e',
-      'testing',
-    ]);
-    await cli.waitFor('journey/start');
-    expect(await cli.exitCode).toBe(0);
-    const output = cli.output();
-    expect(JSON.parse(output).payload).toMatchObject({
+  it('pass dynamic config to journey params', async () => {
+    // jest by default sets NODE_ENV to `test`
+    const original = process.env['NODE_ENV'];
+    const output = async () => {
+      const cli = new CLIMock([
+        join(FIXTURES_DIR, 'fake.journey.ts'),
+        '--json',
+        '--config',
+        join(FIXTURES_DIR, 'synthetics.config.ts'),
+      ]);
+      await cli.waitFor('journey/start');
+      expect(await cli.exitCode).toBe(0);
+      return cli.output();
+    };
+
+    expect(JSON.parse(await output()).payload).toMatchObject({
       params: { url: 'non-dev' },
     });
+    process.env['NODE_ENV'] = 'development';
+    expect(JSON.parse(await output()).payload).toMatchObject({
+      params: { url: 'dev' },
+    });
+    process.env['NODE_ENV'] = original;
   });
 
   it('suite params wins over config params', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,10 +158,9 @@ async function prepareSuites(inputs: string[]) {
   }
 
   /**
-   * Use the NODE_ENV variable to control the environment if its not explicity
-   * passed from either CLI or through the API
+   * Use the NODE_ENV variable to control the environment
    */
-  const environment = options.environment || process.env['NODE_ENV'];
+  const environment = process.env['NODE_ENV'] || 'development';
   /**
    * Validate and handle configs
    */

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -119,7 +119,6 @@ export type ScreenshotOptions = 'on' | 'off' | 'only-on-failure';
 export type CliArgs = {
   capability?: Array<string>;
   config?: string;
-  environment?: string;
   outfd?: number;
   headless?: boolean;
   screenshots?: ScreenshotOptions;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -61,6 +61,7 @@ export type RunOptions = Omit<
   | 'richEvents'
   | 'capability'
 > & {
+  environment?: string;
   params?: Params;
   reporter?: CliArgs['reporter'] | Reporter;
 };

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -38,7 +38,6 @@ program
     'configuration path (default: synthetics.config.js)'
   )
   .option('-s, --suite-params <jsonstring>', 'suite variables', '{}')
-  .option('-e, --environment <envname>', 'e.g. production', 'development')
   .option('-j, --json', 'output newline delimited JSON')
   .addOption(
     new Option('--reporter <value>', `output repoter format`).choices(


### PR DESCRIPTION
+ Remove -e flag in favor of NODE_ENV which will behave the same way as the -e flag. 
+ Dynamic config still works the same way and we default to `development` when running suites. 