### PR TITLE
Feature/173 accessibility violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@axe-core/playwright": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.2.2.tgz",
+      "integrity": "sha512-KR3wXC1zNMPxPsK2bo9mgGFic7eewvhco3Y8mPtj4HsACy9Z2jsx+oYjsEbgNH6XsUP5NP9ZfWHtngcyPgwEQw==",
+      "requires": {
+        "axe-core": "^4.2.3",
+        "playwright": "^1.8.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -1255,6 +1264,11 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "axe-core": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.1.tgz",
+      "integrity": "sha512-3WVgVPs/7OnKU3s+lqMtkv3wQlg3WxK1YifmpJSDO0E1aPBrZWlrrTO6cxRqCXLuX2aYgCljqXIQd0VnRidV0g=="
     },
     "babel-jest": {
       "version": "26.6.3",
@@ -5017,6 +5031,39 @@
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
+      }
+    },
+    "playwright": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.12.3.tgz",
+      "integrity": "sha512-eyhHvZV7dMAUltqjQsgJ9CjZM8dznzN1+rcfCI6W6lfQ7IlPvTFGLuKOCcI4ETbjfbxqaS5FKIkb1WDDzq2Nww==",
+      "requires": {
+        "commander": "^6.1.0",
+        "debug": "^4.1.1",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "jpeg-js": "^0.4.2",
+        "mime": "^2.4.6",
+        "pngjs": "^5.0.0",
+        "progress": "^2.0.3",
+        "proper-lockfile": "^4.1.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "stack-utils": "^2.0.3",
+        "ws": "^7.4.6",
+        "yazl": "^2.5.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        },
+        "ws": {
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+          "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+        }
       }
     },
     "playwright-chromium": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@axe-core/playwright": "^4.2.2",
     "commander": "^7.0.0",
     "deepmerge": "^4.2.2",
     "expect": "^27.0.2",

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -125,6 +125,7 @@ export type CliArgs = {
   screenshots?: ScreenshotOptions;
   ssblocks?: boolean;
   metrics?: boolean;
+  accessibility?: boolean;
   filmstrips?: boolean;
   trace?: boolean;
   dryRun?: boolean;

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -70,11 +70,12 @@ export class Gatherer {
    */
   static async beginRecording(driver: Driver, options: RunOptions) {
     log('Gatherer: started recording');
-    const { filmstrips, trace, network, metrics } = options;
+    const { filmstrips, trace, network, metrics, accessibility } = options;
     const pluginManager = new PluginManager(driver);
     const plugins = [pluginManager.start('browserconsole')];
     network && plugins.push(pluginManager.start('network'));
     metrics && plugins.push(pluginManager.start('performance'));
+    accessibility && plugins.push(pluginManager.start('accessibility'));
     if (filmstrips || trace) {
       plugins.push(pluginManager.start('trace', { filmstrips, trace }));
     }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -48,7 +48,7 @@ import {
   PlaywrightOptions,
 } from '../common_types';
 import { PluginManager } from '../plugins';
-import { PerformanceManager, Metrics } from '../plugins';
+import { PerformanceManager, Metrics, Accessibility, AccessibilityReport } from '../plugins';
 import { Driver, Gatherer } from './gatherer';
 import { log } from './logger';
 
@@ -87,6 +87,7 @@ type StepResult = {
   url?: string;
   metrics?: Metrics;
   error?: Error;
+  accessibility?: AccessibilityReport;
 };
 
 type JourneyResult = {
@@ -219,7 +220,7 @@ export default class Runner extends EventEmitter {
       status: 'succeeded',
     };
     log(`Runner: start step (${step.name})`);
-    const { metrics, screenshots } = options;
+    const { metrics, screenshots, accessibility } = options;
     const { driver, pluginManager } = context;
     /**
      * URL needs to be the first navigation request of any step
@@ -238,6 +239,9 @@ export default class Runner extends EventEmitter {
       await step.callback();
       if (metrics) {
         data.metrics = await pluginManager.get(PerformanceManager).getMetrics();
+      }
+      if (accessibility) {
+        data.accessibility = await pluginManager.get(Accessibility).getViolations();
       }
     } catch (error) {
       data.status = 'failed';

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -121,6 +121,7 @@ if (options.capability) {
     'filmstrips',
     'metrics',
     'ssblocks',
+    'accessibility'
   ];
   /**
    * trace - record chrome trace events(LCP, FCP, CLS, etc.) for all journeys

--- a/src/plugins/accessibility.ts
+++ b/src/plugins/accessibility.ts
@@ -1,0 +1,89 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+import type { NodeResult, ImpactValue } from 'axe-core';
+import AxeBuilder from '@axe-core/playwright';
+
+import { Page } from 'playwright-chromium';
+import { Step } from '../dsl';
+import { getTimestamp } from '../helpers';
+
+interface AccessibilityViolationMetadata {
+  id: string,
+  tags: string[],
+  help: string;
+  helpUrl: string;
+}
+
+type AccessibilityViolation = AccessibilityViolationMetadata & {
+  html: string;
+  impact: ImpactValue;
+  failureSummary: string;
+  timestamp: number;
+  step: Pick<Step, 'name' | 'index'>;
+}
+
+export type AccessibilityReport = {
+  violations: AccessibilityViolation[]
+}
+
+export class Accessibility {
+  _currentStep: Partial<Step> = null;
+
+  constructor(private page: Page) {}
+
+  private accessibilityNodeProcessor(nodes: NodeResult[], metadata: AccessibilityViolationMetadata): AccessibilityViolation[] {
+    const { name, index } = this._currentStep;
+
+    return nodes.map(({ html, impact, failureSummary }) => ({
+      ...metadata,
+      timestamp: getTimestamp(),
+      html, 
+      impact,
+      failureSummary,
+      step: { name, index },
+    }));
+  }
+
+  public async getViolations(): Promise<AccessibilityReport> {
+    if (!this._currentStep) {
+      return;
+    }
+    const { violations: axeViolations } = await new AxeBuilder({ page: this.page as ConstructorParameters<typeof AxeBuilder>[0]['page'] }).analyze();
+
+    const violations = axeViolations.reduce((prevViolations, { id, tags, help, helpUrl, nodes }) => {
+      return [
+        ...prevViolations,
+        ...this.accessibilityNodeProcessor(
+          nodes, 
+          {
+            id, tags, help, helpUrl
+          }
+        )
+      ];
+    }, []);
+
+    return { violations };
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -28,3 +28,4 @@ export * from './network';
 export * from './performance';
 export * from './tracing';
 export * from './browser-console';
+export * from './accessibility';

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -26,6 +26,7 @@
 import { PluginOutput } from '../common_types';
 import {
   BrowserConsole,
+  Accessibility,
   NetworkManager,
   PerformanceManager,
   Tracing,
@@ -34,8 +35,8 @@ import {
 import { Driver } from '../core/gatherer';
 import { Step } from '../dsl';
 
-type PluginType = 'network' | 'trace' | 'performance' | 'browserconsole';
-type Plugin = NetworkManager | Tracing | PerformanceManager | BrowserConsole;
+type PluginType = 'network' | 'trace' | 'performance' | 'browserconsole' | 'accessibility';
+type Plugin = NetworkManager | Tracing | PerformanceManager | BrowserConsole | Accessibility;
 type PluginOptions = TraceOptions;
 
 export class PluginManager {
@@ -62,6 +63,9 @@ export class PluginManager {
         instance = new BrowserConsole(this.driver.page);
         instance.start();
         break;
+      case 'accessibility':
+        instance = new Accessibility(this.driver.page);
+        break;
     }
 
     this.plugins.set(instance.constructor.name, instance);
@@ -74,6 +78,7 @@ export class PluginManager {
 
   onStep(step: Step) {
     this.get(BrowserConsole) && (this.get(BrowserConsole)._currentStep = step);
+    this.get(Accessibility) && (this.get(Accessibility)._currentStep = step);
     this.get(NetworkManager) && (this.get(NetworkManager)._currentStep = step);
   }
 


### PR DESCRIPTION
Relates to #173 

This PR collects accessibility violations on each synthetics test step using [axe-core/playwright](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright)

This PR was done as part of an exploration during spacetime.

**Why Axe?**
Axe is a leading provider of accessibility testing software, and currently powers Google's Lighthouse accessibility tool. Their new `axe-core/playwright` provides dedicated support for playwright, and allows for user configuration of custom elements or accessibility rule types to ignore or focus on. 

Example step violation
```
{
      id: 'nested-interactive',
      tags: ['nested-interactive'],
      help: 'Ensure interactive controls are not nested',
      helpUrl: 'https://dequeuniversity.com/rules/axe/4.3/nested-interactive?application=playwright',
      timestamp: 1626698831479267.5,
      html: '<div data-testid="splashScreen" class="_1Kl9L _1v5hd" title="Play Video" aria-label="Play Video" role="button" tabindex="-1" style="background-color: transparent;">',
      impact: 'serious',
      failureSummary: 'Fix any of the following:\n  Element has focusable descendants',
      step: { name: 'test step', index: 1 }
}
```

Accessibility violations are currently collected on step to account for potential changes in the DOM or reloads per step. However, this may produce a large number of repeated violations. We may want to consider running accessibility tests once per journey instead, but that may result in missing additional violations on page or DOM changes.

This PR does not currently include tests, or the indexing of violation documents. This is currently an experimental PR to help me get familiar with synthetics, but I'd love to see an accessibility feature set for synthetics driven through to completion. 