### PR TITLE
Path to certs and command changed due to ubuntu

### DIFF
--- a/examples/todos/Dockerfile
+++ b/examples/todos/Dockerfile
@@ -18,9 +18,9 @@ ENV ELASTIC_SYNTHETICS_OFFLINE=true
 COPY heartbeat.docker.yml /usr/share/heartbeat/heartbeat.yml
 
 # Uncomment the lines below to add custom cert/CA to CA store if needed
-#COPY elasticsearch-ca.pem /usr/share/pki/ca-trust-source/anchors/
+#COPY elasticsearch-ca.pem /etc/ssl/certs
 #USER root
-#RUN /usr/bin/update-ca-trust
+#RUN update-ca-certificates
 #USER heartbeat
 
 RUN mkdir -p $SUITES_DIR/todos


### PR DESCRIPTION
The update-ca command changed since we updated our docker base images to ubuntu.

```
Step 5/6 : RUN /usr/bin/update-ca-trust
 ---> Running in c66a5970571e
/bin/sh: 1: /usr/bin/update-ca-trust: not found
ERROR: Service 'synthclient' failed to build: The command '/bin/sh -c /usr/bin/update-ca-trust' returned a non-zero code: 127
```

```
Step 5/6 : RUN update-ca-certificates
 ---> Running in dd3cdc5d5f78
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
```