### PR TITLE
feat: bundle and push all journeys to kibana

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -676,7 +676,7 @@ describe('runner', () => {
   it('runner - build monitors with local config', async () => {
     const j1 = new Journey({ name: 'j1' }, noop);
     const j2 = new Journey({ name: 'j2' }, noop);
-    j1.updateMonitor({ id: 'test-j1', schedule: '2m', locations: ['EU West'] });
+    j1.updateMonitor({ id: 'test-j1', schedule: 2, locations: ['EU West'] });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
     runner.addJourney(j2);
@@ -688,33 +688,31 @@ describe('runner', () => {
     expect(monitors[0].config).toEqual({
       id: 'test-j1',
       name: 'j1',
+      tags: [],
       locations: ['EU West'],
-      schedule: '2m',
-      throttling: {
-        download: 5,
-        latency: 20,
-        upload: 3,
-      },
+      schedule: 2,
+      params: undefined,
+      playwrightOptions: undefined,
+      throttling: { download: 5, latency: 20, upload: 3 },
     });
     expect(monitors[1].config).toMatchObject({
       locations: ['US East'],
-      schedule: '10m',
+      schedule: 10,
       throttling: { latency: 1000 },
     });
   });
 
   it('runner - build monitors with global config', async () => {
     runner.updateMonitor({
-      schedule: '5m',
-      throttling: {
-        download: 100,
-        upload: 50,
-      },
+      schedule: 5,
+      throttling: { download: 100, upload: 50 },
+      params: { env: 'test' },
+      playwrightOptions: { ignoreHTTPSErrors: true },
     });
 
-    const j1 = new Journey({ name: 'j1' }, noop);
+    const j1 = new Journey({ name: 'j1', tags: ['foo*'] }, noop);
     const j2 = new Journey({ name: 'j2' }, noop);
-    j1.updateMonitor({ id: 'test-j1', schedule: '2m', locations: ['EU West'] });
+    j1.updateMonitor({ id: 'test-j1', schedule: 2, locations: ['EU West'] });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
     runner.addJourney(j2);
@@ -726,17 +724,16 @@ describe('runner', () => {
     expect(monitors[0].config).toEqual({
       id: 'test-j1',
       name: 'j1',
+      tags: ['foo*'],
       locations: ['EU West'],
-      schedule: '2m',
-      throttling: {
-        download: 100,
-        latency: 20,
-        upload: 50,
-      },
+      schedule: 2,
+      params: { env: 'test' },
+      playwrightOptions: { ignoreHTTPSErrors: true },
+      throttling: { download: 100, latency: 20, upload: 50 },
     });
     expect(monitors[1].config).toMatchObject({
       locations: ['US East'],
-      schedule: '5m',
+      schedule: 5,
       throttling: { latency: 1000 },
     });
   });

--- a/__tests__/fixtures/example.journey.ts
+++ b/__tests__/fixtures/example.journey.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { journey, step } from '../../';
+import { journey, step } from '../../src/index';
 
 journey('example journey', ({ page, params }) => {
   step('go to test page', async () => {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -76,15 +76,15 @@ describe('options', () => {
   it('normalize monitor configs', () => {
     expect(normalizeOptions({ throttling: false })).toMatchObject({
       locations: ['US East'],
-      schedule: '10m',
+      schedule: 10,
       throttling: {},
     });
 
     expect(
-      normalizeOptions({ throttling: { download: 50 }, schedule: '2m' })
+      normalizeOptions({ throttling: { download: 50 }, schedule: 2 })
     ).toMatchObject({
       locations: ['US East'],
-      schedule: '2m',
+      schedule: 2,
       throttling: {
         download: 50,
         upload: 3,

--- a/__tests__/push/__snapshots__/plugin.test.ts.snap
+++ b/__tests__/push/__snapshots__/plugin.test.ts.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Plugin bundle jouneys 1`] = `
+"/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the \\"Software\\"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { beforeAll, journey, step } from '@elastic/synthetics';
+import axios from 'axios';
+
+beforeAll(async () => {
+  await waitForElasticSearch();
+  await waitForSyntheticsData();
+  await waitForKibana();
+});
+
+journey('E2e test synthetics', async ({ page }) => {
+  async function refreshUptimeApp() {
+    while (!(await page.$('div.euiBasicTable'))) {
+      await page.click('[data-test-subj=superDatePickerApplyTimeButton]', {
+        timeout: 60 * 1000,
+      });
+    }
+  }
+
+  step('Go to kibana uptime app', async () => {
+    await page.goto('http://localhost:5620/app/uptime', {
+      waitUntil: 'networkidle',
+    });
+  });
+
+  step('Check if there is table data', async () => {
+    await page.click('[data-test-subj=uptimeOverviewPage]', {
+      timeout: 60 * 1000,
+    });
+    await refreshUptimeApp();
+    await page.click('div.euiBasicTable', { timeout: 60 * 1000 });
+  });
+
+  step('Click on my monitor', async () => {
+    await page.click('[data-test-subj=monitor-page-link-my-monitor]');
+  });
+
+  step('It navigates to details page', async () => {
+    await page.click('[data-test-subj=uptimeMonitorPage]');
+  });
+});
+
+async function waitForSyntheticsData() {
+  console.log('Waiting for Synthetics to send data to ES for test monitor');
+  let status = false;
+
+  while (!status) {
+    try {
+      const { data } = await axios.post(
+        'http://localhost:9220/heartbeat-*/_search',
+        {
+          query: {
+            bool: {
+              filter: [
+                {
+                  term: {
+                    'monitor.id': 'my-monitor',
+                  },
+                },
+                {
+                  exists: {
+                    field: 'summary',
+                  },
+                },
+              ],
+            },
+          },
+        }
+      );
+
+      // we want some data in uptime app
+      status = data?.hits.total.value >= 2;
+    } catch (e) {}
+  }
+}
+
+async function waitForElasticSearch() {
+  console.log('Waiting for Elastic Search  to start');
+  let esStatus = false;
+
+  while (!esStatus) {
+    try {
+      const { data } = await axios.get('http://localhost:9220/_cluster/health');
+      esStatus = data?.status !== 'red';
+    } catch (e) {}
+  }
+}
+
+async function waitForKibana() {
+  console.log('Waiting for kibana server to start');
+
+  let esStatus = false;
+
+  while (!esStatus) {
+    try {
+      const { data } = await axios.get('http://localhost:5620/api/status');
+      esStatus = data?.status.overall.level === 'available';
+    } catch (e) {}
+  }
+}
+"
+`;

--- a/__tests__/push/__snapshots__/request.test.ts.snap
+++ b/__tests__/push/__snapshots__/request.test.ts.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Push api request format api error 1`] = `
-"[31m✖[39m [1mError[22m
-   [1m[31m✖[39m monitor creation failed - 401:Unauthorized
-   [22m    [security_exception: [security_exception] Reason: unable to authenticate user"
+"✖ Error
+   ✖ monitor creation failed - 401:Unauthorized
+       [security_exception: [security_exception] Reason: unable to authenticate user"
 `;
 
 exports[`Push api request format failed monitors 1`] = `
-"[31m✖[39m [1mError[22m
-   [1m> Failed to save or update monitor. Configuration is not valid: monitor(monitor-without-schedule)
-   [22m    Invalid value \\"undefined\\" supplied to \\"schedule\\"
+"✖ Error
+   > Failed to save or update monitor. Configuration is not valid: monitor(monitor-without-schedule)
+       Invalid value \\"undefined\\" supplied to \\"schedule\\"
 
-   [1m> Failed to save or update monitor. Configuration is not valid: monitor(monitor-without-id)
-   [22m    Invalid value \\"undefined\\" supplied to \\"id\\"
+   > Failed to save or update monitor. Configuration is not valid
+       Invalid value \\"undefined\\" supplied to \\"id\\"
 
 "
 `;
 
 exports[`Push api request stale monitor error 1`] = `
-"[1m[33m[33m⚠[39m[33m Found stale monitors
-[39m[22m   [90mPass --delete to remove all the stale monitors.[39m"
+"⚠ Found stale monitors
+   Pass --delete to remove all the stale monitors."
 `;

--- a/__tests__/push/__snapshots__/request.test.ts.snap
+++ b/__tests__/push/__snapshots__/request.test.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Push api request format api error 1`] = `
+"[31m✖[39m [1mError[22m
+   [1m[31m✖[39m monitor creation failed - 401:Unauthorized
+   [22m    [security_exception: [security_exception] Reason: unable to authenticate user"
+`;
+
+exports[`Push api request format failed monitors 1`] = `
+"[31m✖[39m [1mError[22m
+   [1m> Failed to save or update monitor. Configuration is not valid: monitor(monitor-without-schedule)
+   [22m    Invalid value \\"undefined\\" supplied to \\"schedule\\"
+
+   [1m> Failed to save or update monitor. Configuration is not valid: monitor(monitor-without-id)
+   [22m    Invalid value \\"undefined\\" supplied to \\"id\\"
+
+"
+`;
+
+exports[`Push api request stale monitor error 1`] = `
+"[1m[33m[33m⚠[39m[33m Found stale monitors
+[39m[22m   [90mPass --delete to remove all the stale monitors.[39m"
+`;

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -25,8 +25,8 @@
 
 import { join } from 'path';
 import { Monitor } from '../../src/dsl/monitor';
-import { createMonitorSchema } from '../../src/push/monitor';
-import { createMonitor } from '../../src/push/request';
+import { buildMonitorSchema } from '../../src/push/monitor';
+import { createMonitors } from '../../src/push/request';
 import { Server } from '../utils/server';
 
 const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
@@ -71,7 +71,7 @@ describe('Push', () => {
     );
 
     const monitor = createTestMonitor('example.journey.ts');
-    const schema = await createMonitorSchema([monitor]);
+    const schema = await buildMonitorSchema([monitor]);
     expect(schema[0]).toMatchObject({
       id: 'test-monitor',
       name: 'test',
@@ -79,7 +79,7 @@ describe('Push', () => {
       locations: ['europe-west2-a'],
       content: expect.any(String),
     });
-    const { statusCode, body } = await createMonitor(schema, {
+    const { statusCode, body } = await createMonitors(schema, {
       url: `${server.PREFIX}`,
       auth: 'foo:bar',
       project: 'blah',

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -1,0 +1,74 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { join } from 'path';
+import { Monitor } from '../../src/dsl/monitor';
+import { createSchema } from '../../src/push';
+import { createMonitor } from '../../src/push/request';
+import { createMockServer } from './mock-server';
+
+const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
+
+function createTestMonitor(filename: string) {
+  const monitor = new Monitor({
+    id: 'test-monitor',
+    name: 'test',
+    schedule: '10m',
+    locations: ['EU West'],
+  });
+  monitor.setSource({
+    file: join(FIXTURES_DIR, filename),
+    line: 0,
+    column: 0,
+  });
+  return monitor;
+}
+
+describe('Push', () => {
+  it('creates monitor', async () => {
+    const { url, close } = await createMockServer();
+    const monitor = createTestMonitor('example.journey.ts');
+    const schema = await createSchema([monitor]);
+    expect(schema[0]).toMatchObject({
+      id: 'test-monitor',
+      name: 'test',
+      schedule: '10m',
+      locations: ['EU West'],
+      content: expect.any(String),
+    });
+    const { statusCode, body } = await createMonitor(schema, {
+      url,
+      auth: 'foo:bar',
+    });
+    await close();
+
+    expect(statusCode).toBe(200);
+    let data = '';
+    for await (const chunk of body) {
+      data += chunk;
+    }
+    expect(JSON.parse(data)).toEqual(schema);
+  });
+});

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -23,25 +23,23 @@
  *
  */
 
-import { join } from 'path';
-import { Monitor } from '../../dist/dsl/monitor';
+import { buildMonitorSchema } from '../../src/push/monitor';
+import { createTestMonitor } from '../utils/test-config';
 
-export const wsEndpoint = process.env.WSENDPOINT;
-
-const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
-export function createTestMonitor(filename: string) {
-  const monitor = new Monitor({
-    id: 'test-monitor',
-    name: 'test',
-    schedule: 10,
-    enabled: true,
-    locations: ['EU West'],
+describe('Monitor schema', () => {
+  it('build monitor schema monitor', async () => {
+    const monitor = createTestMonitor('example.journey.ts');
+    const schema = await buildMonitorSchema([monitor]);
+    expect(schema[0]).toEqual({
+      id: 'test-monitor',
+      name: 'test',
+      schedule: 10,
+      enabled: true,
+      locations: ['europe-west2-a'],
+      content: expect.any(String),
+      filter: {
+        match: 'test',
+      },
+    });
   });
-  monitor.setSource({
-    file: join(FIXTURES_DIR, filename),
-    line: 0,
-    column: 0,
-  });
-  monitor.setFilter({ match: 'test' });
-  return monitor;
-}
+});

--- a/__tests__/push/plugin.test.ts
+++ b/__tests__/push/plugin.test.ts
@@ -23,25 +23,27 @@
  *
  */
 
+import * as esbuild from 'esbuild';
 import { join } from 'path';
-import { Monitor } from '../../dist/dsl/monitor';
+import {
+  MultiAssetPlugin,
+  commonOptions,
+  PluginData,
+} from '../../src/push/plugin';
 
-export const wsEndpoint = process.env.WSENDPOINT;
+const E2E_DIR = join(__dirname, '..', 'e2e');
 
-const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
-export function createTestMonitor(filename: string) {
-  const monitor = new Monitor({
-    id: 'test-monitor',
-    name: 'test',
-    schedule: 10,
-    enabled: true,
-    locations: ['EU West'],
+describe('Plugin', () => {
+  it('bundle jouneys', async () => {
+    const callback = (data: PluginData) => {
+      expect(data.path).toContain('e2e/uptime.journey.ts');
+      expect(data.contents).toMatchSnapshot();
+    };
+
+    await esbuild.build({
+      ...commonOptions(),
+      entryPoints: [join(E2E_DIR, 'uptime.journey.ts')],
+      plugins: [MultiAssetPlugin(callback)],
+    });
   });
-  monitor.setSource({
-    file: join(FIXTURES_DIR, filename),
-    line: 0,
-    column: 0,
-  });
-  monitor.setFilter({ match: 'test' });
-  return monitor;
-}
+});

--- a/__tests__/push/request.test.ts
+++ b/__tests__/push/request.test.ts
@@ -23,6 +23,8 @@
  *
  */
 
+process.env.NO_COLOR = '1';
+
 import { buildMonitorSchema } from '../../src/push/monitor';
 import {
   APIMonitorError,
@@ -42,6 +44,7 @@ describe('Push api request', () => {
   });
   afterAll(async () => {
     await server.close();
+    process.env.NO_COLOR = '';
   });
 
   it('api schema', async () => {
@@ -95,7 +98,6 @@ describe('Push api request', () => {
         details: `Invalid value "undefined" supplied to "schedule"`,
       },
       {
-        id: 'monitor-without-id',
         reason: 'Failed to save or update monitor. Configuration is not valid',
         details: `Invalid value "undefined" supplied to "id"`,
       },

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "^1.0.0-beta"
+    "@elastic/synthetics": "file:../../"
   },
   "devDependencies": {
     "node-static": "^0.7.11"

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "license": "MIT",
   "dependencies": {
-    "@elastic/synthetics": "file:../../"
+    "@elastic/synthetics": "^1.0.0-beta"
   },
   "devDependencies": {
     "node-static": "^0.7.11"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1755,6 +1755,22 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1776,6 +1792,12 @@
           }
         }
       }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1851,6 +1873,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1868,6 +1902,15 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
       "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
       "dev": true
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
     },
     "chalk": {
       "version": "4.1.1",
@@ -2286,6 +2329,15 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
       }
     },
     "electron-to-chromium": {
@@ -3031,6 +3083,29 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5233,6 +5308,12 @@
         }
       }
     },
+    "listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true
+    },
     "listr2": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.8.2.tgz",
@@ -5445,6 +5526,23 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.6"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+          "dev": true
+        }
+      }
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -6176,6 +6274,12 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
     "sharp": {
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
@@ -6570,6 +6674,12 @@
         "punycode": "^2.1.1"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
     "ts-jest": {
       "version": "27.1.2",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
@@ -6675,6 +6785,24 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1244,9 +1244,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.45.tgz",
-      "integrity": "sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw=="
+      "version": "14.18.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
+      "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -6664,6 +6664,11 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+    },
+    "undici": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1535,6 +1535,49 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "archiver": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
+      "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.0",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "are-we-there-yet": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
@@ -1569,6 +1612,11 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1988,6 +2036,29 @@
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
+    "compress-commons": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
+      "integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2023,6 +2094,36 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "crc-32": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.1.tgz",
+      "integrity": "sha512-Dn/xm/1vFFgs3nfrpEVScHoIslO9NZRITWGz/1E/St6u4xw99vfZzVkW0OSnzx2h9egej9xwMCEut6sqwokM/w==",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.3.1"
+      }
+    },
+    "crc32-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+      "integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+      "requires": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "create-require": {
@@ -2229,6 +2330,153 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "esbuild": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.27.tgz",
+      "integrity": "sha512-MZQt5SywZS3hA9fXnMhR22dv0oPGh6QtjJRIYbgL1AeqAoQZE+Qn5ppGYQAoHv/vq827flj4tIJ79Mrdiwk46Q==",
+      "requires": {
+        "esbuild-android-64": "0.14.27",
+        "esbuild-android-arm64": "0.14.27",
+        "esbuild-darwin-64": "0.14.27",
+        "esbuild-darwin-arm64": "0.14.27",
+        "esbuild-freebsd-64": "0.14.27",
+        "esbuild-freebsd-arm64": "0.14.27",
+        "esbuild-linux-32": "0.14.27",
+        "esbuild-linux-64": "0.14.27",
+        "esbuild-linux-arm": "0.14.27",
+        "esbuild-linux-arm64": "0.14.27",
+        "esbuild-linux-mips64le": "0.14.27",
+        "esbuild-linux-ppc64le": "0.14.27",
+        "esbuild-linux-riscv64": "0.14.27",
+        "esbuild-linux-s390x": "0.14.27",
+        "esbuild-netbsd-64": "0.14.27",
+        "esbuild-openbsd-64": "0.14.27",
+        "esbuild-sunos-64": "0.14.27",
+        "esbuild-windows-32": "0.14.27",
+        "esbuild-windows-64": "0.14.27",
+        "esbuild-windows-arm64": "0.14.27"
+      }
+    },
+    "esbuild-android-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.27.tgz",
+      "integrity": "sha512-LuEd4uPuj/16Y8j6kqy3Z2E9vNY9logfq8Tq+oTE2PZVuNs3M1kj5Qd4O95ee66yDGb3isaOCV7sOLDwtMfGaQ==",
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.27.tgz",
+      "integrity": "sha512-E8Ktwwa6vX8q7QeJmg8yepBYXaee50OdQS3BFtEHKrzbV45H4foMOeEE7uqdjGQZFBap5VAqo7pvjlyA92wznQ==",
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.27.tgz",
+      "integrity": "sha512-czw/kXl/1ZdenPWfw9jDc5iuIYxqUxgQ/Q+hRd4/3udyGGVI31r29LCViN2bAJgGvQkqyLGVcG03PJPEXQ5i2g==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.27.tgz",
+      "integrity": "sha512-BEsv2U2U4o672oV8+xpXNxN9bgqRCtddQC6WBh4YhXKDcSZcdNh7+6nS+DM2vu7qWIWNA4JbRG24LUUYXysimQ==",
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.27.tgz",
+      "integrity": "sha512-7FeiFPGBo+ga+kOkDxtPmdPZdayrSzsV9pmfHxcyLKxu+3oTcajeZlOO1y9HW+t5aFZPiv7czOHM4KNd0tNwCA==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.27.tgz",
+      "integrity": "sha512-8CK3++foRZJluOWXpllG5zwAVlxtv36NpHfsbWS7TYlD8S+QruXltKlXToc/5ZNzBK++l6rvRKELu/puCLc7jA==",
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.27.tgz",
+      "integrity": "sha512-qhNYIcT+EsYSBClZ5QhLzFzV5iVsP1YsITqblSaztr3+ZJUI+GoK8aXHyzKd7/CKKuK93cxEMJPpfi1dfsOfdw==",
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.27.tgz",
+      "integrity": "sha512-ESjck9+EsHoTaKWlFKJpPZRN26uiav5gkI16RuI8WBxUdLrrAlYuYSndxxKgEn1csd968BX/8yQZATYf/9+/qg==",
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.27.tgz",
+      "integrity": "sha512-JnnmgUBdqLQO9hoNZQqNHFWlNpSX82vzB3rYuCJMhtkuaWQEmQz6Lec1UIxJdC38ifEghNTBsF9bbe8dFilnCw==",
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.27.tgz",
+      "integrity": "sha512-no6Mi17eV2tHlJnqBHRLekpZ2/VYx+NfGxKcBE/2xOMYwctsanCaXxw4zapvNrGE9X38vefVXLz6YCF8b1EHiQ==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.27.tgz",
+      "integrity": "sha512-NolWP2uOvIJpbwpsDbwfeExZOY1bZNlWE/kVfkzLMsSgqeVcl5YMen/cedRe9mKnpfLli+i0uSp7N+fkKNU27A==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.27.tgz",
+      "integrity": "sha512-/7dTjDvXMdRKmsSxKXeWyonuGgblnYDn0MI1xDC7J1VQXny8k1qgNp6VmrlsawwnsymSUUiThhkJsI+rx0taNA==",
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.27.tgz",
+      "integrity": "sha512-D+aFiUzOJG13RhrSmZgrcFaF4UUHpqj7XSKrIiCXIj1dkIkFqdrmqMSOtSs78dOtObWiOrFCDDzB24UyeEiNGg==",
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.27.tgz",
+      "integrity": "sha512-CD/D4tj0U4UQjELkdNlZhQ8nDHU5rBn6NGp47Hiz0Y7/akAY5i0oGadhEIg0WCY/HYVXFb3CsSPPwaKcTOW3bg==",
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.27.tgz",
+      "integrity": "sha512-h3mAld69SrO1VoaMpYl3a5FNdGRE/Nqc+E8VtHOag4tyBwhCQXxtvDDOAKOUQexBGca0IuR6UayQ4ntSX5ij1Q==",
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.27.tgz",
+      "integrity": "sha512-xwSje6qIZaDHXWoPpIgvL+7fC6WeubHHv18tusLYMwL+Z6bEa4Pbfs5IWDtQdHkArtfxEkIZz77944z8MgDxGw==",
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.27.tgz",
+      "integrity": "sha512-/nBVpWIDjYiyMhuqIqbXXsxBc58cBVH9uztAOIfWShStxq9BNBik92oPQPJ57nzWXRNKQUEFWr4Q98utDWz7jg==",
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.27.tgz",
+      "integrity": "sha512-Q9/zEjhZJ4trtWhFWIZvS/7RUzzi8rvkoaS9oiizkHTTKd8UxFwn/Mm2OywsAfYymgUYm8+y2b+BKTNEFxUekw==",
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.27.tgz",
+      "integrity": "sha512-b3y3vTSl5aEhWHK66ngtiS/c6byLf6y/ZBvODH1YkBM+MGtVL6jN38FdHUsZasCz9gFwYs/lJMVY9u7GL6wfYg==",
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.27.tgz",
+      "integrity": "sha512-I/reTxr6TFMcR5qbIkwRGvldMIaiBu2+MP0LlD7sOlNXrfqIl9uNjsuxFPGEG4IRomjfQ5q8WT+xlF/ySVkqKg==",
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -2558,6 +2806,11 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "expand-template": {
       "version": "2.0.3",
@@ -4902,6 +5155,14 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
+    "lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5017,6 +5278,26 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5028,6 +5309,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -5209,8 +5495,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -5622,6 +5907,11 @@
         }
       }
     },
+    "printj": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.3.1.tgz",
+      "integrity": "sha512-GA3TdL8szPK4AQ2YnOe/b+Y1jUFwmmGMMK/qbY7VcE3Z7FU8JstbKiKRzO6CIiAKPhTO8m01NoQ0V5f3jc4OGg=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5727,6 +6017,14 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdir-glob": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+      "integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+      "requires": {
+        "minimatch": "^3.0.4"
       }
     },
     "regexpp": {
@@ -6616,6 +6914,28 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zip-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+      "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
   "license": "MIT",
   "dependencies": {
     "@cspotcode/source-map-support": "^0.7.0",
+    "archiver": "^5.3.0",
     "commander": "^9.0.0",
     "deepmerge": "^4.2.2",
+    "esbuild": "^0.14.27",
     "expect": "^27.0.2",
     "http-proxy": "^1.18.1",
     "kleur": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -53,12 +53,13 @@
     "snakecase-keys": "^3.2.1",
     "sonic-boom": "^2.6.0",
     "ts-node": "^10.7.0",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "undici": "^5.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/micromatch": "^4.0.1",
-    "@types/node": "^14.14.14",
+    "@types/node": "^14.17.5",
     "@types/sharp": "^0.28.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "lint-staged": "^10.5.3",
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",
-    "ts-jest": "^27.1.2"
+    "ts-jest": "^27.1.2",
+    "unzipper": "^0.10.11"
   },
   "engines": {
     "node": ">14.14.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import { normalizeOptions, parseThrottling } from './options';
 import { loadTestFiles } from './loader';
 import { run } from './';
 import { runner } from './core';
+import { SyntheticsLocations } from './dsl/monitor';
 import { push } from './push';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
@@ -149,9 +150,15 @@ program
     '--schedule <time>',
     "The default interval for the pushed monitors. Setting `10m`, for example, configures monitors which don't have a specified interval defined to run every 10 minutes."
   )
-  .option(
-    '--locations <locations...>',
-    'The default list of locations from which your monitors will run.'
+  .addOption(
+    new Option(
+      '--locations <locations...>',
+      'The default list of locations from which your monitors will run.'
+    ).choices(SyntheticsLocations)
+  )
+  .requiredOption(
+    '--project <id/name>',
+    'project/repository that is used for grouping the pushed monitors.'
   )
   .requiredOption('--url <url>', 'kibana URL to upload the monitors')
   .requiredOption(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,8 +158,8 @@ program
       const cliArgs = { inline: false };
       await loadTestFiles(cliArgs, files);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
-      runner.buildMonitors(options);
-      await push();
+      const monitors = runner.buildMonitors(options);
+      await push(monitors);
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,6 +158,12 @@ program
     '--auth <auth>',
     'user authentication/API key that will be used to communicate with Kibana.'
   )
+  .option(
+    '--space <space>',
+    'kibana spaces that helps you to organize the pushed monitors.',
+    'default'
+  )
+  .option('--delete', 'automatically delete the stale monitors.')
   .action(async (files, cmdOpts: PushOptions) => {
     try {
       const cliArgs = { inline: false };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@
  */
 
 import { program, Option } from 'commander';
-import { CliArgs } from './common_types';
+import { CliArgs, PushOptions } from './common_types';
 import { reporters } from './reporters';
 import { normalizeOptions, parseThrottling } from './options';
 import { loadTestFiles } from './loader';
@@ -153,13 +153,18 @@ program
     '--locations <locations...>',
     'The default list of locations from which your monitors will run.'
   )
-  .action(async (files, cmdOpts) => {
+  .requiredOption('--url <url>', 'kibana URL to upload the monitors')
+  .requiredOption(
+    '--auth <auth>',
+    'user authentication/API key that will be used to communicate with Kibana.'
+  )
+  .action(async (files, cmdOpts: PushOptions) => {
     try {
       const cliArgs = { inline: false };
       await loadTestFiles(cliArgs, files);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
       const monitors = runner.buildMonitors(options);
-      await push(monitors);
+      await push(cmdOpts, monitors);
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,7 +159,7 @@ program
   )
   .requiredOption(
     '--project <id/name>',
-    'project/repository that is used for grouping the pushed monitors.'
+    'project/repository that will be used for grouping the monitors.'
   )
   .requiredOption('--url <url>', 'kibana URL to upload the monitors')
   .requiredOption(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,8 +147,9 @@ program
     'Push monitors to create new montors with Kibana monitor management UI'
   )
   .option(
-    '--schedule <time>',
-    "The default interval for the pushed monitors. Setting `10m`, for example, configures monitors which don't have a specified interval defined to run every 10 minutes."
+    '--schedule <time-in-minutes>',
+    "schedule in minutes for the pushed monitors. Setting `10`, for example, configures monitors which don't have a specified interval defined to run every 10 minutes.",
+    parseInt
   )
   .addOption(
     new Option(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,7 +148,7 @@ program
   )
   .option(
     '--schedule <time-in-minutes>',
-    "schedule in minutes for the pushed monitors. Setting `10`, for example, configures monitors which don't have a specified interval defined to run every 10 minutes.",
+    "schedule in minutes for the pushed monitors. Setting `10`, for example, configures monitors which don't have an interval defined to run every 10 minutes.",
     parseInt
   )
   .addOption(
@@ -164,11 +164,11 @@ program
   .requiredOption('--url <url>', 'kibana URL to upload the monitors')
   .requiredOption(
     '--auth <auth>',
-    'user authentication/API key that will be used to communicate with Kibana.'
+    'user authentication (in user:password format) or API key that will be used to communicate with Kibana.'
   )
   .option(
     '--space <space>',
-    'kibana spaces that helps you to organize the pushed monitors.',
+    'the target Kibana spaces for the pushed monitors — spaces help you organise pushed monitors.',
     'default'
   )
   .option('--delete', 'automatically delete the stale monitors.')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -164,7 +164,7 @@ program
       await loadTestFiles(cliArgs, files);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
       const monitors = runner.buildMonitors(options);
-      await push(cmdOpts, monitors);
+      await push(monitors, cmdOpts);
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import { normalizeOptions, parseThrottling } from './options';
 import { loadTestFiles } from './loader';
 import { run } from './';
 import { runner } from './core';
+import { push } from './push';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
@@ -158,7 +159,7 @@ program
       await loadTestFiles(cliArgs, files);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
       runner.buildMonitors(options);
-      // TODO: Push logic will be implemented in follow up PR's
+      await push();
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -33,7 +33,7 @@ import {
 } from 'playwright-chromium';
 import { Step } from './dsl';
 import { BuiltInReporterName, ReporterInstance } from './reporters';
-import { Monitor, MonitorConfig } from './dsl/monitor';
+import { MonitorConfig } from './dsl/monitor';
 
 export type VoidCallback = () => void;
 export type Location = {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -33,7 +33,7 @@ import {
 } from 'playwright-chromium';
 import { Step } from './dsl';
 import { BuiltInReporterName, ReporterInstance } from './reporters';
-import { MonitorConfig } from './dsl/monitor';
+import { Monitor, MonitorConfig } from './dsl/monitor';
 
 export type VoidCallback = () => void;
 export type Location = {
@@ -208,7 +208,7 @@ type BaseArgs = {
   playwrightOptions?: PlaywrightOptions;
   quietExitCode?: boolean;
   throttling?: ThrottlingOptions;
-  schedule?: string;
+  schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
 };
 
@@ -244,7 +244,7 @@ export type PushOptions = {
   project: string;
   space: string;
   delete: boolean;
-  schedule?: string;
+  schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
 };
 

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -33,7 +33,7 @@ import {
 } from 'playwright-chromium';
 import { Step } from './dsl';
 import { BuiltInReporterName, ReporterInstance } from './reporters';
-import { MonitorConfig, SyntheticsLocations } from './dsl/monitor';
+import { MonitorConfig } from './dsl/monitor';
 
 export type VoidCallback = () => void;
 export type Location = {
@@ -209,7 +209,7 @@ type BaseArgs = {
   quietExitCode?: boolean;
   throttling?: ThrottlingOptions;
   schedule?: string;
-  locations?: SyntheticsLocations[];
+  locations?: MonitorConfig['locations'];
 };
 
 export type CliArgs = BaseArgs & {
@@ -241,10 +241,11 @@ export type RunOptions = BaseArgs & {
 export type PushOptions = {
   auth: string;
   url: string;
+  project: string;
   space: string;
   delete: boolean;
   schedule?: string;
-  locations?: SyntheticsLocations[];
+  locations?: MonitorConfig['locations'];
 };
 
 export type PlaywrightOptions = LaunchOptions & BrowserContextOptions;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -239,10 +239,12 @@ export type RunOptions = BaseArgs & {
 };
 
 export type PushOptions = {
-  schedule?: string;
-  locations?: SyntheticsLocations[];
   auth: string;
   url: string;
+  space: string;
+  delete: boolean;
+  schedule?: string;
+  locations?: SyntheticsLocations[];
 };
 
 export type PlaywrightOptions = LaunchOptions & BrowserContextOptions;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -238,6 +238,13 @@ export type RunOptions = BaseArgs & {
   reporter?: BuiltInReporterName | ReporterInstance;
 };
 
+export type PushOptions = {
+  schedule?: string;
+  locations?: SyntheticsLocations[];
+  auth: string;
+  url: string;
+};
+
 export type PlaywrightOptions = LaunchOptions & BrowserContextOptions;
 export type SyntheticsConfig = {
   params?: Params;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -393,6 +393,8 @@ export default class Runner {
       throttling: options.throttling,
       schedule: options.schedule,
       locations: options.locations,
+      params: options.params,
+      playwrightOptions: options.playwrightOptions,
     });
 
     const monitors: Monitor[] = [];

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -65,7 +65,7 @@ export class Journey {
     this.tags = options.tags;
     this.callback = callback;
     this.location = location;
-    this.monitor = new Monitor({ name: this.name, id: this.id });
+    this.updateMonitor({});
   }
 
   addStep(name: string, callback: VoidCallback, location?: Location) {
@@ -83,6 +83,7 @@ export class Journey {
      * Use defaults values from journey for monitor like `name` and `id`
      */
     this.monitor = new Monitor({ name: this.name, id: this.id, ...config });
+    this.monitor.setSource(this.location);
   }
 
   /**

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -80,10 +80,16 @@ export class Journey {
 
   updateMonitor(config: MonitorConfig) {
     /**
-     * Use defaults values from journey for monitor like `name` and `id`
+     * Use defaults values from journey for monitor object (id, name and tags)
      */
-    this.monitor = new Monitor({ name: this.name, id: this.id, ...config });
+    this.monitor = new Monitor({
+      name: this.name,
+      id: this.id,
+      tags: this.tags ?? [],
+      ...config,
+    });
     this.monitor.setSource(this.location);
+    this.monitor.setFilter({ match: this.name });
   }
 
   /**

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -24,7 +24,7 @@
  */
 
 import merge from 'deepmerge';
-import { ThrottlingOptions } from '../common_types';
+import { ThrottlingOptions, Location } from '../common_types';
 
 export type SyntheticsLocations = 'US East' | 'EU West';
 export type MonitorConfig = {
@@ -36,6 +36,7 @@ export type MonitorConfig = {
 };
 
 export class Monitor {
+  source?: Location;
   constructor(public config: MonitorConfig = {}) {}
   /**
    * Treat the creation time config with `monitor.use` as source of truth by
@@ -47,5 +48,9 @@ export class Monitor {
         return [...new Set(source)];
       },
     });
+  }
+
+  setSource(source: Location) {
+    this.source = source;
   }
 }

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -32,13 +32,14 @@ import {
   PlaywrightOptions,
 } from '../common_types';
 
-export type SyntheticsLocations = 'US East' | 'EU West';
+export const SyntheticsLocations = ['US East', 'EU West'] as const;
+export type SyntheticsLocationsType = typeof SyntheticsLocations[number];
 export type MonitorConfig = {
   id?: string;
   name?: string;
   schedule?: string;
   enabled?: boolean;
-  locations?: SyntheticsLocations[];
+  locations?: SyntheticsLocationsType[];
   throttling?: ThrottlingOptions;
   screenshot?: ScreenshotOptions;
   params?: Params;

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -37,7 +37,8 @@ export type SyntheticsLocationsType = typeof SyntheticsLocations[number];
 export type MonitorConfig = {
   id?: string;
   name?: string;
-  schedule?: string;
+  tags?: string[];
+  schedule?: number;
   enabled?: boolean;
   locations?: SyntheticsLocationsType[];
   throttling?: ThrottlingOptions;
@@ -46,8 +47,14 @@ export type MonitorConfig = {
   playwrightOptions?: PlaywrightOptions;
 };
 
+type MonitorFilter = {
+  match: string;
+  tags?: string[];
+};
+
 export class Monitor {
   source?: Location;
+  filter: MonitorFilter;
   constructor(public config: MonitorConfig = {}) {}
   /**
    * Treat the creation time config with `monitor.use` as source of truth by
@@ -63,5 +70,14 @@ export class Monitor {
 
   setSource(source: Location) {
     this.source = source;
+  }
+  /**
+   * If journey files are colocated within the same file during
+   * push command, when we invoke synthetics from HB we rely on
+   * this filter for running that specific journey alone instead of
+   * all journeys on the file
+   */
+  setFilter(filter: MonitorFilter) {
+    this.filter = filter;
   }
 }

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -24,15 +24,25 @@
  */
 
 import merge from 'deepmerge';
-import { ThrottlingOptions, Location } from '../common_types';
+import {
+  ThrottlingOptions,
+  Location,
+  ScreenshotOptions,
+  Params,
+  PlaywrightOptions,
+} from '../common_types';
 
 export type SyntheticsLocations = 'US East' | 'EU West';
 export type MonitorConfig = {
   id?: string;
   name?: string;
   schedule?: string;
+  enabled?: boolean;
   locations?: SyntheticsLocations[];
   throttling?: ThrottlingOptions;
+  screenshot?: ScreenshotOptions;
+  params?: Params;
+  playwrightOptions?: PlaywrightOptions;
 };
 
 export class Monitor {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -61,6 +61,7 @@ const NO_UTF8_SUPPORT = process.platform === 'win32';
 export const symbols = {
   warning: yellow(NO_UTF8_SUPPORT ? '!' : '⚠'),
   skipped: cyan('-'),
+  progress: cyan('>'),
   succeeded: green(NO_UTF8_SUPPORT ? 'ok' : '✓'),
   failed: red(NO_UTF8_SUPPORT ? 'x' : '✖'),
 };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -81,7 +81,7 @@ export async function loadTestFiles(options: CliArgs, args: string[]) {
    */
   const files =
     args.length > 0 ? args : (await readStdin()).split('\n').filter(Boolean);
-  const suites = await prepareSuites(files, options);
+  const suites = await prepareSuites(files, options.pattern);
   requireSuites(suites);
 }
 
@@ -123,7 +123,7 @@ function requireSuites(suites: Iterable<string>) {
  * Handle both directory and files that are passed through TTY
  * and add them to suites
  */
-async function prepareSuites(inputs: string[], cliArgs: CliArgs) {
+async function prepareSuites(inputs: string[], filePattern?: string) {
   const suites = new Set<string>();
   const addSuite = absPath => {
     log(`Processing file: ${absPath}`);
@@ -133,8 +133,8 @@ async function prepareSuites(inputs: string[], cliArgs: CliArgs) {
    * Match all files inside the directory with the
    * .journey.{mjs|cjs|js|ts) extensions
    */
-  const pattern = cliArgs.pattern
-    ? new RegExp(cliArgs.pattern, 'i')
+  const pattern = filePattern
+    ? new RegExp(filePattern, 'i')
     : /.+\.journey\.([mc]js|[jt]s?)$/;
   /**
    * Ignore node_modules by default when running suites

--- a/src/options.ts
+++ b/src/options.ts
@@ -142,7 +142,7 @@ export function getDefaultMonitorConfig(): MonitorConfig {
   return {
     throttling: DEFAULT_THROTTLING_OPTIONS,
     locations: ['US East'],
-    schedule: '10m',
+    schedule: 10,
   };
 }
 

--- a/src/push/bundler.ts
+++ b/src/push/bundler.ts
@@ -83,7 +83,9 @@ export class Bundler {
   async build(entry: string, output: string) {
     await this.prepare(entry);
     await this.zip(output);
-    return this.encode(output);
+    const data = this.encode(output);
+    await this.cleanup(output);
+    return data;
   }
 
   async encode(outputPath: string) {

--- a/src/push/bundler.ts
+++ b/src/push/bundler.ts
@@ -1,0 +1,98 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import path from 'path';
+import fs, { unlink } from 'fs/promises';
+import { createWriteStream } from 'fs';
+import * as esbuild from 'esbuild';
+import archiver from 'archiver';
+import { commonOptions, Plugin, PluginData } from './plugin';
+
+function relativeToCwd(entry: string) {
+  return path.relative(process.cwd(), entry);
+}
+
+export class Bundler {
+  moduleMap = new Map<string, string>();
+  constructor() {}
+
+  async prepare(absPath: string) {
+    const addToMap = (data: PluginData) => {
+      this.moduleMap.set(data.path, data.contents);
+    };
+
+    const options: esbuild.BuildOptions = {
+      ...commonOptions(),
+      ...{
+        entryPoints: {
+          [absPath]: absPath,
+        },
+        plugins: [Plugin(addToMap)],
+      },
+    };
+    try {
+      const result = await esbuild.build(options);
+      if (result.errors.length > 0) {
+        throw result.errors;
+      }
+      this.moduleMap.set(absPath, result.outputFiles[0].text);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  zip(outputPath: string) {
+    return new Promise((fulfill, reject) => {
+      const output = createWriteStream(outputPath);
+      const archive = archiver('zip', {
+        zlib: { level: 9 },
+      });
+      archive.on('error', err => reject(err));
+      output.on('close', fulfill);
+      archive.pipe(output);
+      for (const [path, content] of this.moduleMap.entries()) {
+        const relativePath = relativeToCwd(path);
+        archive.append(content, { name: relativePath });
+      }
+      archive.finalize();
+    });
+  }
+
+  async build(entry: string, output: string) {
+    await this.prepare(entry);
+    await this.zip(output);
+    return this.encode(output);
+  }
+
+  async encode(outputPath: string) {
+    const encoded = await fs.readFile(outputPath, 'base64');
+    return encoded.toString();
+  }
+
+  async cleanup(outputPath: string) {
+    this.moduleMap = new Map<string, string>();
+    await unlink(outputPath);
+  }
+}

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -1,0 +1,59 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { green, cyan } from 'kleur/colors';
+import { Bundler } from './bundler';
+import { runner } from '../core';
+import { mkdir } from 'fs/promises';
+import { join } from 'path';
+import { CACHE_PATH } from '../helpers';
+
+function write(message) {
+  process.stderr.write(green(message) + '\n');
+}
+
+function progress(message) {
+  process.stderr.write(cyan(message) + '\n');
+}
+
+export async function push() {
+  if (runner.journeys.length == 0) {
+    throw new Error('No Monitors found');
+  }
+  const bundler = new Bundler();
+  // Create bundles path to be able to create journey artificats
+  const bundlePath = join(CACHE_PATH, 'bundles');
+  await mkdir(bundlePath, { recursive: true });
+
+  for (const journey of runner.journeys) {
+    const { name, location } = journey;
+    const outPath = join(bundlePath, name + '.zip');
+    progress(`Preparing journey: ${name}`);
+    const value = await bundler.build(location.file, outPath);
+    console.log('Bundled', value);
+    await bundler.cleanup(outPath);
+  }
+  write('Done');
+}

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -24,46 +24,21 @@
  */
 
 import { cyan, red } from 'kleur/colors';
-import { mkdir } from 'fs/promises';
-import { join } from 'path';
-import { Bundler } from './bundler';
-import { createMonitor, MonitorSchema } from './request';
-import { CACHE_PATH } from '../helpers';
+import { createMonitor } from './request';
 import { Monitor } from '../dsl/monitor';
 import { PushOptions } from '../common_types';
+import { createMonitorSchema } from './monitor';
 
 function progress(message) {
-  process.stderr.write(cyan(message) + '\n');
+  process.stderr.write(`> ${cyan(message)} \n`);
 }
 
 function error(message) {
   process.stderr.write(red(message) + '\n');
 }
 
-export async function createSchema(monitors: Monitor[]) {
-  if (monitors.length == 0) {
-    throw new Error('No Monitors found');
-  }
-  /**
-   * Set up the bundle artifacts path which can be used to
-   * create the bundles required for uploading journeys
-   */
-  const bundlePath = join(CACHE_PATH, 'bundles');
-  await mkdir(bundlePath, { recursive: true });
-  const bundler = new Bundler();
-  const schemas: MonitorSchema[] = [];
-
-  for (const monitor of monitors) {
-    const { source, config } = monitor;
-    const outPath = join(bundlePath, config.name + '.zip');
-    const content = await bundler.build(source.file, outPath);
-    schemas.push({ ...config, content });
-  }
-  return schemas;
-}
-
 export async function push(monitors: Monitor[], options: PushOptions) {
-  const schemas = await createSchema(monitors);
+  const schemas = await createMonitorSchema(monitors);
   progress(`preparing all monitors`);
   try {
     progress(`creating all monitors`);

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -49,7 +49,7 @@ function translateLocation(locations: MonitorConfig['locations']) {
   return locations.map(loc => LocationsMap[loc]).filter(Boolean);
 }
 
-export async function createMonitorSchema(monitors: Monitor[]) {
+export async function buildMonitorSchema(monitors: Monitor[]) {
   if (monitors.length == 0) {
     throw new Error('No Monitors found');
   }
@@ -73,6 +73,5 @@ export async function createMonitorSchema(monitors: Monitor[]) {
       filter: filter,
     });
   }
-  schemas.forEach(console.log);
   return schemas;
 }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -36,6 +36,7 @@ import {
 export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
   content: string;
   locations: string[];
+  filter: Monitor['filter'];
 };
 
 // Internal representation of Locations that would be used when
@@ -62,14 +63,16 @@ export async function createMonitorSchema(monitors: Monitor[]) {
   const schemas: MonitorSchema[] = [];
 
   for (const monitor of monitors) {
-    const { source, config } = monitor;
+    const { source, config, filter } = monitor;
     const outPath = join(bundlePath, config.name + '.zip');
     const content = await bundler.build(source.file, outPath);
     schemas.push({
       ...config,
       content,
       locations: translateLocation(config.locations),
+      filter: filter,
     });
   }
+  schemas.forEach(console.log);
   return schemas;
 }

--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -1,0 +1,113 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import path from 'path';
+import fs from 'fs/promises';
+import * as esbuild from 'esbuild';
+
+export function commonOptions(): esbuild.BuildOptions {
+  return {
+    bundle: true,
+    external: ['@elastic/synthetics'],
+    minify: false,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    outExtension: {
+      '.js': '.js',
+    },
+  };
+}
+
+export type PluginData = {
+  path: string;
+  contents: string;
+};
+export type PluginCallback = (data: PluginData) => void;
+
+export function Plugin(callback: PluginCallback): esbuild.Plugin {
+  const isBare = (str: string) => {
+    if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../')) {
+      return true;
+    }
+    return false;
+  };
+
+  return {
+    name: 'esbuild-multiasset-plugin',
+    setup(build) {
+      build.onResolve({ filter: /.*?/ }, async args => {
+        // External and other packages need be marked external to
+        // be removed from the bundle
+        if (
+          build.initialOptions.external?.includes(args.path) ||
+          !isBare(args.path)
+        ) {
+          return {
+            external: true,
+          };
+        }
+
+        if (args.kind === 'entry-point') {
+          return {
+            path: args.path,
+            namespace: 'asset',
+          };
+        }
+
+        // If the modules are resolved locally, then
+        // use the imported path to get full path
+        const entryPath =
+          path.join(path.dirname(args.importer), args.path) +
+          path.extname(args.importer);
+        // Spin off another build to copy over the imported modules without bundling
+        const result = await esbuild.build({
+          ...commonOptions(),
+          entryPoints: {
+            [entryPath]: entryPath,
+          },
+          bundle: false,
+          external: [],
+        });
+
+        callback({
+          path: entryPath,
+          contents: result.outputFiles[0].text,
+        });
+
+        return {
+          errors: result.errors,
+          external: true,
+        };
+      });
+
+      build.onLoad({ filter: /.*?/, namespace: 'asset' }, async args => {
+        const contents = await fs.readFile(args.path, 'utf-8');
+        callback({ path: args.path, contents });
+        return { contents };
+      });
+    },
+  };
+}

--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -47,7 +47,7 @@ export type PluginData = {
 };
 export type PluginCallback = (data: PluginData) => void;
 
-export function Plugin(callback: PluginCallback): esbuild.Plugin {
+export function MultiAssetPlugin(callback: PluginCallback): esbuild.Plugin {
   const isBare = (str: string) => {
     if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../')) {
       return true;

--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -30,7 +30,7 @@ import * as esbuild from 'esbuild';
 export function commonOptions(): esbuild.BuildOptions {
   return {
     bundle: true,
-    external: ['@elastic/synthetics'],
+    external: ['node_modules', '@elastic/synthetics'],
     minify: false,
     platform: 'node',
     format: 'esm',

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -25,10 +25,15 @@
 
 import { request } from 'undici';
 import { PushOptions } from '../common_types';
-import { MonitorConfig } from '../dsl/monitor';
+import { MonitorSchema } from './monitor';
 
-export type MonitorSchema = MonitorConfig & {
-  content: string;
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { version } = require('../../package.json');
+
+export type APISchema = {
+  space: string;
+  keep_stale: boolean;
+  monitors: MonitorSchema[];
 };
 
 function encodeAuth(auth: string) {
@@ -42,13 +47,19 @@ export async function createMonitor(
   monitors: MonitorSchema[],
   options: PushOptions
 ) {
+  const schema: APISchema = {
+    space: options.space,
+    keep_stale: !options.delete,
+    monitors,
+  };
+
   return await request(options.url, {
     method: 'POST',
-    body: JSON.stringify(monitors),
+    body: JSON.stringify(schema),
     headers: {
       authorization: `Basic ${encodeAuth(options.auth)}`,
       'content-type': 'application/json',
-      'user-agent': 'Elastic/Synthetics',
+      'user-agent': `Elastic/Synthetics ${version}`,
     },
   });
 }

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -77,7 +77,7 @@ export async function createMonitors(
   });
 }
 
-type APIMonitorError = {
+export type APIMonitorError = {
   id: string;
   reason: string;
   details: string;
@@ -111,7 +111,7 @@ export function formatFailedMonitors(errors: APIMonitorError[]) {
 
 export function formatStaleMonitors() {
   let outer = bold(yellow(`${symbols['warning']} Found stale monitors\n`));
-  const inner = gray(`Please pass --delete to remove the stale monitors.`);
+  const inner = gray(`Pass --delete to remove all the stale monitors.`);
   outer += indent(inner, '   ');
   return outer;
 }

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -78,7 +78,7 @@ export async function createMonitors(
 }
 
 export type APIMonitorError = {
-  id: string;
+  id?: string;
   reason: string;
   details: string;
 };
@@ -88,7 +88,7 @@ export function formatAPIError(
   error: string,
   message: string
 ) {
-  let outer = `${symbols['failed']} ${bold('Error')}\n`;
+  let outer = bold(`${symbols['failed']} Error\n`);
   let inner = bold(
     `${symbols['failed']} monitor creation failed - ${statuCode}:${error}\n`
   );
@@ -98,7 +98,7 @@ export function formatAPIError(
 }
 
 export function formatFailedMonitors(errors: APIMonitorError[]) {
-  let outer = `${symbols['failed']} ${bold('Error')}\n`;
+  let outer = bold(`${symbols['failed']} Error\n`);
   for (const error of errors) {
     const monitorId = error.id ? `: monitor(${error.id})` : '';
     let inner = bold(`> ${error.reason}${monitorId}\n`);

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -31,7 +31,7 @@ import { MonitorSchema } from './monitor';
 const { version } = require('../../package.json');
 
 export type APISchema = {
-  space: string;
+  project: string;
   keep_stale: boolean;
   monitors: MonitorSchema[];
 };
@@ -43,17 +43,23 @@ function encodeAuth(auth: string) {
   return auth;
 }
 
+function getAPIUrl(options: PushOptions) {
+  return (
+    options.url + `/s/${options.space}/api/synthetics/service/push/monitors`
+  );
+}
+
 export async function createMonitor(
   monitors: MonitorSchema[],
   options: PushOptions
 ) {
   const schema: APISchema = {
-    space: options.space,
+    project: options.project,
     keep_stale: !options.delete,
     monitors,
   };
 
-  return await request(options.url, {
+  return await request(getAPIUrl(options), {
     method: 'POST',
     body: JSON.stringify(schema),
     headers: {


### PR DESCRIPTION
+ Part of #470 
+ Adds the subcommand `push` to the Synthetics CLI that would do the following
   - Goes over each journey file and bundles that particular journey along with relevant files that are imported by the particular journey
   - Creates a archived file for each journeys maintaining the local path (to help with Stack traces when invoked via HB)
   - creates a base 64 encoded content that would be sent to Kibana as part of the `MonitorSchema`. 
 + Introduce required options `--url` and `--auth` to the CLI flags that lets user specify the `Kibana URL endpoint` and also the `authentication` details. User auth accepts `username:pass` or `encoded` strings, If the auth parameter is not encoded, they would be encoded by the Synthetics agent before communicating with Kibana. 
+ In order to reduce the monitor id collision, it is required to set the project/suite id when invoking the push command. Users can pass it via `--project <name>`. 
+ Current schema looks like this for the create monitor part. 

```ts
type body = MonitorSchema[]

type MonitorSchema = {
  content: string; // base64 encoded monitor source
  id: string;
  name: string;
  schedule: string;
  locations: SyntheticsLocations[];
  throttling: {
    download: number;
    upload: number;
    latency: number;
  };
};

```

### To run locally

+ Install the deps and build the files by `npm run build`
```
npx @elastic/synthetics push examples/todos/basic.journey.ts --auth elastic:changeme  --url http://localhost:5601/wuv  --project test
```
+ Use the PR from Kibana - https://github.com/elastic/kibana/pull/131270 and do `yarn start`. Once Kibana is up use the kibana URL to push the monitors from local journey files. 