### PR TITLE
fix: add fallback for terminal w/o utf-8 support

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -123,7 +123,8 @@ describe('CLI', () => {
   it('pass playwright options to runner', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'pwoptions.journey.ts'),
-      '--json',
+      '--reporter',
+      'json',
       '--config',
       join(FIXTURES_DIR, 'synthetics.config.ts'),
     ]);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,7 +41,7 @@ export function indent(lines: string, tab = '   ') {
   return lines.replace(/^/gm, tab);
 }
 
-const NO_UTF8_SUPPORT = process.platform === 'win32' && !process.env.WT_SESSION;
+const NO_UTF8_SUPPORT = process.platform === 'win32' && process.env.WT_SESSION;
 export const symbols = {
   warning: yellow(NO_UTF8_SUPPORT ? '!' : '⚠'),
   skipped: cyan('-'),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,7 +41,11 @@ export function indent(lines: string, tab = '   ') {
   return lines.replace(/^/gm, tab);
 }
 
-const NO_UTF8_SUPPORT = process.platform === 'win32' && process.env.WT_SESSION;
+/**
+ *  Disable unicode symbols for windows, the underlying
+ *  FS stream has a known issue in windows
+ */
+const NO_UTF8_SUPPORT = process.platform === 'win32';
 export const symbols = {
   warning: yellow(NO_UTF8_SUPPORT ? '!' : '⚠'),
   skipped: cyan('-'),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,11 +41,12 @@ export function indent(lines: string, tab = '   ') {
   return lines.replace(/^/gm, tab);
 }
 
+const NO_UTF8_SUPPORT = process.platform === 'win32' && !process.env.WT_SESSION;
 export const symbols = {
-  warning: yellow('⚠'),
+  warning: yellow(NO_UTF8_SUPPORT ? '!' : '⚠'),
   skipped: cyan('-'),
-  succeeded: green('✓'),
-  failed: red('✖'),
+  succeeded: green(NO_UTF8_SUPPORT ? 'ok' : '✓'),
+  failed: red(NO_UTF8_SUPPORT ? 'x' : '✖'),
 };
 
 export function generateUniqueId() {


### PR DESCRIPTION
+ fix #324 