### PR TITLE
Stop runner from hanging indefinitely within ubuntu docker images [elastic/beats#29681]

### DIFF
--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -29,6 +29,7 @@ import { wsEndpoint } from '../utils/test-config';
 import { devices } from 'playwright-chromium';
 import { Server } from '../utils/server';
 import { megabitsToBytes } from '../../src/helpers';
+import { chromium } from 'playwright-chromium';
 
 jest.mock('../../src/plugins/network');
 
@@ -42,9 +43,24 @@ describe('Gatherer', () => {
     await server.close();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('boot and close browser', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     expect(typeof driver.page.goto).toBe('function');
+    await Gatherer.stop();
+  });
+
+  it('uses the disable-gpu flag to start browser', async () => {
+    const chromiumLaunch = jest.spyOn(chromium, 'launch');
+    await Gatherer.setupDriver({ wsEndpoint });
+    expect(chromiumLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.arrayContaining(['--disable-gpu']),
+      })
+    );
     await Gatherer.stop();
   });
 

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -45,7 +45,10 @@ export class Gatherer {
         log(`Gatherer: connecting to WS endpoint: ${wsEndpoint}`);
         Gatherer.browser = await chromium.connect({ wsEndpoint });
       } else {
-        Gatherer.browser = await chromium.launch(playwrightOptions);
+        Gatherer.browser = await chromium.launch({
+          ...playwrightOptions,
+          args: ['--disable-gpu', ...(playwrightOptions?.args ?? [])],
+        });
       }
     }
     const context = await Gatherer.browser.newContext({

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -47,7 +47,10 @@ export class Gatherer {
       } else {
         Gatherer.browser = await chromium.launch({
           ...playwrightOptions,
-          args: ['--disable-gpu', ...(playwrightOptions?.args ?? [])],
+          args: [
+            ...(playwrightOptions?.headless ? ['--disable-gpu'] : []),
+            ...(playwrightOptions?.args ?? []),
+          ],
         });
       }
     }


### PR DESCRIPTION
> ⚠️ There is more E2E test information [here](https://github.com/elastic/beats/issues/29495#issuecomment-1011068200) in case you'd like to use the Heartbeat image built from source.

# Summary

This PR contributes to elastic/beats#29681 as it makes the `synthetics` runner work with the `ubuntu` images we will use.

After this PR, the Heartbeat container should be able to execute the `synthetics` runner.


# The problem in detail

The Heartbeat container wasn't able to run `synthetics` to completion, as the runner would hang indefinitely.

It couldn't do so because it didn't have the necessary graphics library ([`mesagl`](https://www.mesa3d.org/)) available to make hardware acceleration work ([more specifically, it seems Chromium uses `osmesa` for off-screen rendering](https://docs.mesa3d.org/osmesa.html)) and `newPage` not to hang if called too soon.

> ⚠️ The real problem here btw is not the lack of GL it seems, it's that the default GL used causes the `newPage` method to hang if we call it immediately after launching the browser. If we used `mesa` it seems that method would not hang, but I still have to manually test it.

**When that library wasn't available, and hardware acceleration was turned on, the creation of a new page would hang indefinitely if we _immediately_ tried to create a new page**. Just adding an `await new Promise(resolve => setTimeout(resolve, 5000))` statement after the browser launch did make journeys work given it caused `newPage` to return (instead of hanging).

**Therefore, I have disabled hardware acceleration by launching Chromium with the `--disable-gpu` flag, which makes it work fine in our Ubuntu image.** I decided to use that flag rather than changing the base image because [that's the exact fix that was applied in Playwright's master branch](https://github.com/microsoft/playwright/issues/4761).

> ⚠️ [You can see in this chromium mailing list thread that needing that flag to run within Linux containers is necessary](https://bugs.chromium.org/p/chromium/issues/detail?id=737678).


# How to test this PR

1. Build the Heartbeat image (your `cwd` must be the `x-pack/heartbeat` folder) using `env PLATFORMS="+all linux/amd64" mage package`
2. Run the image overwriting the `entrypoint` with a script similar to the one below
    ```
    #!/bin/bash
    docker run \
      -it \
      --entrypoint=/bin/bash \
      --rm \
      --name=heartbeat \
      --user=heartbeat \
      --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
      --volume="$PWD/monitors.d:/usr/share/heartbeat/monitors.d:ro" \
      --volume="/your_path_to_the_synthetics_module/synthetics:/usr/share/synthetics" \
      docker.elastic.co/beats/heartbeat:8.1.0
    ```
    This will execute the image you've just built.
3. Once inside the container, you can either build the mounted `synthetics` module and run `dist/cli.js` or `npm link` it, and then run `heartbeat`, which will cause it to use the locally linked module.

The process is the same for `elastic-agent`, just make sure you change the image name to `elastic-agent-complete`.


# How I debugged it (in case it's helpful for others in a next opportunity):

* When executing the runner within the container, do so through building a mounted directory and running `dist/cli.js` with `node` (whenever you change a file, make sure to `npm run build`)
* Expose the container's `9229` port through the docker arg `-p 9229:9229` so that you can connect to the Node debugger in `chrome://inspect` from `localhost` when running `node --inspect-brk=0.0.0.0 dist/cli.js my_synthetic_path` (this is how I figured out that just waiting would not make the process hang, because as I stepped through lines that was enough time for the browser to init itself)