### PR TITLE
fix: record correct screenshots for popups

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -560,4 +560,37 @@ describe('runner', () => {
       },
     ]);
   });
+
+  it('run - differentiate screenshots for popups', async () => {
+    const j1 = journey('j1', async ({ page, context }) => {
+      step('visit test page', async () => {
+        await page.goto(server.TEST_PAGE);
+        await page.setContent(
+          '<a target=_blank rel=noopener href="/popup.html">popup</a>'
+        );
+      });
+      step('click popup', async () => {
+        const [page1] = await Promise.all([
+          context.waitForEvent('page'),
+          page.click('a'),
+        ]);
+        await page1.waitForLoadState();
+      });
+    });
+    runner.addJourney(j1);
+
+    await runner.run({
+      wsEndpoint,
+      reporter: 'json',
+      screenshots: 'on',
+      outfd: fs.openSync(dest, 'w'),
+    });
+
+    const screenshotDocs = readAndCloseStreamJson().filter(
+      ({ type }) => type === 'step/screenshot'
+    );
+    expect(screenshotDocs.length).toEqual(2);
+    const blobs = screenshotDocs.map(data => data.blob);
+    expect(blobs[0]).not.toEqual(blobs[1]);
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,9 +51,16 @@ if (process.env.DEBUG === namespace || Boolean(options.debug)) {
 }
 
 const loadInlineScript = source => {
-  const scriptFn = new Function('step', 'page', 'browser', 'params', source);
-  journey('inline', async ({ page, browser, params }) => {
-    scriptFn.apply(null, [step, page, browser, params]);
+  const scriptFn = new Function(
+    'step',
+    'page',
+    'context',
+    'browser',
+    'params',
+    source
+  );
+  journey('inline', async ({ page, context, browser, params }) => {
+    scriptFn.apply(null, [step, page, context, browser, params]);
   });
 };
 

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -233,6 +233,13 @@ export default class Runner extends EventEmitter {
       driver.page.off('request', captureUrl);
     };
     driver.page.on('request', captureUrl);
+    /**
+     * Capture screenshot for the newly created pages
+     * via popup or new windows/tabs
+     */
+    let page = driver.page;
+    const capturePage = newPage => (page = newPage);
+    driver.context.on('page', capturePage);
     try {
       pluginManager.onStep(step);
       await step.callback();
@@ -243,11 +250,12 @@ export default class Runner extends EventEmitter {
       data.status = 'failed';
       data.error = error;
     } finally {
-      data.url ??= driver.page.url();
+      data.url ??= page.url();
       if (screenshots && screenshots !== 'off') {
-        await this.captureScreenshot(driver.page, step);
+        await this.captureScreenshot(page, step);
       }
     }
+    driver.context.off('page', capturePage);
     log(`Runner: end step (${step.name})`);
     return data;
   }


### PR DESCRIPTION
+ part of #253 
+ captures proper screenshots for new navigations done via popups and new tabs.
+ Listens for `page` events in each step and captures the screenshot of last navigation that happened in the step. 

### Tested using inline script for popups and navigation
```js
 step('Popup Landing Page', async () => {
  await page.goto(`http://localhost:8080/popup1.html`);
  await page.waitForSelector('text=Test popup page 1');
});
step('Open Popup', async () => {
  const [popup] = await Promise.all([
    page.waitForEvent('popup'),
    page.click('#linkWithPopup'),
  ]);
  // Test 2 - new tab (not new popup window)
  await Promise.all([
    context.waitForEvent('page'),
    page.click('#linkWithPopupNoNewWindow'),
  ]);
});

```

### Screenshots

<img width="689" alt="Screen Shot 2021-07-21 at 17 00 12" src="https://user-images.githubusercontent.com/3902525/126575596-fb24c1c9-f8a9-4d6f-90f6-62fed19037c1.png">
<img width="623" alt="Screen Shot 2021-07-21 at 17 00 02" src="https://user-images.githubusercontent.com/3902525/126575599-7d53d7c0-34eb-4348-8465-d31b37c3d2e7.png">


