### PR TITLE
fix: remove the node version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,9 +69,8 @@
     "ts-jest": "^26.4.4",
     "rimraf": "^3.0.2"
   },
-  "engineStrict": true,
   "engines": {
-    "node": "12.18.4",
+    "node": ">12.0.0",
     "npm": "6"
   }
 }


### PR DESCRIPTION
+ fix errors that will be thrown when using different version of node on the local environment. 

From Kibana
```
info [bazel] error @elastic/synthetics@1.0.0-beta.8: The engine "node" is incompatible with this module. Expected version "12.18.4". Got "14.17.2"
```
+ CI still runs with the version of `12.18.4` as per `.nvmrc` file. 
