### PR TITLE
Fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: git@github.com:pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
     -   id: check-case-conflict


### PR DESCRIPTION
We shouldn't use unauthenticated git anymore for pre-commit, this breaks things.