### PR TITLE
fix: capture screenshots during device emulation

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -112,6 +112,26 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
+  it('screenshots with device emulation', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'fake.journey.ts'),
+      '--rich-events',
+      '--config',
+      join(FIXTURES_DIR, 'synthetics.config.ts'),
+    ]);
+    await cli.waitFor('journey/end');
+    const data = cli.buffer().map(data => JSON.parse(data));
+    const screenshotRef = data.find(
+      ({ type }) => type === 'step/screenshot_ref'
+    );
+    const screenshotBlocks = data.filter(
+      ({ type }) => type === 'screenshot/block'
+    );
+    expect(screenshotRef).toBeDefined();
+    expect(screenshotBlocks.length).toBe(64);
+    expect(await cli.exitCode).toBe(0);
+  });
+
   it('pass dynamic config to journey params', async () => {
     // jest by default sets NODE_ENV to `test`
     const original = process.env['NODE_ENV'];

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -282,8 +282,8 @@ export async function getScreenshotBlocks(screenshot: Buffer) {
    * optimal for caching in the ES and proved out to be bad, so we stick to 8
    */
   const divisions = 8;
-  const blockWidth = width / divisions;
-  const blockHeight = height / divisions;
+  const blockWidth = Math.floor(width / divisions);
+  const blockHeight = Math.floor(height / divisions);
   const reference: ScreenshotReference = {
     width,
     height,


### PR DESCRIPTION
+ fix #339 
+ When device is emulated via playwright options - https://github.com/elastic/synthetics/blob/87d1b9a8cb6fea360a74cd66a4910551059bf3ec/examples/todos/synthetics.config.ts#L8-L21 the underlying screenshot block calculation is in float instead of integers which causes error in sharp. 
+ Instead of trying to use floating points, we fallback to the nearest using `Math.floor' and discard the extra width and height. 

**NOTE: This is a quick fix and in the future we will modify the block construction algorithm to handle all the dynamic device emulation strategies and construct different number of blocks for greater efficiency.**