### PR TITLE
feat: add inline e2e test for real world page

### DIFF
--- a/__tests__/e2e/package.json
+++ b/__tests__/e2e/package.json
@@ -13,6 +13,8 @@
   },
   "devDependencies": {
     "@elastic/synthetics": "file:../../",
-    "axios": "^0.21.0"
-  }
+    "axios": "^0.21.0",
+    "semver": "^7.3.5"
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Adds an inline browser monitor to test to Synthetics e2e tests.

This test is intended to replace the flaky test skipped here: https://github.com/elastic/synthetics/blob/main/__tests__/core/runner.test.ts#L701