### PR TITLE
deprecate suite-params option over params

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -54,22 +54,6 @@ describe('CLI', () => {
     expect(await cli.exitCode).toBe(0);
   });
 
-  // TODO: Delete this once --suite-params is removed
-  it('runs with legacy suite-params', async () => {
-    const cli = new CLIMock()
-      .stdin(
-        `step('check h2', async () => {
-        await page.goto(params.url, { timeout: 1500 });
-        const sel = await page.waitForSelector('h2.synthetics', { timeout: 1500 });
-        expect(await sel.textContent()).toBe("Synthetics test page");
-      })`
-      )
-      .args(['--inline', '--suite-params', JSON.stringify(serverParams)])
-      .run();
-    await cli.waitFor('Journey: inline');
-    expect(await cli.exitCode).toBe(0);
-  });
-
   it('run suites and exit with 0', async () => {
     const cli = new CLIMock()
       .args([join(FIXTURES_DIR, 'fake.journey.ts')])

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,11 +175,7 @@ async function prepareSuites(inputs: string[]) {
    * Validate and handle configs
    */
   const config = readConfig(environment, options.config);
-  const params = merge(
-    config.params,
-    options.suiteParams || {},
-    options.params || {}
-  );
+  const params = merge(config.params, options.params || {});
   const playwrightOptions = merge(config.playwrightOptions, {
     headless: options.headless,
     chromiumSandbox: options.sandbox,

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -164,10 +164,6 @@ export type CliArgs = {
   ignoreHttpsErrors?: boolean;
   params?: Params;
   throttling?: boolean | string;
-  /**
-   * @deprecated use params instead
-   */
-  suiteParams?: Params;
   richEvents?: boolean;
 };
 

--- a/src/parse_args.ts
+++ b/src/parse_args.ts
@@ -43,11 +43,6 @@ program
     'JSON object that gets injected to all journeys',
     JSON.parse
   )
-  .option(
-    '-s, --suite-params <jsonstring>',
-    'DEPRECATED: Use --params instead',
-    JSON.parse
-  )
   .addOption(
     new Option('--reporter <value>', `output repoter format`).choices(
       Object.keys(reporters)


### PR DESCRIPTION
+ We have reverted this change - https://github.com/elastic/synthetics/pull/379 for the time being to make 7.15 work, But we added patch to the 7.x branch to add params support in HB and now that we are at the 7.16 release timeline, we can safely remove this from Synthetics side. 