### PR TITLE
fix: capture correct url for navigations

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -230,9 +230,9 @@ export default class Runner extends EventEmitter {
       if (!data.url && req.isNavigationRequest()) {
         data.url = req.url();
       }
-      driver.page.off('request', captureUrl);
+      driver.context.off('request', captureUrl);
     };
-    driver.page.on('request', captureUrl);
+    driver.context.on('request', captureUrl);
     try {
       pluginManager.onStep(step);
       await step.callback();


### PR DESCRIPTION
+ When there are iframes and new windows that exists as part of the page lifecycle, we capture the wrong page URL as we are using the page object from previous session. 
+ part of #253 