### PR TITLE
chore: update e2e again to latest snapshot

### DIFF
--- a/__tests__/e2e/scripts/setup.sh
+++ b/__tests__/e2e/scripts/setup.sh
@@ -33,4 +33,4 @@ echo "" # newline
 echo "${bold}Starting elasticsearch , kibana and synthetics docker${normal}"
 echo "" # newline
 
-STACK_VERSION=7.13.1 docker-compose --file docker-compose.yml up --remove-orphans > ${TMP_DIR}/docker-logs.log 2>&1 &
+STACK_VERSION=8.0.0-SNAPSHOT docker-compose --file docker-compose.yml up --remove-orphans > ${TMP_DIR}/docker-logs.log 2>&1 &


### PR DESCRIPTION
+ Revert back to the latest snapshot as we tested the E2E for both 7.13.1 and now latest master. 