### PR TITLE
Append Elastic/synthetics to UA string

### DIFF
--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -28,13 +28,11 @@ import { PluginManager } from '../../src/plugins';
 import { wsEndpoint } from '../utils/test-config';
 import { devices } from 'playwright-chromium';
 import { Server } from '../utils/server';
-import exp = require('constants');
 
 jest.mock('../../src/plugins/network');
 
 describe('Gatherer', () => {
   let server: Server;
-
   beforeAll(async () => {
     server = await Server.create();
   });
@@ -67,11 +65,9 @@ describe('Gatherer', () => {
   describe('Append Elastic/Synthetics to UA', () => {
     it('works on a single page', async () => {
       const driver = await Gatherer.setupDriver({ wsEndpoint });
-
       expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
         ' Elastic/Synthetics'
       );
-
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });
@@ -81,11 +77,9 @@ describe('Gatherer', () => {
         wsEndpoint,
         playwrightOptions: { ...devices['Galaxy S9+'] },
       });
-
       expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
         ' Elastic/Synthetics'
       );
-
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });
@@ -95,26 +89,20 @@ describe('Gatherer', () => {
         wsEndpoint,
         playwrightOptions: { ...devices['Galaxy S9+'] },
       });
-
       const { page, context } = driver;
-
       await page.goto(server.TEST_PAGE);
       await page.setContent(
         '<a target=_blank rel=noopener href="/popup.html">popup</a>'
       );
-
       const [page1] = await Promise.all([
         context.waitForEvent('page'),
         page.click('a'),
       ]);
       await page1.waitForLoadState();
-
       expect(await page1.evaluate(() => navigator.userAgent)).toContain(
         ' Elastic/Synthetics'
       );
-
       expect(await page1.textContent('body')).toEqual('Not found');
-
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });
@@ -124,21 +112,16 @@ describe('Gatherer', () => {
         wsEndpoint,
         playwrightOptions: { ...devices['Galaxy S9+'] },
       });
-
       const { page } = driver;
-
       await page.goto(server.TEST_PAGE);
       await page.setContent(
         '<iframe id="frameID" width="200" height="200">iframe</iframe>'
       );
-
       const handle = await page.$('#frameID');
       const contentFrame = await handle.contentFrame();
-
       expect(await contentFrame.evaluate(() => navigator.userAgent)).toContain(
         ' Elastic/Synthetics'
       );
-
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -58,8 +58,8 @@ describe('Gatherer', () => {
   it('append Elastic/Synthetics as part of userAgent', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
 
-    expect(await driver.page.evaluate(() => navigator.userAgent)).toBe(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/94.0.4595.0 Safari/537.36 Elastic/Synthetics'
+    expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
+      ' Elastic/Synthetics'
     );
 
     await Gatherer.dispose(driver);

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -115,24 +115,5 @@ describe('Gatherer', () => {
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });
-
-    it('works with iframe content', async () => {
-      const driver = await Gatherer.setupDriver({
-        wsEndpoint,
-        playwrightOptions: { ...devices['Galaxy S9+'] },
-      });
-      const { page } = driver;
-      await page.goto(server.TEST_PAGE);
-      await page.setContent(
-        '<iframe id="frameID" width="200" height="200">iframe</iframe>'
-      );
-      const handle = await page.$('#frameID');
-      const contentFrame = await handle.contentFrame();
-      expect(await contentFrame.evaluate(() => navigator.userAgent)).toContain(
-        ' Elastic/Synthetics'
-      );
-      await Gatherer.dispose(driver);
-      await Gatherer.stop();
-    });
   });
 });

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -26,6 +26,7 @@
 import { Gatherer } from '../../src/core/gatherer';
 import { PluginManager } from '../../src/plugins';
 import { wsEndpoint } from '../utils/test-config';
+import { devices } from 'playwright-chromium';
 
 jest.mock('../../src/plugins/network');
 
@@ -57,6 +58,20 @@ describe('Gatherer', () => {
 
   it('append Elastic/Synthetics as part of userAgent', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
+
+    expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
+      ' Elastic/Synthetics'
+    );
+
+    await Gatherer.dispose(driver);
+    await Gatherer.stop();
+  });
+
+  it('append Elastic/Synthetics as part of userAgent with device emulation', async () => {
+    const driver = await Gatherer.setupDriver({
+      wsEndpoint,
+      playwrightOptions: { ...devices['Galaxy S9+'] },
+    });
 
     expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
       ' Elastic/Synthetics'

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -37,6 +37,10 @@ describe('Gatherer', () => {
     server = await Server.create();
   });
 
+  afterAll(async () => {
+    await server.close();
+  });
+
   it('boot and close browser', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     expect(typeof driver.page.goto).toBe('function');
@@ -62,7 +66,7 @@ describe('Gatherer', () => {
     await Gatherer.stop();
   });
 
-  describe('Append Elastic/Synthetics to UA', () => {
+  describe('Elastic UA identifier', () => {
     it('works on a single page', async () => {
       const driver = await Gatherer.setupDriver({ wsEndpoint });
       expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
@@ -91,6 +95,11 @@ describe('Gatherer', () => {
       });
       const { page, context } = driver;
       await page.goto(server.TEST_PAGE);
+      context.on('request', request => {
+        expect(request.headers()['user-agent']).toContain(
+          ' Elastic/Synthetics'
+        );
+      });
       await page.setContent(
         '<a target=_blank rel=noopener href="/popup.html">popup</a>'
       );

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -54,4 +54,15 @@ describe('Gatherer', () => {
     expect(network.start).toHaveBeenCalled();
     await Gatherer.stop();
   });
+
+  it('append Elastic/Synthetics as part of userAgent', async () => {
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
+
+    expect(await driver.page.evaluate(() => navigator.userAgent)).toBe(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/94.0.4595.0 Safari/537.36 Elastic/Synthetics'
+    );
+
+    await Gatherer.dispose(driver);
+    await Gatherer.stop();
+  });
 });

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -27,10 +27,18 @@ import { Gatherer } from '../../src/core/gatherer';
 import { PluginManager } from '../../src/plugins';
 import { wsEndpoint } from '../utils/test-config';
 import { devices } from 'playwright-chromium';
+import { Server } from '../utils/server';
+import exp = require('constants');
 
 jest.mock('../../src/plugins/network');
 
 describe('Gatherer', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    server = await Server.create();
+  });
+
   it('boot and close browser', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     expect(typeof driver.page.goto).toBe('function');
@@ -56,28 +64,83 @@ describe('Gatherer', () => {
     await Gatherer.stop();
   });
 
-  it('append Elastic/Synthetics as part of userAgent', async () => {
-    const driver = await Gatherer.setupDriver({ wsEndpoint });
+  describe('Append Elastic/Synthetics to UA', () => {
+    it('works on a single page', async () => {
+      const driver = await Gatherer.setupDriver({ wsEndpoint });
 
-    expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
-      ' Elastic/Synthetics'
-    );
+      expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
+        ' Elastic/Synthetics'
+      );
 
-    await Gatherer.dispose(driver);
-    await Gatherer.stop();
-  });
-
-  it('append Elastic/Synthetics as part of userAgent with device emulation', async () => {
-    const driver = await Gatherer.setupDriver({
-      wsEndpoint,
-      playwrightOptions: { ...devices['Galaxy S9+'] },
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
     });
 
-    expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
-      ' Elastic/Synthetics'
-    );
+    it('works with device emulation', async () => {
+      const driver = await Gatherer.setupDriver({
+        wsEndpoint,
+        playwrightOptions: { ...devices['Galaxy S9+'] },
+      });
 
-    await Gatherer.dispose(driver);
-    await Gatherer.stop();
+      expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
+        ' Elastic/Synthetics'
+      );
+
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
+    });
+
+    it('works with popup window', async () => {
+      const driver = await Gatherer.setupDriver({
+        wsEndpoint,
+        playwrightOptions: { ...devices['Galaxy S9+'] },
+      });
+
+      const { page, context } = driver;
+
+      await page.goto(server.TEST_PAGE);
+      await page.setContent(
+        '<a target=_blank rel=noopener href="/popup.html">popup</a>'
+      );
+
+      const [page1] = await Promise.all([
+        context.waitForEvent('page'),
+        page.click('a'),
+      ]);
+      await page1.waitForLoadState();
+
+      expect(await page1.evaluate(() => navigator.userAgent)).toContain(
+        ' Elastic/Synthetics'
+      );
+
+      expect(await page1.textContent('body')).toEqual('Not found');
+
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
+    });
+
+    it('works with iframe content', async () => {
+      const driver = await Gatherer.setupDriver({
+        wsEndpoint,
+        playwrightOptions: { ...devices['Galaxy S9+'] },
+      });
+
+      const { page } = driver;
+
+      await page.goto(server.TEST_PAGE);
+      await page.setContent(
+        '<iframe id="frameID" width="200" height="200">iframe</iframe>'
+      );
+
+      const handle = await page.$('#frameID');
+      const contentFrame = await handle.contentFrame();
+
+      expect(await contentFrame.evaluate(() => navigator.userAgent)).toContain(
+        ' Elastic/Synthetics'
+      );
+
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
+    });
   });
 });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -314,7 +314,7 @@ describe('runner', () => {
     });
   });
 
-  it('run api - match journey name explict', async () => {
+  it('run api - match journey name explicit', async () => {
     runner.addJourney(new Journey({ name: 'j1' }, noop));
     runner.addJourney(new Journey({ name: 'j2' }, noop));
     expect(

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -27,9 +27,7 @@ import { chromium, ChromiumBrowser } from 'playwright-chromium';
 import { PluginManager } from '../plugins';
 import { RunOptions } from './runner';
 import { log } from './logger';
-import { Driver, PlaywrightOptions } from '../common_types';
-import { Protocol } from 'playwright-chromium/types/protocol';
-import Browser = Protocol.Browser;
+import { Driver } from '../common_types';
 
 /**
  * Purpose of the Gatherer is to set up the necessary browser driver
@@ -48,23 +46,18 @@ export class Gatherer {
         Gatherer.browser = await chromium.launch(playwrightOptions);
       }
     }
-
     const context = await Gatherer.browser.newContext({
       ...playwrightOptions,
       userAgent: await Gatherer.getUserAgent(),
     });
-
     const page = await context.newPage();
-
     const client = await context.newCDPSession(page);
-
     return { browser: Gatherer.browser, context, page, client };
   }
 
   static async getUserAgent() {
     const session = await Gatherer.browser.newBrowserCDPSession();
     const { userAgent } = await session.send('Browser.getVersion');
-
     return userAgent + ' Elastic/Synthetics';
   }
 

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -27,7 +27,7 @@ import { chromium, ChromiumBrowser } from 'playwright-chromium';
 import { PluginManager } from '../plugins';
 import { RunOptions } from './runner';
 import { log } from './logger';
-import { Driver } from '../common_types';
+import { Driver, PlaywrightOptions } from '../common_types';
 
 /**
  * Purpose of the Gatherer is to set up the necessary browser driver
@@ -46,10 +46,27 @@ export class Gatherer {
         Gatherer.browser = await chromium.launch(playwrightOptions);
       }
     }
-    const context = await Gatherer.browser.newContext(playwrightOptions);
+    const context = await Gatherer.browser.newContext({
+      userAgent: await Gatherer.getUserAgent(),
+      ...playwrightOptions,
+    });
+
     const page = await context.newPage();
+
     const client = await context.newCDPSession(page);
     return { browser: Gatherer.browser, context, page, client };
+  }
+
+  static async getUserAgent(playwrightOptions?: PlaywrightOptions) {
+    const dummyContext = await Gatherer.browser.newContext(playwrightOptions);
+
+    const dummyPage = await dummyContext.newPage();
+    const currentUAStr = await dummyPage.evaluate(() => navigator.userAgent);
+
+    await dummyPage.close();
+    await dummyContext.close();
+
+    return currentUAStr + ' Elastic/Synthetics';
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/elastic/synthetics/issues/232

Appends Elastic/Synthetics to UA string. 

This PR uses a pretty ugly way to determin current user agent string and append the desired string into it.

Not sure if there is a way better way to do this. Struggling with playwright docs on how to get the current user agent string without opening a browser context. 

