### PR TITLE
chore: exclude 8.1.0-SNAPSHOT from CI

### DIFF
--- a/__tests__/e2e/scripts/test_versions.sh
+++ b/__tests__/e2e/scripts/test_versions.sh
@@ -7,5 +7,7 @@ SYNTHETICS_E2E_ARGS="${@:2}"
 
 while IFS= read -r line
 do
-  sh ./scripts/setup_integration.sh $line && sh ./scripts/$1_integration.sh $line $SYNTHETICS_E2E_ARGS
+  if [[ "$line" != *"DISABLED"* ]]; then
+      sh ./scripts/setup_integration.sh $line && sh ./scripts/$1_integration.sh $line $SYNTHETICS_E2E_ARGS
+  fi
 done < "$input"

--- a/__tests__/e2e/versions
+++ b/__tests__/e2e/versions
@@ -2,4 +2,4 @@
 7.16.0
 7.16.1
 8.0.0-SNAPSHOT
-8.1.0-SNAPSHOT
+DISABLED -> 8.1.0-SNAPSHOT # enable it again in https://github.com/elastic/synthetics/issues/432


### PR DESCRIPTION
# Context

The synthetics E2E [pipeline](https://apm-ci.elastic.co/job/apm-agent-rum/job/e2e-synthetics-mbp/job/master/63/console) is failing when executing tests for 8.1.0-SNAPSHOT due to an unhealthy container: ERROR: for elastic-agent Container "dada48cb7ab1" is unhealthy.

The reason of this issue is visible in the logs of that container:

`Kibana Fleet setup failed: http POST request to http://kibana:5601/api/fleet/setup fails: Unauthorized: <nil>. Response: {"statusCode":401,"error":"Unauthorized","message":"Unauthorized"}`

Issue where the agent team is working on a fix: elastic/beats#29603

# Summary

Having the E2E pipeline repeatedly is not good psychologically speaking that's why is being disabled. Once the fix in the agent is done we will enable it again.

That's why this [new](https://github.com/elastic/synthetics/issues/432) issue has been created as well.
