### PR TITLE
chore: prevent docker rmi to fail when removing image

### DIFF
--- a/__tests__/e2e/scripts/ci_integration.sh
+++ b/__tests__/e2e/scripts/ci_integration.sh
@@ -19,4 +19,4 @@ STACK_VERSION=$1 SYNTHETICS_JUNIT_FILE="junit_$1.xml" npx @elastic/synthetics sy
 # Take the stack down
 elastic-package stack down
 
-docker rmi docker.elastic.co/beats/elastic-agent-complete:$1 docker.elastic.co/elasticsearch/elasticsearch:$1 docker.elastic.co/kibana/kibana:$1 elastic-package-stack_package-registry:latest
+docker rmi docker.elastic.co/beats/elastic-agent-complete:$1 docker.elastic.co/elasticsearch/elasticsearch:$1 docker.elastic.co/kibana/kibana:$1 elastic-package-stack_package-registry:latest || echo "FAILED"


### PR DESCRIPTION
# Context

The e2e pipeline has been failing for a few days. It has been failing because the image downloaded for elastic agent complete was ```docker.elastic.co/beats/elastic-agent-complete:8.0.0-52f8db06-SNAPSHOT``` but the cleanup process try to remove ```docker.elastic.co/beats/elastic-agent-complete:8.0.0-SNAPSHOT``` causing then a failure on the pipeline

# Fix

Following @kuisathaverat recommendation the ```|| echo "FAILED"``` is being added in the cleanup in order to ignore the error. In CI this is not a problem since the agents are ephemeral.
