### PR TITLE
[jjbb] for scheduling e2e jobs

### DIFF
--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -41,7 +41,7 @@ pipeline {
       notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] e2e failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
     }
     success {
-      notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] e2e ran successfully", body: "Great news, the e2e for synthetics has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>).")
+      notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] e2e ran successfully", body: "Great news, the e2e for synthetics has finished successfully. (<${env.RUN_DISPLAY_URL}|Open>).")
     }
   }
 }

--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -1,0 +1,61 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'ubuntu-18 && immutable' }
+  environment {
+    REPO = "synthetics"
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    PIPELINE_LOG_LEVEL = 'INFO'
+    SLACK_CHANNEL = '#synthetics-user_experience-uptime'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')  // to support releases then we will add a timeout in each stage
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  stages {
+    stage('Checkout') {
+      options {
+        skipDefaultCheckout()
+        timeout(5)
+      }
+      steps {
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}")
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false, excludes: ".nvm/**,.npm/_cacache/**,.nvm/.git/**"
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: true)
+    }
+    unsuccessful {
+      notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] e2e failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+    }
+    success {
+      notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] e2e ran successfully", body: "Great news, the e2e for synthetics has been done successfully. (<${env.RUN_DISPLAY_URL}|Open>).")
+    }
+  }
+}
+
+/**
+  This is the wrapper to send notifications for the release process through
+  slack and email, since it requires some formatting to support the same
+  message in both systems.
+ */
+def notifyStatus(def args = [:]) {
+  releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: 'synthrum@elastic.co',
+                      subject: args.subject,
+                      body: args.body)
+}

--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -52,6 +52,8 @@ pipeline {
   message in both systems.
  */
 def notifyStatus(def args = [:]) {
+  // Disabled temporarily to avoid spamming users while we are still developing this feature
+  return
   releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
                       slackColor: args.slackStatus,
                       slackCredentialsId: 'jenkins-slack-integration-token',

--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -47,7 +47,7 @@ pipeline {
 }
 
 /**
-  This is the wrapper to send notifications for the release process through
+  This is the wrapper to send notifications for the e2e process through
   slack and email, since it requires some formatting to support the same
   message in both systems.
  */

--- a/.ci/jobs/e2e-synthetics-mbp.yml
+++ b/.ci/jobs/e2e-synthetics-mbp.yml
@@ -1,0 +1,44 @@
+---
+- job:
+    name: apm-agent-rum/e2e-synthetics-mbp
+    display-name: E2E for Elastic Synthetics
+    description: E2E for Elastic Synthetics.
+    project-type: multibranch
+    script-path: .ci/e2e-synthetics.groovy
+    scm:
+      - github:
+          branch-discovery: 'no-pr'
+          discover-pr-forks-strategy: 'merge-current'
+          discover-pr-forks-trust: 'permission'
+          discover-pr-origin: 'merge-current'
+          discover-tags: false
+          disable-pr-notifications: true
+          head-filter-regex: '(master|\d+\.\d+\.\d+|PR-.*)'
+          notification-context: 'elastic-synthetics'
+          repo: 'synthetics'
+          repo-owner: 'elastic'
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - regular-branches: true
+            - change-request:
+                ignore-target-only-changes: true
+          property-strategies:
+            all-branches:
+              - suppress-scm-triggering: true
+          clean:
+              after: true
+              before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+              disable: false
+              recursive: true
+              parent-credentials: true
+              timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: true

--- a/.ci/jobs/e2e-synthetics-schedule.yml
+++ b/.ci/jobs/e2e-synthetics-schedule.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    name: apm-agent-rum/e2e-synthetics-schedule
+    display-name: Jobs scheduled daily
+    description: Jobs scheduled daily from Monday to Friday
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/synthetics.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/synthetics.git
+            branches:
+              - $branch_specifier
+    triggers:
+      - timed: 'H 4,16 * * 1-5'

--- a/.ci/schedule.groovy
+++ b/.ci/schedule.groovy
@@ -22,7 +22,7 @@ pipeline {
   stages {
     stage('Run Tasks'){
       steps {
-        build(job: 'apm-agent-rum/e2e-synthetics-mpb/master',
+        build(job: 'apm-agent-rum/e2e-synthetics-mbp/master',
           propagate: false,
           wait: false
         )

--- a/.ci/schedule.groovy
+++ b/.ci/schedule.groovy
@@ -1,0 +1,37 @@
+#!/usr/bin/env groovy
+
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL='INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H 4,16 * * 1-5')
+  }
+  stages {
+    stage('Run Tasks'){
+      steps {
+        build(job: 'apm-agent-rum/e2e-synthetics-mpb/master',
+          propagate: false,
+          wait: false
+        )
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}


### PR DESCRIPTION
### What

Create the JJBB definition (aka the Jenkins UI jobs) for:
- The scheduling twice a day as requested
- The e2e pipeline.

Create the e2e pipeline skeleton, the implementation for what to run to be done in a follow up.

### Why

It was requested to create a scheduled execution of the new E2E twice a day and notify in slack the outcome.

### Further details

I decided to enable a Multibranch Pipeline to be able to test the pipeline manually if needed on a PR basis. It will only be triggered automatically on a daily basis (twice).

In my experience, Multibranch Pipelines help to iterate faster since we can work on a PR basis.


### Notifies

https://github.com/elastic/synthetics/pull/417 and https://github.com/elastic/synthetics/pull/393
