### PR TITLE
chore: Add missing fields for action/context types

### DIFF
--- a/src/formatter/javascript.ts
+++ b/src/formatter/javascript.ts
@@ -35,6 +35,7 @@ export type ActionInContext = {
   isMainFrame: boolean;
   action: Action;
   committed?: boolean;
+  modified?: boolean;
   title?: string;
 };
 
@@ -47,6 +48,7 @@ type Action = {
   modifiers?: number;
   button?: 'left' | 'middle' | 'right';
   clickCount?: number;
+  text?: string;
   value?: string;
   isAssert?: boolean;
   command?: string;


### PR DESCRIPTION
As part of the work for https://github.com/elastic/synthetics-recorder/issues/85, these additional fields are required.

They're part of Playwright's output objects, and while they're not used in Synthetics we do use them downstream in the recorder.

Both fields added as optional, should be no measurable impact.