### PR TITLE
Re-add support for suite params

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -53,6 +53,22 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
+  // TODO: Delete this once --suite-params is removed
+  it('runs with legacy suite-params', async () => {
+    const cli = new CLIMock()
+      .stdin(
+        `step('check h2', async () => {
+        await page.goto(params.url, { timeout: 1500 });
+        const sel = await page.waitForSelector('h2.synthetics', { timeout: 1500 });
+        expect(await sel.textContent()).toBe("Synthetics test page");
+      })`
+      )
+      .args(['--inline', '--suite-params', JSON.stringify(serverParams)])
+      .run();
+    await cli.waitFor('Journey: inline');
+    expect(await cli.exitCode).toBe(0);
+  });
+
   it('run suites and exit with 0', async () => {
     const cli = new CLIMock()
       .args([join(FIXTURES_DIR, 'fake.journey.ts')])

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -174,7 +174,11 @@ async function prepareSuites(inputs: string[]) {
    * Validate and handle configs
    */
   const config = readConfig(environment, options.config);
-  const params = merge(config.params, options.params || {});
+  const params = merge(
+    config.params,
+    options.suiteParams || {},
+    options.params || {}
+  );
   const playwrightOptions = merge(config.playwrightOptions, {
     headless: options.headless,
     chromiumSandbox: options.sandbox,

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -157,6 +157,9 @@ export type CliArgs = {
   debug?: boolean;
   ignoreHttpsErrors?: boolean;
   params?: Params;
+  /**
+   * @deprecated use params instead
+   */
   suiteParams?: Params;
   richEvents?: boolean;
 };

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -157,6 +157,7 @@ export type CliArgs = {
   debug?: boolean;
   ignoreHttpsErrors?: boolean;
   params?: Params;
+  suiteParams?: Params;
   richEvents?: boolean;
 };
 

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -38,8 +38,13 @@ program
     'configuration path (default: synthetics.config.js)'
   )
   .option(
-    '-p, --params <jsonstring>',
+    '-p, --params <jsonstring>, --suite-params <jsonstring>',
     'JSON object that gets injected to all journeys',
+    JSON.parse
+  )
+  .option(
+    '-s, --suite-params <jsonstring>, --suite-params <jsonstring>',
+    'DEPRECATED: Use --params instead',
     JSON.parse
   )
   .addOption(
@@ -142,6 +147,10 @@ if (options.capability) {
       );
     }
   }
+}
+
+if (options.suiteParams && !options.params) {
+  options.params = options.suiteParams;
 }
 
 export { options };

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -38,7 +38,7 @@ program
     'configuration path (default: synthetics.config.js)'
   )
   .option(
-    '-p, --params <jsonstring>, --suite-params <jsonstring>',
+    '-p, --params <jsonstring>',
     'JSON object that gets injected to all journeys',
     JSON.parse
   )

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -149,9 +149,5 @@ if (options.capability) {
   }
 }
 
-if (options.suiteParams && !options.params) {
-  options.params = options.suiteParams;
-}
-
 export { options };
 export default command;

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -43,7 +43,7 @@ program
     JSON.parse
   )
   .option(
-    '-s, --suite-params <jsonstring>, --suite-params <jsonstring>',
+    '-s, --suite-params <jsonstring>',
     'DEPRECATED: Use --params instead',
     JSON.parse
   )


### PR DESCRIPTION
Heartbeat 7.15/7.x did not get https://github.com/elastic/beats/pull/26674 backported to them. Since they will be released soon we need to work on re-supporting the `--suite-params` flag and do a new release once this is merged.