### PR TITLE
chore: update demo to load content

### DIFF
--- a/examples/e-commerce/demo.journey.js
+++ b/examples/e-commerce/demo.journey.js
@@ -4,15 +4,20 @@ const URL = 'https://elastic-synthetics.vercel.app/';
 
 const navigateToProductDetail = (page, params) => {
   step('visit landing page', async () => {
-    await page.goto(params.url || URL);
-    await page.waitForSelector('.card');
+    await page.goto(params.url || URL, { waitUntil: 'networkidle' });
+    // check to make sure all products are loaded
+    const productImages = await page.$$('.card img');
+    expect(productImages.length).toBe(9);
   });
 
   step('navigate to product detail page', async () => {
     const productImages = await page.$$('.card img');
     const randomCard = Math.floor(Math.random() * productImages.length);
     const product = productImages[randomCard];
-    await Promise.all([page.waitForLoadState('load'), product.click()]);
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle' }),
+      product.click(),
+    ]);
   });
 };
 
@@ -24,9 +29,8 @@ journey(
     step('look for recommendations', async () => {
       const recommendationsNode = await page.$('text=Products you might like');
       expect(recommendationsNode).toBeDefined();
-      // Waits for recommendation cards
-      await page.waitForSelector('.card');
-      const recommendedProducts = await page.$$('.card');
+      // Waits for recommendation product cards
+      const recommendedProducts = await page.$$('.container .card');
       expect(recommendedProducts.length).toBe(4);
     });
   }
@@ -40,30 +44,31 @@ journey({ name: 'Delete cart items', tags: ['cart'] }, ({ page, params }) => {
     await Promise.all([
       page.waitForNavigation({
         url: /cart/,
+        waitUntil: 'networkidle',
       }),
       page.click('text=Add to Cart'),
     ]);
   });
 
   step('empty cart items', async () => {
-    expect(page.url()).toContain('cart');
-    await page.waitForSelector('.container');
     const headline = await page.$('.container h3');
     expect(await headline.textContent()).toContain(
       '1 items in your Shopping Cart'
     );
     await Promise.all([
-      page.waitForNavigation(),
+      page.waitForNavigation({ waitUntil: 'networkidle' }),
       page.click('text=Empty cart'),
     ]);
   });
 
   step('verify empty shopping cart', async () => {
-    await page.click('text=View Cart');
-    expect(page.url()).toContain('cart');
+    await Promise.all([
+      page.waitForNavigation({ url: /cart/, waitUntil: 'networkidle' }),
+      page.click('text=View Cart'),
+    ]);
     await page.waitForSelector('.container');
-    const containerNode = await page.$('.container h3');
-    expect(await containerNode.textContent()).toContain(
+    const headline = await page.$('.container h3');
+    expect(await headline.textContent()).toContain(
       'Your shopping cart is empty'
     );
   });
@@ -79,14 +84,13 @@ journey(
       await Promise.all([
         page.waitForNavigation({
           url: /cart/,
+          waitUntil: 'networkidle',
         }),
         page.click('text=Add to Cart'),
       ]);
     });
 
     step('check cart items and place the order', async () => {
-      expect(page.url()).toContain('cart');
-      await page.waitForSelector('.container');
       const headline = await page.$('.container h3');
       expect(await headline.textContent()).toContain(
         '1 items in your Shopping Cart'
@@ -94,6 +98,7 @@ journey(
       await Promise.all([
         page.waitForNavigation({
           url: /checkout/,
+          waitUntil: 'networkidle',
         }),
         page.click('text=Place your order →'),
       ]);
@@ -101,7 +106,6 @@ journey(
 
     step('verify the order details', async () => {
       expect(page.url()).toContain('checkout');
-      await page.waitForSelector('.container');
       const containerNode = await page.$('.container .row');
       const content = await containerNode.textContent();
       expect(content).toContain('Your order is complete');


### PR DESCRIPTION
+ Updates the e-commerce demo to load all the lazy loaded contents as most of the content is asynchronously loaded and we need to wait until the network requests are complete to keep the screenshots of the step meaningful. 