### PR TITLE
chore: fix flaky cache resource test

### DIFF
--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -271,10 +271,11 @@ describe('network', () => {
     );
     expect(resources.length).toBe(2);
     resources.forEach(res => {
-      expect(res.timings.wait).toBeGreaterThan(delayTime);
+      const timing = res.timings;
+      expect(timing.wait).toBeGreaterThan(delayTime);
+      expect(timing.total).toBeGreaterThan(timing.wait + timing.receive);
+      // Check with absolute value to make sure we are not crossing absurd values
+      expect(timing.total).toBeLessThan(50);
     });
-    expect(resources[1].timings.total).toBeLessThanOrEqual(
-      resources[0].timings.total
-    );
   });
 });


### PR DESCRIPTION
+ The previous logic is sometimes flaky when run on CI, so we check for absolute values to make sure the we are not seeing absurd values for cached resources. 