### PR TITLE
fix: end timestamp should reflect duration

### DIFF
--- a/__tests__/reporters/base.test.ts
+++ b/__tests__/reporters/base.test.ts
@@ -102,6 +102,7 @@ describe('base reporter', () => {
     };
     runner.emit('journey:end', {
       journey: j1,
+      timestamp,
       status: 'failed',
       error,
       start: 0,

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -163,6 +163,7 @@ describe('json reporter', () => {
     });
     runner.emit('journey:end', {
       journey: j1,
+      timestamp,
       status: 'succeeded',
       start: 0,
       end: 11,
@@ -225,6 +226,7 @@ describe('json reporter', () => {
 
     runner.emit('journey:end', {
       journey: j1,
+      timestamp,
       start: 0,
       end: 1,
       status: 'failed',
@@ -242,6 +244,7 @@ describe('json reporter', () => {
     const journeyOpts = { name: 'name', id: 'id', tags: ['tag1', 'tag2'] };
     runner.emit('journey:end', {
       journey: journey(journeyOpts, () => {}),
+      timestamp,
       start: 0,
       end: 1,
       status: 'skipped',
@@ -301,6 +304,7 @@ describe('json reporter', () => {
     const emitEnd = (options, status = 'failed' as StatusValue) =>
       runner.emit('journey:end', {
         journey: j1,
+        timestamp,
         start: 0,
         status,
         options,

--- a/__tests__/reporters/junit.test.ts
+++ b/__tests__/reporters/junit.test.ts
@@ -81,6 +81,7 @@ describe('junit reporter', () => {
     });
     runner.emit('journey:end', {
       journey: j1,
+      timestamp,
       start: 0,
       status: 'failed',
       options: {},
@@ -115,6 +116,7 @@ describe('junit reporter', () => {
     });
     runner.emit('journey:end', {
       journey: j1,
+      timestamp,
       start: 0,
       status: 'failed',
       options: {},

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -37,6 +37,7 @@ export class Gatherer {
   static browser: ChromiumBrowser;
 
   static async setupDriver(options: RunOptions): Promise<Driver> {
+    log('Gatherer: setup driver');
     const { wsEndpoint, playwrightOptions, networkConditions } = options;
 
     if (Gatherer.browser == null) {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -435,6 +435,7 @@ export default class JSONReporter extends BaseReporter {
       'journey:end',
       async ({
         journey,
+        timestamp,
         start,
         end,
         networkinfo,
@@ -501,6 +502,7 @@ export default class JSONReporter extends BaseReporter {
         this.writeJSON({
           type: 'journey/end',
           journey,
+          timestamp,
           error,
           payload: {
             start,


### PR DESCRIPTION
+ fix #409 

### Problem
Heartbeat monitor calculation is based on the event.timestamp field for journey start and journey end event. Synthetic agent journey/end timestamp is calculated after post processing of the screenshots and network events being written to the JSON output. As a result, Step duration and Monitor duration timings would be hugely different as we are accounting for all the CPU heavy work that comes to extracting and chopping screenshots. 

### Solution

We use the timestamp during journey end and don't account for the time taken for the post processing of other work that synthetics agent is doing under the hood. 