### PR TITLE
add .vscode directory to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ tmp
 # Vim temp files
 *.swp
 
+# VSCode config files
+.vscode
+
 __tests__/e2e/tmp/
 __tests__/e2e/junit.xml
 


### PR DESCRIPTION
While working in VSCode it's nice to be able to customize settings per project, which creates a `.vscode` directory in the root of the repo. It's very convenient to have this file excluded by `.gitignore`