### PR TITLE
fix: support --json flag for heartbeat 7.13

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -41,19 +41,21 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(1);
   });
 
-  it('produce json output via --json flag', async () => {
-    const cli = new CLIMock([
-      join(FIXTURES_DIR, 'fake.journey.ts'),
-      '--reporter',
-      'json',
-    ]);
-    await cli.waitFor('fake journey');
-    const output = cli.output();
-    expect(JSON.parse(output).journey).toEqual({
+  it('produce json output  --json and reporter=json flag', async () => {
+    const output = async args => {
+      const cli = new CLIMock([join(FIXTURES_DIR, 'fake.journey.ts'), ...args]);
+      await cli.waitFor('fake journey');
+      expect(await cli.exitCode).toBe(0);
+      return JSON.parse(cli.output());
+    };
+    expect((await output(['--reporter', 'json'])).journey).toEqual({
       id: 'fake journey',
       name: 'fake journey',
     });
-    expect(await cli.exitCode).toBe(0);
+    expect((await output(['--json'])).journey).toEqual({
+      id: 'fake journey',
+      name: 'fake journey',
+    });
   });
 
   it('mimick heartbeat with `--rich-events` flag', async () => {

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -38,6 +38,7 @@ program
     'configuration path (default: synthetics.config.js)'
   )
   .option('-s, --suite-params <jsonstring>', 'suite variables', '{}')
+  .option('-j, --json', 'output newline delimited JSON')
   .addOption(
     new Option('--reporter <value>', `output repoter format`).choices(
       Object.keys(reporters)


### PR DESCRIPTION
+ fix #332 
+ `--json` flag was removed unintentionally in this PR https://github.com/elastic/synthetics/commit/8ec94c9382b8d23a6a451d087b4dd3a498d0e3fd#, so we bring that flag back which is still used by heartbeat 7.13. 
