### PR TITLE
Add --quiet-exit-code and make it default --rich-events behavior

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -41,15 +41,13 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(1);
   });
 
-  describe('with --quiet-exit-code', () => {
-    it('runs the suites, exiting with 0', async () => {
-      const cli = new CLIMock([
-        join(FIXTURES_DIR, 'error.journey.ts'),
-        '--quiet-exit-code',
-      ]);
-      await cli.waitFor('boom');
-      expect(await cli.exitCode).toBe(0);
-    });
+  it('runs the suites with --quiet-exit-code, always exiting with 0', async () => {
+    const cli = new CLIMock([
+      join(FIXTURES_DIR, 'error.journey.ts'),
+      '--quiet-exit-code',
+    ]);
+    await cli.waitFor('boom');
+    expect(await cli.exitCode).toBe(0);
   });
 
   it('produce json output  --json and reporter=json flag', async () => {
@@ -106,7 +104,7 @@ describe('CLI', () => {
     });
 
     expect(await cli.exitCode).toBe(0);
-  });
+  }, 30);
 
   it('override screenshots with `--rich-events` flag', async () => {
     const cli = new CLIMock([

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -104,7 +104,7 @@ describe('CLI', () => {
     });
 
     expect(await cli.exitCode).toBe(0);
-  }, 30);
+  }, 30000);
 
   it('override screenshots with `--rich-events` flag', async () => {
     const cli = new CLIMock([

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -41,6 +41,17 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(1);
   });
 
+  describe('with --quiet-exit-code', () => {
+    it('runs the suites, exiting with 0', async () => {
+      const cli = new CLIMock([
+        join(FIXTURES_DIR, 'error.journey.ts'),
+        '--quiet-exit-code',
+      ]);
+      await cli.waitFor('boom');
+      expect(await cli.exitCode).toBe(0);
+    });
+  });
+
   it('produce json output  --json and reporter=json flag', async () => {
     const output = async args => {
       const cli = new CLIMock([join(FIXTURES_DIR, 'fake.journey.ts'), ...args]);
@@ -77,6 +88,7 @@ describe('CLI', () => {
   it('mimick new heartbeat with `--rich-events` flag', async () => {
     const cli = new CLIMock([
       join(FIXTURES_DIR, 'fake.journey.ts'),
+      join(FIXTURES_DIR, 'error.journey.ts'),
       '--rich-events',
     ]);
     await cli.waitFor('journey/end');

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -72,6 +72,7 @@ describe('Run', () => {
       match: 'check*',
       network: true,
       pauseOnError: true,
+      quietExitCode: true,
       reporter: 'json',
     };
     await run(options);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -194,12 +194,14 @@ async function prepareSuites(inputs: string[]) {
     ...options,
   });
 
-  /**
-   * Exit with error status if any journey fails
-   */
-  for (const result of Object.values(results)) {
-    if (result.status === 'failed') {
-      process.exit(1);
+  if (!options.quietExitCode) {
+    /**
+     * Exit with error status if any journey fails
+     */
+    for (const result of Object.values(results)) {
+      if (result.status === 'failed') {
+        process.exit(1);
+      }
     }
   }
 })().catch(e => {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -130,6 +130,7 @@ export type CliArgs = {
   dryRun?: boolean;
   network?: boolean;
   pauseOnError?: boolean;
+  quietExitCode?: boolean;
   reporter?: Reporters;
   wsEndpoint?: string;
   sandbox?: boolean;

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -98,6 +98,10 @@ program
     '--pause-on-error',
     'pause on error until a keypress is made in the console. Useful during development'
   )
+  .option(
+    '--quiet-exit-code',
+    'always return 0 as an exit code status, regardless of test pass / fail. Only return > 0 exit codes on internal errors where the suite could not be run'
+  )
   .version(version)
   .description('Run synthetic tests');
 
@@ -112,6 +116,7 @@ if (options.richEvents) {
   options.reporter = options.reporter ?? 'json';
   options.ssblocks = true;
   options.network = true;
+  options.quietExitCode = true;
 }
 
 if (options.capability) {


### PR DESCRIPTION
Fixes https://github.com/elastic/synthetics/issues/356

Accomplishes the fix by making --rich-events always exit with a code of 0, even if tests fail