### PR TITLE
fix: handle page close during response event

### DIFF
--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -43,7 +43,7 @@ describe('network', () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     const network = new NetworkManager(driver);
     await network.start();
-    await driver.page.goto(server.TEST_PAGE, { waitUntil: 'networkidle' });
+    await driver.page.goto(server.TEST_PAGE);
     const netinfo = await network.stop();
     await Gatherer.stop();
     expect(netinfo[0]).toMatchObject({

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -39,8 +39,8 @@ export type Params = Record<string, any>;
 export type NetworkConditions = {
   offline: boolean;
   downloadThroughput: number;
-	uploadThroughput: number;
-	latency: number;
+  uploadThroughput: number;
+  latency: number;
 };
 export type HooksArgs = {
   env: string;
@@ -118,7 +118,7 @@ export type Response = {
   url?: string;
   statusCode: number;
   statusText?: string;
-  mimeType: string;
+  mimeType?: string;
   httpVersion?: string;
   headers: Record<string, string>;
   // Total size in bytes of the response (body and headers)


### PR DESCRIPTION
+ Trying to access some of the API's like headers, sizes would trigger unhandled error as the underlying page would be closed before the response event is finished. 

**Note: This technique is used by Hartracer in Playwright and we use the same here, we might move to PW HarTracer once its extendable.**