### PR TITLE
fix: do not stash `.nvm` folder

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,7 +61,6 @@ pipeline {
     /**
      Checks formatting / linting.
      */
-     /*
     stage('Lint') {
       options {
         timeout(5)
@@ -77,11 +76,10 @@ pipeline {
           }
         }
       }
-    }*/
+    }
     /**
      Build the main package
      */
-     /*
     stage('Build') {
       options {
         timeout(5)
@@ -96,11 +94,10 @@ pipeline {
           }
         }
       }
-    }*/
+    }
     /**
      Execute integration tests.
      */
-     /*
     stage('Test') {
       options {
         timeout(5)
@@ -121,7 +118,7 @@ pipeline {
           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
         }
       }
-    }*/
+    }
     stage('E2e Test') {
       agent { label 'ubuntu-18 && immutable' }
       environment {
@@ -259,9 +256,7 @@ def withNodeEnv(Map args=[:], Closure body){
       fi
     ''')
     sh(label: 'install Node.js', script: '''
-      set -ex
-      pwd
-      ls -la
+      set -e
       export NVM_DIR="${HOME}/.nvm"
       [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -244,7 +244,7 @@ def withNodeInDockerEnv(Map args=[:], Closure body){
 def withNodeEnv(Map args=[:], Closure body){
   withEnv(["HOME=${WORKSPACE}"]) {
     sh(label: 'install Node.js', script: '''
-      set +x
+      set -x
       export NVM_DIR="${HOME}/.nvm"
       [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh"
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -245,11 +245,13 @@ def withNodeEnv(Map args=[:], Closure body){
   withEnv(["HOME=${WORKSPACE}"]) {
     sh(label: 'install Node.js', script: '''
       set +x
+      export NVM_DIR="${HOME}/.nvm"
+      [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh"
+
       if [ -z "$(command -v nvm)" ]; then
         curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.1/install.sh | bash
       fi
 
-      export NVM_DIR="${HOME}/.nvm"
       [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh"
 
       # install node version required by .nvmrc in BASE_DIR
@@ -257,7 +259,7 @@ def withNodeEnv(Map args=[:], Closure body){
       nvm install
       cd -
 
-      nvm version | head -n1 > .nvm-node-version
+      nvm version | head -n1 > ".nvm-node-version"
     ''')
     def node_version = readFile(file: '.nvm-node-version').trim()
     withEnv(["PATH+NVM=${HOME}/.nvm/versions/node/${node_version}/bin"]){

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,17 +43,23 @@ pipeline {
         timeout(5)
       }
       steps {
+        sh "df -h"
         deleteDir()
+        sh "df -h"
         gitCheckout(basedir: "${BASE_DIR}")
+        sh "df -h"
         retryWithSleep(retries: 3, seconds: 5, backoff: true) {
           dockerLogin(secret: "${DOCKERELASTIC_SECRET}",
                       registry: "${DOCKER_REGISTRY}")
           withNodeEnv(){
+            sh "df -h"
             dir("${BASE_DIR}"){
               sh(label: 'Download dependencies',script: 'npm install')
+              sh "df -h"
             }
           }
         }
+        sh "df -h"
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: ".npm/_cacache/**,.nvm/.git/**"
       }
     }
@@ -66,11 +72,17 @@ pipeline {
       }
       steps {
         withGithubNotify(context: 'Linting') {
+          sh "df -h"
           cleanup()
+          sh "df -h"
           withNodeEnv(){
+            sh "df -h"
             dir("${BASE_DIR}"){
+              sh "df -h"
               sh(label: 'Checks linting',script: 'npm run-script lint')
+              sh "df -h"
               preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+              sh "df -h"
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -246,14 +246,14 @@ def withNodeEnv(Map args=[:], Closure body){
     sh(label: 'install Node.js', script: '''
       set -x
       export NVM_DIR="${HOME}/.nvm"
-      [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh" && ls -la ${NVM_DIR}/versions/node
+      [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh" && ls -la ${NVM_DIR}/versions/node
 
       if [ -z "$(command -v nvm)" ]; then
         rm -fr "${NVM_DIR}"
         curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
       fi
 
-      [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh"
+      [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
 
       # install node version required by .nvmrc in BASE_DIR
       cd "$BASE_DIR"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -262,10 +262,7 @@ def withNodeEnv(Map args=[:], Closure body){
       [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
 
       # install node version required by .nvmrc in BASE_DIR
-      cd "$BASE_DIR"
-      nvm install
-      cd -
-
+      nvm install $(cat $BASE_DIR/.nvmrc)
       nvm version | head -n1 > ".nvm-node-version"
     ''')
     def node_version = readFile(file: '.nvm-node-version').trim()

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -43,24 +43,18 @@ pipeline {
         timeout(5)
       }
       steps {
-        sh "df -h"
         deleteDir()
-        sh "df -h"
         gitCheckout(basedir: "${BASE_DIR}")
-        sh "df -h"
         retryWithSleep(retries: 3, seconds: 5, backoff: true) {
           dockerLogin(secret: "${DOCKERELASTIC_SECRET}",
                       registry: "${DOCKER_REGISTRY}")
           withNodeEnv(){
-            sh "df -h"
             dir("${BASE_DIR}"){
               sh(label: 'Download dependencies',script: 'npm install')
-              sh "df -h"
             }
           }
         }
-        sh "df -h"
-        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: ".npm/_cacache/**,.nvm/.git/**"
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: ".nvm/**,.npm/_cacache/**,.nvm/.git/**"
       }
     }
     /**
@@ -72,17 +66,11 @@ pipeline {
       }
       steps {
         withGithubNotify(context: 'Linting') {
-          sh "df -h"
           cleanup()
-          sh "df -h"
           withNodeEnv(){
-            sh "df -h"
             dir("${BASE_DIR}"){
-              sh "df -h"
               sh(label: 'Checks linting',script: 'npm run-script lint')
-              sh "df -h"
               preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
-              sh "df -h"
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -246,16 +246,19 @@ def withNodeInDockerEnv(Map args=[:], Closure body){
 
 def withNodeEnv(Map args=[:], Closure body){
   withEnv(["HOME=${WORKSPACE}"]) {
-    sh(label: 'install Node.js', script: '''
-      set -x
+    sh(label: 'install nvm', script: '''
+      set -e
       export NVM_DIR="${HOME}/.nvm"
-      [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh" && ls -la ${NVM_DIR}/versions/node
+      [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
 
       if [ -z "$(command -v nvm)" ]; then
         rm -fr "${NVM_DIR}"
         curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
       fi
-
+    ''')
+    sh(label: 'install Node.js', script: '''
+      set -ex
+      export NVM_DIR="${HOME}/.nvm"
       [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
 
       # install node version required by .nvmrc in BASE_DIR

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
     /**
      Checks formatting / linting.
      */
+     /*
     stage('Lint') {
       options {
         timeout(5)
@@ -75,10 +76,11 @@ pipeline {
           }
         }
       }
-    }
+    }*/
     /**
      Build the main package
      */
+     /*
     stage('Build') {
       options {
         timeout(5)
@@ -93,10 +95,11 @@ pipeline {
           }
         }
       }
-    }
+    }*/
     /**
      Execute integration tests.
      */
+     /*
     stage('Test') {
       options {
         timeout(5)
@@ -117,7 +120,7 @@ pipeline {
           junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/junit.xml")
         }
       }
-    }
+    }*/
     stage('E2e Test') {
       agent { label 'ubuntu-18 && immutable' }
       environment {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -246,10 +246,11 @@ def withNodeEnv(Map args=[:], Closure body){
     sh(label: 'install Node.js', script: '''
       set -x
       export NVM_DIR="${HOME}/.nvm"
-      [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh"
+      [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh" && ls -la ${NVM_DIR}/versions/node
 
       if [ -z "$(command -v nvm)" ]; then
-        curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.1/install.sh | bash
+        rm -fr "${NVM_DIR}"
+        curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
       fi
 
       [ -s "${NVM_DIR}/nvm.sh" ] && \\. "${NVM_DIR}/nvm.sh"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
      */
     stage('Checkout') {
       options {
+        skipDefaultCheckout()
         timeout(5)
       }
       steps {
@@ -127,6 +128,7 @@ pipeline {
         E2E_FOLDER = "__tests__/e2e"
       }
       options {
+        skipDefaultCheckout()
         timeout(20)
       }
       steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -258,6 +258,8 @@ def withNodeEnv(Map args=[:], Closure body){
     ''')
     sh(label: 'install Node.js', script: '''
       set -ex
+      pwd
+      ls -la
       export NVM_DIR="${HOME}/.nvm"
       [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
 


### PR DESCRIPTION
Stash the `.nvm` folder is causing the following error, so let's do not doit because is not needed:

```
[2021-11-10T23:49:49.429Z] java.nio.file.NoSuchFileException: /var/lib/jenkins/workspace/nt-rum_elastic-synthetics_PR-405/.nvm/versions/node/v14.17.5/lib/node_modules/npm/bin/npm-cli.js
[2021-11-10T23:49:49.429Z] 	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
[2021-11-10T23:49:49.429Z] 	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
[2021-11-10T23:49:49.429Z] 	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
[2021-11-10T23:49:49.429Z] 	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
[2021-11-10T23:49:49.429Z] 	at java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:434)
[2021-11-10T23:49:49.429Z] 	at java.nio.file.Files.newOutputStream(Files.java:216)
[2021-11-10T23:49:49.429Z] 	at hudson.util.IOUtils.copy(IOUtils.java:52)
[2021-11-10T23:49:49.429Z] 	at hudson.FilePath.readFromTar(FilePath.java:2862)
[2021-11-10T23:49:49.429Z] Also:   hudson.remoting.Channel$CallSiteStackTrace: Remote call to apm-ci-immutable-ubuntu-1804-1636587888864696895
[2021-11-10T23:49:49.429Z] 		at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1797)
[2021-11-10T23:49:49.429Z] 		at hudson.remoting.UserRequest$ExceptionResponse.retrieve(UserRequest.java:356)
[2021-11-10T23:49:49.429Z] 		at hudson.remoting.Channel.call(Channel.java:1001)
[2021-11-10T23:49:49.429Z] 		at hudson.FilePath.act(FilePath.java:1166)
[2021-11-10T23:49:49.429Z] 		at hudson.FilePath.act(FilePath.java:1155)
[2021-11-10T23:49:49.429Z] 		at hudson.FilePath.untar(FilePath.java:617)
[2021-11-10T23:49:49.429Z] 		at org.jenkinsci.plugins.workflow.flow.StashManager.unstash(StashManager.java:161)
[2021-11-10T23:49:49.429Z] 		at org.jenkinsci.plugins.workflow.support.steps.stash.UnstashStep$Execution.run(UnstashStep.java:77)
[2021-11-10T23:49:49.429Z] 		at org.jenkinsci.plugins.workflow.support.steps.stash.UnstashStep$Execution.run(UnstashStep.java:64)
[2021-11-10T23:49:49.429Z] 		at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
[2021-11-10T23:49:49.429Z] 		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2021-11-10T23:49:49.429Z] 		at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-11-10T23:49:49.429Z] 		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-11-10T23:49:49.429Z] 		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-11-10T23:49:49.429Z] Caused: java.io.IOException: Failed to extract source.tar.gz
[2021-11-10T23:49:49.429Z] 	at hudson.FilePath.readFromTar(FilePath.java:2872)
[2021-11-10T23:49:49.429Z] 	at hudson.FilePath.access$500(FilePath.java:213)
[2021-11-10T23:49:49.429Z] 	at hudson.FilePath$UntarRemote.invoke(FilePath.java:633)
[2021-11-10T23:49:49.429Z] 	at hudson.FilePath$UntarRemote.invoke(FilePath.java:622)
[2021-11-10T23:49:49.429Z] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3338)
[2021-11-10T23:49:49.429Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
[2021-11-10T23:49:49.429Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
[2021-11-10T23:49:49.430Z] 	at hudson.remoting.Request$2.run(Request.java:376)
[2021-11-10T23:49:49.430Z] 	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
[2021-11-10T23:49:49.430Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-11-10T23:49:49.430Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-11-10T23:49:49.430Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-11-10T23:49:49.430Z] 	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:122)
[2021-11-10T23:49:49.430Z] 	at java.lang.Thread.run(Thread.java:748)
```