### PR TITLE
BREAKING CHANGES: drop support for heartbeat 7.13

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -50,7 +50,7 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
-  it('produce json output  --json and reporter=json flag', async () => {
+  it('produce json with reporter=json flag', async () => {
     const output = async args => {
       const cli = new CLIMock([join(FIXTURES_DIR, 'fake.journey.ts'), ...args]);
       await cli.waitFor('fake journey');
@@ -61,47 +61,33 @@ describe('CLI', () => {
       id: 'fake journey',
       name: 'fake journey',
     });
-    expect((await output(['--json'])).journey).toEqual({
-      id: 'fake journey',
-      name: 'fake journey',
-    });
-  });
-
-  it('mimick 7.13 heartbeat wiwth all flags', async () => {
-    const cli = new CLIMock([
-      join(FIXTURES_DIR, 'example.journey.ts'),
-      '--network',
-      '--json',
-      '--screenshots',
-      '--suite-params',
-      '{}',
-      '--outfd',
-      process.stdout.fd.toString(),
-    ]);
-    await cli.waitFor('journey/network_info');
-    expect(cli.output()).toBeDefined();
-    expect(await cli.exitCode).toBe(0);
   });
 
   it('mimick new heartbeat with `--rich-events` flag', async () => {
     const cli = new CLIMock([
-      join(FIXTURES_DIR, 'fake.journey.ts'),
+      join(FIXTURES_DIR, 'example.journey.ts'),
       join(FIXTURES_DIR, 'error.journey.ts'),
       '--rich-events',
     ]);
     await cli.waitFor('journey/end');
+
     const screenshotRef = cli
       .buffer()
       .map(data => JSON.parse(data))
       .find(({ type }) => type === 'step/screenshot_ref');
-
     expect(screenshotRef).toMatchObject({
       journey: {
-        id: 'fake journey',
-        name: 'fake journey',
+        id: 'example journey',
+        name: 'example journey',
       },
       root_fields: expect.any(Object),
     });
+
+    const networkData = cli
+      .buffer()
+      .map(data => JSON.parse(data))
+      .find(({ type }) => type === 'journey/network_info');
+    expect(networkData).toBeDefined();
 
     expect(await cli.exitCode).toBe(0);
   }, 30000);
@@ -184,7 +170,7 @@ describe('CLI', () => {
     });
   });
 
-  it('suite params wins over config params', async () => {
+  it('params wins over config params', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'fake.journey.ts'),
       '--reporter',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,24 +172,14 @@ async function prepareSuites(inputs: string[]) {
    * Validate and handle configs
    */
   const config = readConfig(environment, options.config);
-  const params = merge(
-    config.params,
-    options.suiteParams || {},
-    options.params || {}
-  );
+  const params = merge(config.params, options.params || {});
   const playwrightOptions = merge(config.playwrightOptions, {
     headless: options.headless,
     chromiumSandbox: options.sandbox,
   });
-  /**
-   * use JSON reporter if json flag is enabled
-   */
-  const reporter = options.json ? 'json' : options.reporter;
-
   const results = await run({
     params: Object.freeze(params),
     environment,
-    reporter,
     playwrightOptions,
     ...options,
   });

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -134,17 +134,12 @@ export type CliArgs = {
   reporter?: Reporters;
   wsEndpoint?: string;
   sandbox?: boolean;
-  json?: boolean;
   pattern?: string;
   inline: boolean;
   match?: string;
   tags?: Array<string>;
   require: Array<string>;
   debug?: boolean;
-  /**
-   * @deprecated use `params` instead
-   */
-  suiteParams?: Params;
   params?: Params;
   richEvents?: boolean;
 };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -55,11 +55,9 @@ import { log } from './logger';
 export type RunOptions = Omit<
   CliArgs,
   | 'debug'
-  | 'json'
   | 'pattern'
   | 'inline'
   | 'require'
-  | 'suiteParams'
   | 'reporter'
   | 'richEvents'
   | 'capability'

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -38,16 +38,10 @@ program
     'configuration path (default: synthetics.config.js)'
   )
   .option(
-    '-s, --suite-params <jsonstring>',
-    'JSON object that gets injected to all journeys',
-    JSON.parse
-  )
-  .option(
     '-p, --params <jsonstring>',
     'JSON object that gets injected to all journeys',
     JSON.parse
   )
-  .option('-j, --json', 'output newline delimited JSON')
   .addOption(
     new Option('--reporter <value>', `output repoter format`).choices(
       Object.keys(reporters)
@@ -72,7 +66,6 @@ program
       .choices(['on', 'off', 'only-on-failure'])
       .default('on')
   )
-  .option('--network', 'capture network information for all journeys')
   .option(
     '--dry-run',
     "don't actually execute anything, report only registered journeys"


### PR DESCRIPTION
+ fix #335 
+ Remove `--json`, `--network`, '--suite-params'. These flags are not used by HB and we have alternates in place like `--reporter=json`, `--rich-events`, `--params`. 