### PR TITLE
feat: deprecate 'suiteparams' infavor of 'params'

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -143,7 +143,7 @@ describe('CLI', () => {
       'json',
       '--config',
       join(FIXTURES_DIR, 'synthetics.config.ts'),
-      '-s',
+      '-p',
       '{"url": "suite-url"}',
     ]);
     await cli.waitFor('journey/start');

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -60,7 +60,7 @@ describe('Run', () => {
       .spyOn(runner, 'run')
       .mockImplementation(() => Promise.resolve({}));
 
-    const runParams: RunOptions = {
+    const options: RunOptions = {
       environment: 'debug',
       params: {
         foo: 'bar',
@@ -74,7 +74,7 @@ describe('Run', () => {
       pauseOnError: true,
       reporter: 'json',
     };
-    await run(runParams);
-    expect(runnerSpy.mock.calls[0][0]).toEqual(runParams);
+    await run(options);
+    expect(runnerSpy.mock.calls[0][0]).toEqual(options);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,7 +165,11 @@ async function prepareSuites(inputs: string[]) {
    * Validate and handle configs
    */
   const config = readConfig(environment, options.config);
-  const params = merge(config.params, JSON.parse(options.suiteParams));
+  const params = merge(
+    config.params,
+    options.suiteParams || {},
+    options.params || {}
+  );
   const playwrightOptions = merge(config.playwrightOptions, {
     headless: options.headless,
     chromiumSandbox: options.sandbox,

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -140,7 +140,11 @@ export type CliArgs = {
   tags?: Array<string>;
   require: Array<string>;
   debug?: boolean;
-  suiteParams?: string;
+  /**
+   * @deprecated use `params` instead
+   */
+  suiteParams?: Params;
+  params?: Params;
   richEvents?: boolean;
 };
 

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -67,7 +67,6 @@ export type RunOptions = Omit<
   | 'headless'
 > & {
   environment?: string;
-  params?: Params;
   playwrightOptions?: PlaywrightOptions;
   reporter?: CliArgs['reporter'] | Reporter;
 };

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -37,7 +37,16 @@ program
     '-c, --config <path>',
     'configuration path (default: synthetics.config.js)'
   )
-  .option('-s, --suite-params <jsonstring>', 'suite variables', '{}')
+  .option(
+    '-s, --suite-params <jsonstring>',
+    'JSON object that gets injected to all journeys',
+    JSON.parse
+  )
+  .option(
+    '-p, --params <jsonstring>',
+    'JSON object that gets injected to all journeys',
+    JSON.parse
+  )
   .addOption(
     new Option('--reporter <value>', `output repoter format`).choices(
       Object.keys(reporters)

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -43,6 +43,7 @@ import {
   TraceOutput,
   StatusValue,
   PerfMetrics,
+  Params,
 } from '../common_types';
 import { Protocol } from 'playwright-chromium/types/protocol';
 import { Metrics } from '../plugins';
@@ -71,7 +72,7 @@ type Payload = {
   url?: string;
   status?: StatusValue | number;
   metrics?: Metrics;
-  params?: Record<string, unknown>;
+  params?: Params;
   type?: OutputType;
   text?: string;
   index?: number;


### PR DESCRIPTION
+ fix #288 
+ Deprecates `-s, --suite-params` in favor of `-p, --params`, will be removed before GA as heartbeat still uses the `--suite-params` flag. 
