### PR TITLE
chore - prevent notification of successful e2e tests

### DIFF
--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -81,9 +81,9 @@ pipeline {
     unsuccessful {
       notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] e2e failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
     }
-    success {
-      notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] e2e ran successfully", body: "Great news, the e2e for synthetics has finished successfully. (<${env.RUN_DISPLAY_URL}|Open>).")
-    }
+    // success {
+    //   notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] e2e ran successfully", body: "Great news, the e2e for synthetics has finished successfully. (<${env.RUN_DISPLAY_URL}|Open>).")
+    // }
   }
 }
 


### PR DESCRIPTION
Prevents notifications in slack and email when fleet/agent/synthetics e2e tests are successful