### PR TITLE
feat: enable trace as part of rich-events

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -113,7 +113,6 @@ describe('CLI', () => {
     const cli = new CLIMock()
       .args([
         join(FIXTURES_DIR, 'example.journey.ts'),
-        join(FIXTURES_DIR, 'error.journey.ts'),
         '--rich-events',
         '--params',
         JSON.stringify(serverParams),
@@ -125,13 +124,7 @@ describe('CLI', () => {
       .buffer()
       .map(data => JSON.parse(data))
       .find(({ type }) => type === 'step/screenshot_ref');
-    expect(screenshotRef).toMatchObject({
-      journey: {
-        id: 'example journey',
-        name: 'example journey',
-      },
-      root_fields: expect.any(Object),
-    });
+    expect(screenshotRef).toBeDefined();
 
     const networkData = cli
       .buffer()
@@ -139,6 +132,11 @@ describe('CLI', () => {
       .find(({ type }) => type === 'journey/network_info');
     expect(networkData).toBeDefined();
 
+    const traceData = cli
+      .buffer()
+      .map(data => JSON.parse(data))
+      .find(({ type }) => type === 'step/metrics');
+    expect(traceData).toBeDefined();
     expect(await cli.exitCode).toBe(0);
   }, 30000);
 

--- a/__tests__/fixtures/example.journey.ts
+++ b/__tests__/fixtures/example.journey.ts
@@ -28,6 +28,7 @@ import { journey, step } from '../../';
 journey('example journey', ({ page, params }) => {
   step('go to test page', async () => {
     await page.goto(params.url, { timeout: 1500 });
+    await page.evaluate(() => window.performance.mark('page-loaded'));
     await page.waitForSelector('h2.synthetics', { timeout: 1500 });
   });
 });

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -119,6 +119,7 @@ if (options.richEvents) {
   options.ssblocks = true;
   options.network = true;
   options.quietExitCode = true;
+  options.trace = true;
 }
 
 if (options.capability) {


### PR DESCRIPTION
+ fix #386 
+ As part of `--rich-events` flag, all trace level data will be sent as `step/metrics` events to HB. 