### PR TITLE
chore: use action title if available in context

### DIFF
--- a/__tests__/formatter/__snapshots__/javascript.test.ts.snap
+++ b/__tests__/formatter/__snapshots__/javascript.test.ts.snap
@@ -43,3 +43,9 @@ journey('Recorded journey', async ({ page, context }) => {
   });
 });"
 `;
+
+exports[`Synthetics JavaScript formatter use modified title if available 1`] = `
+"step('Visiting profile', async () => {
+  await page.goto('https://vigneshh.in/');
+});"
+`;

--- a/__tests__/formatter/javascript.test.ts
+++ b/__tests__/formatter/javascript.test.ts
@@ -171,4 +171,15 @@ describe('Synthetics JavaScript formatter', () => {
     const formatter = new SyntheticsGenerator(true);
     expect(formatter.generateText(recorderActions)).toMatchSnapshot();
   });
+
+  it('use modified title if available', async () => {
+    const formatter = new SyntheticsGenerator(false);
+    const actions = [
+      {
+        ...recorderActions[1],
+        title: 'Visiting profile',
+      },
+    ];
+    expect(formatter.generateText(actions)).toMatchSnapshot();
+  });
 });

--- a/src/formatter/javascript.ts
+++ b/src/formatter/javascript.ts
@@ -35,6 +35,7 @@ export type ActionInContext = {
   isMainFrame: boolean;
   action: Action;
   committed?: boolean;
+  title?: string;
 };
 
 type Action = {
@@ -71,7 +72,7 @@ export class SyntheticsGenerator extends JavaScriptLanguageGenerator {
   }
 
   generateAction(actionInContext: ActionInContext) {
-    const { action, pageAlias } = actionInContext;
+    const { action, pageAlias, title } = actionInContext;
     if (action.name === 'openPage') {
       return '';
     }
@@ -88,7 +89,7 @@ export class SyntheticsGenerator extends JavaScriptLanguageGenerator {
       if (this.insideStep) {
         formatter.add(this.generateStepEnd());
       }
-      formatter.add(this.generateStepStart(actionTitle(action)));
+      formatter.add(this.generateStepStart(title || actionTitle(action)));
     } else {
       formatter = new JavaScriptFormatter(this.isSuite ? 4 : 2);
     }


### PR DESCRIPTION
+ For the recorded use case, when step action is edited and IR is sent over to the formatter, we need to preserve the edited title instead of generating a new one. 