### PR TITLE
chore: fix flaky tests in CLI mock

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -187,6 +187,7 @@ describe('CLI', () => {
       ])
       .run();
     await cli.waitFor('journey/end');
+    expect(await cli.exitCode).toBe(0);
 
     const data = safeParse(cli.buffer());
     const screenshotRef = data.find(
@@ -201,9 +202,7 @@ describe('CLI', () => {
 
     const traceData = data.find(({ type }) => type === 'step/metrics');
     expect(traceData).toBeDefined();
-
-    expect(await cli.exitCode).toBe(0);
-  }, 30000);
+  });
 
   it('override screenshots with `--rich-events` flag', async () => {
     const cli = new CLIMock()
@@ -215,10 +214,9 @@ describe('CLI', () => {
       ])
       .run();
     await cli.waitFor('journey/end');
-    const screenshots = cli
-      .buffer()
-      .map(data => JSON.parse(data))
-      .find(({ type }) => type === 'step/screenshot_ref');
+    const screenshots = safeParse(cli.buffer()).find(
+      ({ type }) => type === 'step/screenshot_ref'
+    );
     expect(screenshots).not.toBeDefined();
     expect(await cli.exitCode).toBe(0);
   });

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -559,7 +559,7 @@ class CLIMock {
       this.data = data.toString();
       // Uncomment the line below if the process is blocked and you need to see its output
       // console.log('CLIMock.stdout:', this.data);
-      this.chunks.push(...this.data.split('\n').filter(Boolean));
+      this.chunks.push(this.data);
       if (this.waitForPromise && this.data.includes(this.waitForText)) {
         this.process.stdout.off('data', dataListener);
         this.waitForPromise();
@@ -588,6 +588,9 @@ class CLIMock {
   }
 
   buffer() {
-    return this.chunks;
+    // Merge all the interleaved chunks from stdout and
+    // split them on new line as synthetics runner writes the
+    // JSON output in separate lines for every event.
+    return this.chunks.join('').split('\n').filter(Boolean);
   }
 }

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -364,6 +364,8 @@ describe('CLI', () => {
         JSON.stringify({ url: tlsServer.TEST_PAGE }),
         '--reporter',
         'json',
+        '--screenshots',
+        'off',
       ];
     });
 

--- a/__tests__/fixtures/example.journey.ts
+++ b/__tests__/fixtures/example.journey.ts
@@ -27,7 +27,7 @@ import { journey, step } from '../../';
 
 journey('example journey', ({ page, params }) => {
   step('go to test page', async () => {
-    await page.goto(params.url, { timeout: 1500 });
+    await page.goto(params.url, { waitUntil: 'networkidle' });
     await page.evaluate(() => window.performance.mark('page-loaded'));
     await page.waitForSelector('h2.synthetics', { timeout: 1500 });
   });

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -114,17 +114,20 @@ describe('network', () => {
 
   it('timings for aborted requests', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
+    await driver.client.send('Network.setCacheDisabled', {
+      cacheDisabled: true,
+    });
     const network = new NetworkManager(driver);
     await network.start();
 
     const delayTime = 20;
-    server.route('/delay100', async (req, res) => {
+    server.route('/delay20', async (req, res) => {
       await delay(delayTime);
       res.destroy();
     });
     server.route('/index', async (_, res) => {
       res.setHeader('content-type', 'text/html');
-      res.end(`<script src=${server.PREFIX}/delay100 />`);
+      res.end(`<script src=${server.PREFIX}/delay20 />`);
     });
 
     await driver.page.goto(server.PREFIX + '/index');
@@ -133,7 +136,7 @@ describe('network', () => {
     const netinfo = await network.stop();
     expect(netinfo.length).toBe(2);
     expect(netinfo[1]).toMatchObject({
-      url: `${server.PREFIX}/delay100`,
+      url: `${server.PREFIX}/delay20`,
       response: {
         headers: {},
         mimeType: 'x-unknown',


### PR DESCRIPTION
+ fix #430 

Synthetics runner uses streams in object mode to write the data to the corresponding File descriptor, in our case it's process.stdout. So the runner writes the data on each new line for every event type - `journey/start`, `step/end` and so on.

The data written to the underlying stream will be flushed once their internal buffer length exceeds, We can control this [buffering](https://nodejs.org/api/stream.html#buffering) behavior of streams by using `highWaterMark` option. In the tests case, some of the data is interleaved as screenshot blob data events chunk exceeds that limit and written as interleaved chunks to the file descriptor. 

Our current code does not take this in to account and instead pushes the broken data chunk to the final buffer. The solution was simply to move the splitting logic after merging all the chunks which would take care of interleaved chunks. 