### PR TITLE
fix: default to name for journey id

### DIFF
--- a/__tests__/dsl/journey.test.ts
+++ b/__tests__/dsl/journey.test.ts
@@ -27,6 +27,15 @@ import { Journey, Step } from '../../src/dsl';
 
 const noop = () => {};
 describe('Journey', () => {
+  it('add journey details', () => {
+    const name = 'j1';
+    const tags = ['foo', 'bar'];
+    const journey = new Journey({ name, tags }, noop);
+    expect(journey.name).toEqual(name);
+    expect(journey.id).toBe(name);
+    expect(journey.tags).toEqual(tags);
+  });
+
   it('add step to the journey', () => {
     const journey = new Journey({ name: 'j1' }, noop);
     journey.addStep('s1', noop);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -43,7 +43,7 @@ export const journey = (
   options: JourneyOptions | string,
   callback: JourneyCallback
 ) => {
-  log(`register journey: ${options}`);
+  log(`register journey: ${JSON.stringify(options)}`);
   if (typeof options === 'string') {
     options = { name: options, id: options };
   }

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -54,7 +54,7 @@ export class Journey {
 
   constructor(options: JourneyOptions, callback: JourneyCallback) {
     this.name = options.name;
-    this.id = options.id;
+    this.id = options.id || options.name;
     this.tags = options.tags;
     this.callback = callback;
   }


### PR DESCRIPTION
+ Id and Name are always required for the monitor to show correctly in the Uptime UI. 