### PR TITLE
ci: use withNodejsEnv step

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@5b2e96efad9ea4828cfd9a9a7bb3e03ce8c84354') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@feature/add-with-node-env') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }
@@ -49,7 +49,7 @@ pipeline {
         retryWithSleep(retries: 3, seconds: 5, backoff: true) {
           dockerLogin(secret: "${DOCKERELASTIC_SECRET}",
                       registry: "${DOCKER_REGISTRY}")
-          withNodejsEnv(){
+          withNodeJSEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'Download dependencies',script: 'npm install')
             }
@@ -68,7 +68,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'Linting') {
           cleanup()
-          withNodejsEnv(){
+          withNodeJSEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'Checks linting',script: 'npm run-script lint')
               preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
@@ -87,7 +87,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'Build') {
           cleanup()
-          withNodejsEnv(){
+          withNodeJSEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'Build',script: 'npm run build')
             }
@@ -105,7 +105,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'Test') {
           cleanup()
-          withNodejsEnv(){
+          withNodeJSEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'install jest-unit',script: 'npm add --dev jest-junit')
               sh(label: 'Runs the tests',script: './node_modules/.bin/jest --ci --reporters=default --reporters=jest-junit')
@@ -131,7 +131,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'E2e Test') {
           cleanup()
-          withNodejsEnv(){
+          withNodeJSEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'set permissions', script: '''
                 chmod -R ugo+rw examples
@@ -181,7 +181,7 @@ pipeline {
           }
           steps {
             cleanup()
-            withNodejsEnv(){
+            withNodeJSEnv(){
               dir("${BASE_DIR}"){
                 withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
                   withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
         retryWithSleep(retries: 3, seconds: 5, backoff: true) {
           dockerLogin(secret: "${DOCKERELASTIC_SECRET}",
                       registry: "${DOCKER_REGISTRY}")
-          withNodeEnv(){
+          withNodejsEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'Download dependencies',script: 'npm install')
             }
@@ -68,7 +68,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'Linting') {
           cleanup()
-          withNodeEnv(){
+          withNodejsEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'Checks linting',script: 'npm run-script lint')
               preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
@@ -87,7 +87,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'Build') {
           cleanup()
-          withNodeEnv(){
+          withNodejsEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'Build',script: 'npm run build')
             }
@@ -105,7 +105,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'Test') {
           cleanup()
-          withNodeEnv(){
+          withNodejsEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'install jest-unit',script: 'npm add --dev jest-junit')
               sh(label: 'Runs the tests',script: './node_modules/.bin/jest --ci --reporters=default --reporters=jest-junit')
@@ -131,7 +131,7 @@ pipeline {
       steps {
         withGithubNotify(context: 'E2e Test') {
           cleanup()
-          withNodeEnv(){
+          withNodejsEnv(){
             dir("${BASE_DIR}"){
               sh(label: 'set permissions', script: '''
                 chmod -R ugo+rw examples
@@ -181,7 +181,7 @@ pipeline {
           }
           steps {
             cleanup()
-            withNodeEnv(){
+            withNodejsEnv(){
               dir("${BASE_DIR}"){
                 withNpmrc(secret: "${env.NPMRC_SECRET}", path: "${env.WORKSPACE}/${env.BASE_DIR}") {
                   withGitRelease(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken') {
@@ -238,34 +238,6 @@ def cleanup(){
 def withNodeInDockerEnv(Map args=[:], Closure body){
   docker.image("${NODE_DOCKER_IMAGE}").inside(" --security-opt seccomp=${SECCOMP_FILE}"){
     withEnv(["HOME=${WORKSPACE}"]) {
-      body()
-    }
-  }
-}
-
-def withNodeEnv(Map args=[:], Closure body){
-  withEnv(["HOME=${WORKSPACE}"]) {
-    sh(label: 'install nvm', script: '''
-      set -e
-      export NVM_DIR="${HOME}/.nvm"
-      [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
-
-      if [ -z "$(command -v nvm)" ]; then
-        rm -fr "${NVM_DIR}"
-        curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-      fi
-    ''')
-    sh(label: 'install Node.js', script: '''
-      set -e
-      export NVM_DIR="${HOME}/.nvm"
-      [ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
-
-      # install node version required by .nvmrc in BASE_DIR
-      nvm install $(cat $BASE_DIR/.nvmrc)
-      nvm version | head -n1 > ".nvm-node-version"
-    ''')
-    def node_version = readFile(file: '.nvm-node-version').trim()
-    withEnv(["PATH+NVM=${HOME}/.nvm/versions/node/${node_version}/bin"]){
       body()
     }
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@5b2e96efad9ea4828cfd9a9a7bb3e03ce8c84354') _
+@Library('apm@feature/add-with-node-env') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }


### PR DESCRIPTION
### What

Use `withNodejsEnv` to simplify the `nvm` and `nodejs` installation steps


### Issue

Uses https://github.com/elastic/apm-pipeline-library/pull/1402