### PR TITLE
fix: e2e tests - adjust policy selection logic based on version

### DIFF
--- a/__tests__/e2e/synthetics.journey.ts
+++ b/__tests__/e2e/synthetics.journey.ts
@@ -64,8 +64,12 @@ async function selectAgentPolicy({ page }) {
   const hosts = await page.isVisible('text="Existing hosts"');
   if (hosts) {
     await page.click('text="Existing hosts"');
-    await page.click('[data-test-subj="agentPolicySelect"]');
-    await page.click('text="Elastic-Agent (elastic-package)"');
+    if (semver.satisfies(stackVersion, '>=8.2.0')) {
+      await page.click('[data-test-subj="agentPolicySelect"]');
+      await page.click('text="Elastic-Agent (elastic-package)"');
+    } else {
+      await page.selectOption('[data-test-subj="agentPolicySelect"]', { label: 'Elastic-Agent (elastic-package)' });
+    }
     await page.waitForSelector('text="Elastic-Agent (elastic-package)"');
   }
   await page.click('[data-test-subj="packagePolicyNameInput"]');


### PR DESCRIPTION
Elastic Synthetics e2e tests
--
Fleet changed the HTLM element for the agent policy selection in 8.2.0. This PR adjusts the agent policy selection logic to account for the differences in versions. 