### PR TITLE
chore: Use rm instead of rmdir for recursive operations

### DIFF
--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -295,7 +295,7 @@ describe('json reporter', () => {
     });
 
     afterAll(() => {
-      fs.rmdirSync(destDir, { recursive: true });
+      fs.rmSync(destDir, { recursive: true, force: true });
     });
 
     const emitEnd = (options, status = 'failed' as StatusValue) =>

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -35,7 +35,7 @@ import {
   runParallel,
   generateUniqueId,
   mkdirAsync,
-  rmdirAsync,
+  rmAsync,
   writeFileAsync,
 } from '../helpers';
 import {
@@ -353,7 +353,7 @@ export default class Runner extends EventEmitter {
       await once(this, 'journey:end:reported');
     }
     // clear screenshots cache after each journey
-    await rmdirAsync(Runner.screenshotPath, { recursive: true });
+    await rmAsync(Runner.screenshotPath, { recursive: true, force: true });
   }
 
   /**
@@ -479,7 +479,7 @@ export default class Runner extends EventEmitter {
      * Clear all cache data stored for post processing by
      * the current synthetic agent run
      */
-    await rmdirAsync(CACHE_PATH, { recursive: true });
+    await rmAsync(CACHE_PATH, { recursive: true, force: true });
     this.currentJourney = null;
     this.journeys = [];
     this.active = false;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -25,6 +25,7 @@
 
 import { once, EventEmitter } from 'events';
 import { join } from 'path';
+import { rm } from 'fs/promises';
 import { Journey } from '../dsl/journey';
 import { Step } from '../dsl/step';
 import { reporters, Reporter } from '../reporters';
@@ -35,7 +36,6 @@ import {
   runParallel,
   generateUniqueId,
   mkdirAsync,
-  rmAsync,
   writeFileAsync,
 } from '../helpers';
 import {
@@ -353,7 +353,7 @@ export default class Runner extends EventEmitter {
       await once(this, 'journey:end:reported');
     }
     // clear screenshots cache after each journey
-    await rmAsync(Runner.screenshotPath, { recursive: true, force: true });
+    await rm(Runner.screenshotPath, { recursive: true, force: true });
   }
 
   /**
@@ -479,7 +479,7 @@ export default class Runner extends EventEmitter {
      * Clear all cache data stored for post processing by
      * the current synthetic agent run
      */
-    await rmAsync(CACHE_PATH, { recursive: true, force: true });
+    await rm(CACHE_PATH, { recursive: true, force: true });
     this.currentJourney = null;
     this.journeys = [];
     this.active = false;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -36,7 +36,7 @@ const readdirAsync = promisify(fs.readdir);
 
 export const readFileAsync = promisify(fs.readFile);
 export const writeFileAsync = promisify(fs.writeFile);
-export const rmdirAsync = promisify(fs.rmdir);
+export const rmAsync = promisify(fs.rm);
 export const mkdirAsync = promisify(fs.mkdir);
 
 const SEPARATOR = '\n';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -36,7 +36,6 @@ const readdirAsync = promisify(fs.readdir);
 
 export const readFileAsync = promisify(fs.readFile);
 export const writeFileAsync = promisify(fs.writeFile);
-export const rmAsync = promisify(fs.rm);
 export const mkdirAsync = promisify(fs.mkdir);
 
 const SEPARATOR = '\n';


### PR DESCRIPTION
Starting in Node 16, recursive fs.rmdir calls are deprecated and will log a
warning.  It's recommended to use fs.rm intead.

https://nodejs.org/api/deprecations.html#DEP0147

Kibana currently exits on process warnings, this will look like:
```
  ✓  Step: 'Navigates to details page' succeeded (72 ms)
(node:663222) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
Node.js process-warning detected:

DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
    at emitRecursiveRmdirWarning (node:internal/fs/utils:816:13)
    at Object.rmdir (node:fs:1115:5)
    at node:internal/util:363:7
    at new Promise (<anonymous>)
    at Object.rmdir [as rmdirAsync] (node:internal/util:349:12)
    at Runner.endJourney (/home/jon/dev/kibana-node-16/node_modules/@elastic/synthetics/src/core/runner.ts:356:11)
    at Runner.runJourney (/home/jon/dev/kibana-node-16/node_modules/@elastic/synthetics/src/core/runner.ts:414:18)
    at runMicrotasks (<anonymous>)
    at runNextTicks (node:internal/process/task_queues:61:5)
    at processImmediate (node:internal/timers:437:9)
    at Runner.run (/home/jon/dev/kibana-node-16/node_modules/@elastic/synthetics/src/core/runner.ts:465:11)
    at run (/home/jon/dev/kibana-node-16/node_modules/@elastic/synthetics/src/index.ts:45:12)
    at playwrightStart (/home/jon/dev/kibana-node-16/x-pack/plugins/uptime/e2e/playwright_start.ts:43:15)
    at /home/jon/dev/kibana-node-16/x-pack/plugins/uptime/e2e/playwright_start.ts:19:22
    at /home/jon/dev/kibana-node-16/node_modules/@kbn/test/target_node/functional_test_runner/functional_test_runner.js:48:17
    at FunctionalTestRunner._run (/home/jon/dev/kibana-node-16/node_modules/@kbn/test/target_node/functional_test_runner/functional_test_runner.js:105:14)

Terminating process...
node:child_process:903
    throw err;
    ^
```