### PR TITLE
chore: enable 8.1.0-SNAPSHOT

### DIFF
--- a/__tests__/e2e/scripts/test_versions.sh
+++ b/__tests__/e2e/scripts/test_versions.sh
@@ -7,7 +7,5 @@ SYNTHETICS_E2E_ARGS="${@:2}"
 
 while IFS= read -r line
 do
-  if [[ "$line" != *"DISABLED"* ]]; then
-      sh ./scripts/setup_integration.sh $line && sh ./scripts/$1_integration.sh $line $SYNTHETICS_E2E_ARGS
-  fi
+    sh ./scripts/setup_integration.sh $line && sh ./scripts/$1_integration.sh $line $SYNTHETICS_E2E_ARGS
 done < "$input"

--- a/__tests__/e2e/versions
+++ b/__tests__/e2e/versions
@@ -2,4 +2,4 @@
 7.16.0
 7.16.1
 8.0.0-SNAPSHOT
-DISABLED -> 8.1.0-SNAPSHOT # enable it again in https://github.com/elastic/synthetics/issues/432
+8.1.0-SNAPSHOT


### PR DESCRIPTION
# Summary

The [PR](https://github.com/elastic/beats/pull/29651) with the updates in the agent has been already merged. Because of that we can enable again the 8.1.0-SNAPSHOT in the E2E test pipeline.


That snapshot has been excluded since the following PR: https://github.com/elastic/synthetics/pull/433