### PR TITLE
fix: empty the write buffer before exit

### DIFF
--- a/src/reporters/base.ts
+++ b/src/reporters/base.ts
@@ -70,8 +70,13 @@ export default class BaseReporter {
      * before destroying the pipe with underlying file descriptor
      */
     this.stream = new SonicBoom({ fd: this.fd, sync: true, minLength: 1 });
-    this._registerListeners();
+
+    // flushSync is used here to make sure all the data from the underlying
+    // SonicBoom stream buffer is completely written to the fd before closing
+    // the process
     this.runner.on('end', () => this.stream.flush());
+
+    this._registerListeners();
   }
 
   _registerListeners() {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -343,7 +343,7 @@ export async function gatherScreenshots(
 }
 
 export default class JSONReporter extends BaseReporter {
-  _registerListeners() {
+  override _registerListeners() {
     /**
      * report the number of journeys that exists on a suite which
      * could be used for better sharding

--- a/src/reporters/junit.ts
+++ b/src/reporters/junit.ts
@@ -52,7 +52,7 @@ export default class JUnitReporter extends BaseReporter {
   private totalFailures = 0;
   private totalSkipped = 0;
 
-  _registerListeners() {
+  override _registerListeners() {
     const journeyMap = new Map<string, XMLEntry>();
 
     this.runner.on('journey:start', ({ journey }) => {

--- a/src/sdk/trace-processor.ts
+++ b/src/sdk/trace-processor.ts
@@ -111,7 +111,7 @@ export type LHProcessedTrace = {
  * metrics based on multiple navigations instead of a single navigation.
  */
 export class TraceProcessor extends LighthouseTraceProcessor {
-  static _isNavigationStartOfInterest(event) {
+  static override _isNavigationStartOfInterest(event) {
     return (
       event.name === 'navigationStart' &&
       (!event.args.data ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "incremental": true,
     "declarationMap": true,
+    "noImplicitOverride": true,
     "sourceMap": true,
     "outDir": "dist",
     "target": "es2018",


### PR DESCRIPTION
+ fix #446 
+ The max buffer capacity for SonicBoom is `64 * 1024` bytes and the API `flush` and `flushSync` behaves differently when it comes to writing the last data from the streams buffer.

+ `flush` API only writes the current element in the buffer which is always the first item and drops other data and closes the FD.
+ However `flushSync` ensures all the data from the buffer is completely written.

#### Example
```
// Previous - FLUSH Async
SONICBOOM: Data-0-65189
SONICBOOM: Data-1-29862
SONICBOOM: flush-95051
SONICBOOM: Writing-65189
-- Data 1 is completetly lost
- Runner closed

// Current - FlushSync
SONICBOOM: Data-0-61310
SONICBOOM: Data-1-53290
SONICBOOM: flushSync-114600
SONICBOOM: Writing-61310
SONICBOOM: Writing-53290
- Runner closed
```

- [ ] TODO - Add tests