### PR TITLE
Export `ActionInContext` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,3 +72,4 @@ export type { default as Runner } from './core/runner';
 export type { Reporter, ReporterOptions } from './reporters';
 
 export type { SyntheticsConfig } from './common_types';
+export type { ActionInContext } from './formatter/javascript';


### PR DESCRIPTION
As part of https://github.com/elastic/synthetics-recorder/issues/85, it would be good to depend on the upstream action type instead of maintaining parallel types that might be out of sync. It will take some of the maintenance burden off of the recorder as well.

With this change, when the next release is published we should be able to reference this type and delete our existing action type.