### PR TITLE
fix: capture ReferenceError inside journeys

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,7 +62,7 @@ const loadInlineScript = source => {
     'expect',
     source
   );
-  journey('inline', async ({ page, context, browser, params }) => {
+  journey('inline', ({ page, context, browser, params }) => {
     scriptFn.apply(null, [step, page, context, browser, params, expect]);
   });
 };


### PR DESCRIPTION
+ For inline journeys, the ReferenceErrors inside script was not captured as part of the journey error context. This PR fixes that behaviour and also adds tests. 
+ The issue was due to the fact that our inline journey function was `async`, which is wrong as the JourneyCallback is expected to register steps synchronously. 