### PR TITLE
fix: allow UA emulation when overriding

### DIFF
--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -129,11 +129,11 @@ describe('Gatherer', () => {
     it('works with device emulation', async () => {
       const driver = await Gatherer.setupDriver({
         wsEndpoint,
-        playwrightOptions: { ...devices['Galaxy S9+'] },
+        playwrightOptions: { ...devices['iPhone 12 Pro Max'] },
       });
-      expect(await driver.page.evaluate(() => navigator.userAgent)).toContain(
-        ' Elastic/Synthetics'
-      );
+      const userAgent = await driver.page.evaluate(() => navigator.userAgent);
+      expect(userAgent).toContain('Elastic/Synthetics');
+      expect(userAgent).toContain('iPhone');
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -65,7 +65,7 @@ export class Gatherer {
     return { browser: Gatherer.browser, context, page, client };
   }
 
-  static async getUserAgent(userAgent: string) {
+  static async getUserAgent(userAgent?: string) {
     const syntheticsIdentifier = ' Elastic/Synthetics';
     if (!userAgent) {
       const session = await Gatherer.browser.newBrowserCDPSession();

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -56,7 +56,7 @@ export class Gatherer {
     }
     const context = await Gatherer.browser.newContext({
       ...playwrightOptions,
-      userAgent: await Gatherer.getUserAgent(),
+      userAgent: await Gatherer.getUserAgent(playwrightOptions?.userAgent),
     });
     await Gatherer.setNetworkConditions(context, networkConditions);
 
@@ -65,10 +65,13 @@ export class Gatherer {
     return { browser: Gatherer.browser, context, page, client };
   }
 
-  static async getUserAgent() {
-    const session = await Gatherer.browser.newBrowserCDPSession();
-    const { userAgent } = await session.send('Browser.getVersion');
-    return userAgent + ' Elastic/Synthetics';
+  static async getUserAgent(userAgent: string) {
+    const syntheticsIdentifier = ' Elastic/Synthetics';
+    if (!userAgent) {
+      const session = await Gatherer.browser.newBrowserCDPSession();
+      ({ userAgent } = await session.send('Browser.getVersion'));
+    }
+    return userAgent + syntheticsIdentifier;
   }
 
   static async setNetworkConditions(


### PR DESCRIPTION
+ When users are overriding the useragent with  `--playwright-options` the UA was being overwritten in the agent code. This PR fixes that by using the UA passed to the agent. 
