### PR TITLE
feat: location info for journey and step

### DIFF
--- a/__tests__/helper.test.ts
+++ b/__tests__/helper.test.ts
@@ -33,6 +33,7 @@ import {
   rewriteErrorStack,
   findPWLogsIndexes,
   microSecsToSeconds,
+  wrapFnWithLocation,
 } from '../src/helpers';
 
 it('indent message with seperator', () => {
@@ -132,4 +133,11 @@ it('does not rewrite non playwright errors', () => {
   const indexes = findPWLogsIndexes(normalStack);
   const newNormalStack = rewriteErrorStack(normalStack, indexes);
   expect(normalStack).toStrictEqual(newNormalStack);
+});
+
+it('location info on execution', () => {
+  const checkLoc = wrapFnWithLocation(location => {
+    return location;
+  });
+  expect(checkLoc().file).toBe(__filename);
 });

--- a/__tests__/helper.test.ts
+++ b/__tests__/helper.test.ts
@@ -139,5 +139,7 @@ it('location info on execution', () => {
   const checkLoc = wrapFnWithLocation(location => {
     return location;
   });
+  // line no and column no will not match as we are using
+  // ts-jest preset to transpile code.
   expect(checkLoc().file).toBe(__filename);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1800,7 +1800,8 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -5873,12 +5874,14 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -6151,9 +6154,9 @@
       }
     },
     "ts-node": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.5.0.tgz",
-      "integrity": "sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@cspotcode/source-map-support": "^0.7.0",
     "commander": "^9.0.0",
     "deepmerge": "^4.2.2",
     "expect": "^27.0.2",
@@ -48,8 +49,7 @@
     "sharp": "^0.30.1",
     "snakecase-keys": "^3.2.1",
     "sonic-boom": "^2.6.0",
-    "source-map-support": "^0.5.21",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.7.0",
     "typescript": "^4.5.5"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,7 +141,7 @@ async function prepareSuites(inputs: string[]) {
     compilerOptions: {
       esModuleInterop: true,
       allowJs: true,
-      target: 'es2018',
+      target: 'es2020',
     },
   });
 

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -36,13 +36,13 @@ import { Step } from './dsl';
 import { reporters } from './reporters';
 
 export type VoidCallback = () => void;
-export type Params = Record<string, any>;
-export type NetworkConditions = {
-  offline: boolean;
-  downloadThroughput: number;
-  uploadThroughput: number;
-  latency: number;
+export type Location = {
+  file: string;
+  line: number;
+  column: number;
 };
+
+export type Params = Record<string, any>;
 export type HooksArgs = {
   env: string;
   params: Params;
@@ -50,6 +50,13 @@ export type HooksArgs = {
 export type HooksCallback = (args: HooksArgs) => void;
 export type StatusValue = 'succeeded' | 'failed' | 'skipped';
 export type Reporters = keyof typeof reporters;
+
+export type NetworkConditions = {
+  offline: boolean;
+  downloadThroughput: number;
+  uploadThroughput: number;
+  latency: number;
+};
 
 export type Driver = {
   browser: ChromiumBrowser;

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -26,7 +26,7 @@
 import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
 import micromatch, { isMatch } from 'micromatch';
 import { Step } from './step';
-import { VoidCallback, HooksCallback, Params } from '../common_types';
+import { VoidCallback, HooksCallback, Params, Location } from '../common_types';
 
 export type JourneyOptions = {
   name: string;
@@ -49,18 +49,24 @@ export class Journey {
   id?: string;
   tags?: string[];
   callback: JourneyCallback;
+  location?: Location;
   steps: Step[] = [];
   hooks: Hooks = { before: [], after: [] };
 
-  constructor(options: JourneyOptions, callback: JourneyCallback) {
+  constructor(
+    options: JourneyOptions,
+    callback: JourneyCallback,
+    location?: Location
+  ) {
     this.name = options.name;
     this.id = options.id || options.name;
     this.tags = options.tags;
     this.callback = callback;
+    this.location = location;
   }
 
-  addStep(name: string, callback: VoidCallback) {
-    const step = new Step(name, this.steps.length + 1, callback);
+  addStep(name: string, callback: VoidCallback, location?: Location) {
+    const step = new Step(name, this.steps.length + 1, callback, location);
     this.steps.push(step);
     return step;
   }

--- a/src/dsl/step.ts
+++ b/src/dsl/step.ts
@@ -23,16 +23,23 @@
  *
  */
 
-import { VoidCallback } from '../common_types';
+import { Location, VoidCallback } from '../common_types';
 
 export class Step {
   name: string;
   index: number;
   callback: VoidCallback;
+  location?: Location;
 
-  constructor(name: string, index: number, callback: VoidCallback) {
+  constructor(
+    name: string,
+    index: number,
+    callback: VoidCallback,
+    location: Location
+  ) {
     this.name = name;
     this.index = index;
     this.callback = callback;
+    this.location = location;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,16 +25,8 @@
 
 import { runner } from './core';
 import { RunOptions } from './core/runner';
-import sourceMapSupport from 'source-map-support';
 
 export async function run(options: RunOptions) {
-  /**
-   * Install source map support
-   */
-  sourceMapSupport.install({
-    environment: 'node',
-  });
-
   try {
     return await runner.run(options);
   } catch (e) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "noImplicitOverride": true,
     "sourceMap": true,
     "outDir": "dist",
-    "target": "es2018",
+    "target": "es2020",
     "module": "commonjs"
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
+ Part of #470 
+ Adds `Location` metadata to the Journey and Step DSL which can be used for formatting the error location and pinpointing to the exact source on the test files. Location metadata is not used anywhere as it lays the foundation for pushing journeys to the monitor management. Will be used in the subsequent PR's. 
+ Sourcemap data was broken due to the discrepancies between `ts-node` which we use to transpile the journey files on the fly and the `source-map-support` library as both were looking in different places for the original source-maps. `ts-node` moved to a forked version of the library. More details here - https://github.com/cspotcode/node-source-map-support/issues/24