### PR TITLE
feat: introduce monitor DSL

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -450,6 +450,21 @@ describe('CLI', () => {
       });
     });
 
+    it('supports older format', async () => {
+      const cli = new CLIMock()
+        .args(cliArgs.concat(['--throttling', '17u/30l/3d']))
+        .run();
+      await cli.waitFor('synthetics/metadata');
+      const journeyStartOutput = JSON.parse(cli.output());
+      expect(await cli.exitCode).toBe(0);
+      expect(journeyStartOutput.payload).toHaveProperty('network_conditions', {
+        downloadThroughput: megabitsToBytes(3),
+        uploadThroughput: megabitsToBytes(17),
+        latency: 30,
+        offline: false,
+      });
+    });
+
     it('uses default throttling when specific params are not provided', async () => {
       const cli = new CLIMock()
         .args(cliArgs.concat(['--throttling', JSON.stringify({ download: 2 })]))

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -27,7 +27,11 @@ import { ChildProcess, spawn } from 'child_process';
 import { join } from 'path';
 import { devices } from 'playwright-chromium';
 import { Server } from './utils/server';
-import { getNetworkConditions, megabitsToBytes } from '../src/helpers';
+import {
+  DEFAULT_THROTTLING_OPTIONS,
+  getNetworkConditions,
+  megabitsToBytes,
+} from '../src/helpers';
 
 const safeParse = (chunks: string[]) => {
   return chunks.map(data => {
@@ -418,7 +422,7 @@ describe('CLI', () => {
       expect(await cli.exitCode).toBe(0);
       expect(journeyStartOutput.payload).toHaveProperty(
         'network_conditions',
-        getNetworkConditions({} as any)
+        getNetworkConditions(DEFAULT_THROTTLING_OPTIONS)
       );
     });
 
@@ -454,7 +458,7 @@ describe('CLI', () => {
       const journeyStartOutput = JSON.parse(cli.output());
       expect(await cli.exitCode).toBe(0);
       expect(journeyStartOutput.payload).toHaveProperty('network_conditions', {
-        ...getNetworkConditions({} as any),
+        ...getNetworkConditions(DEFAULT_THROTTLING_OPTIONS),
         downloadThroughput: megabitsToBytes(2),
       });
     });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -26,7 +26,7 @@
 import fs from 'fs';
 import { Gatherer } from '../../src/core/gatherer';
 import Runner from '../../src/core/runner';
-import { step, journey } from '../../src/core';
+import { step, journey, monitor } from '../../src/core';
 import { Journey, Step } from '../../src/dsl';
 import { Server } from '../utils/server';
 import { generateTempPath, noop } from '../../src/helpers';
@@ -670,6 +670,17 @@ describe('runner', () => {
     ];
     const collectOrder = events.map(event => event.type);
     expect(collectOrder).toEqual(realEventsOrder);
+  });
+
+  it.only('runner - push command', async () => {
+    const j1 = journey('journey1', async ({ page }) => {
+      // monitor.use({ schedule: '2m', location: 'US Central' });
+      step('load test server', async () => {
+        await page.goto(server.PREFIX);
+      });
+    });
+    runner.addJourney(j1);
+    await runner.push();
   });
 
   /**

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -28,7 +28,7 @@ import { normalizeOptions } from '../src/options';
 import { join } from 'path';
 
 describe('options', () => {
-  it('normalize', async () => {
+  it('normalize', () => {
     const cliArgs: CliArgs = {
       params: {
         foo: 'bar',
@@ -70,6 +70,26 @@ describe('options', () => {
         },
       },
       screenshots: 'on',
+    });
+  });
+
+  it('normalize monitor configs', () => {
+    expect(normalizeOptions({ throttling: false })).toMatchObject({
+      locations: ['US East'],
+      schedule: '10m',
+      throttling: {},
+    });
+
+    expect(
+      normalizeOptions({ throttling: { download: 50 }, schedule: '2m' })
+    ).toMatchObject({
+      locations: ['US East'],
+      schedule: '2m',
+      throttling: {
+        download: 50,
+        upload: 3,
+        latency: 20,
+      },
     });
   });
 });

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -24,7 +24,7 @@
  */
 
 import { CliArgs } from '../src/common_types';
-import { normalizeOptions } from '../src/options';
+import { normalizeOptions, parseThrottling } from '../src/options';
 import { join } from 'path';
 
 describe('options', () => {
@@ -90,6 +90,19 @@ describe('options', () => {
         upload: 3,
         latency: 20,
       },
+    });
+  });
+
+  it('parse throttling', () => {
+    expect(parseThrottling('{}')).toEqual({});
+    expect(parseThrottling('{"download": 20, "upload": 10}')).toEqual({
+      download: 20,
+      upload: 10,
+    });
+    expect(parseThrottling('100l/41u/9d')).toEqual({
+      download: 9,
+      upload: 41,
+      latency: 100,
     });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,7 +106,7 @@ program
   )
   .option(
     '--throttling <config>',
-    'JSON object to throttle network conditions for download throughput in megabits/second, upload throughput in megabits/second and latency in milliseconds.',
+    'JSON object to throttle network conditions for download and upload throughput in megabits/second and latency in milliseconds. Ex: { "download": 10, "upload": 5, "latency": 200 }.',
     JSON.parse,
     {}
   )
@@ -146,11 +146,11 @@ program
   )
   .option(
     '--schedule <time>',
-    'schedule the monitors at configured intervals. Ex: setting `10m` configures the monitor to be executed every 10 minutes.'
+    "The default interval for the pushed monitors. Setting `10m`, for example, configures monitors which don't have a specified interval defined to run every 10 minutes."
   )
   .option(
     '--locations <locations...>',
-    'Multiple global locations based on Synthetics nodes availability.'
+    'The default list of locations from which your monitors will run.'
   )
   .action(async (files, cmdOpts) => {
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,10 +28,10 @@
 import { program, Option } from 'commander';
 import { CliArgs } from './common_types';
 import { reporters } from './reporters';
-import { DEFAULT_THROTTLING_OPTIONS } from './helpers';
 import { normalizeOptions } from './options';
 import { loadTestFiles } from './loader';
 import { run } from './';
+import { runner } from './core';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
@@ -106,9 +106,9 @@ program
   )
   .option(
     '--throttling <config>',
-    'JSON object to to throttle network conditions for download throughput in megabits/second, upload throughput in megabits/second and latency in milliseconds.',
+    'JSON object to throttle network conditions for download throughput in megabits/second, upload throughput in megabits/second and latency in milliseconds.',
     JSON.parse,
-    DEFAULT_THROTTLING_OPTIONS
+    {}
   )
   .option('--no-throttling', 'Turns off default network throttling.')
   .option(
@@ -144,14 +144,21 @@ program
   .description(
     'Push monitors to create new montors with Kibana monitor management UI'
   )
+  .option(
+    '--schedule <time>',
+    'schedule the monitors at configured intervals. Ex: setting `10m` configures the monitor to be executed every 10 minutes.'
+  )
+  .option(
+    '--locations <locations...>',
+    'Multiple global locations based on Synthetics nodes availability.'
+  )
   .action(async (files, cmdOpts) => {
     try {
       const cliArgs = { inline: false };
       await loadTestFiles(cliArgs, files);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
-      console.log('Options', options);
-
-      // TODO: Push logic will be implemened in subsequent PR's
+      runner.buildMonitors(options);
+      // TODO: Push logic will be implemented in follow up PR's
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@
 import { program, Option } from 'commander';
 import { CliArgs } from './common_types';
 import { reporters } from './reporters';
-import { DEFAULT_NETWORK_CONDITIONS_ARG } from './helpers';
+import { DEFAULT_THROTTLING_OPTIONS } from './helpers';
 import { normalizeOptions } from './options';
 import { loadTestFiles } from './loader';
 import { run } from './';
@@ -105,9 +105,10 @@ program
     'always return 0 as an exit code status, regardless of test pass / fail. Only return > 0 exit codes on internal errors where the suite could not be run'
   )
   .option(
-    '--throttling <d/u/l>',
-    'List of options to throttle network conditions for download throughput (d) in megabits/second, upload throughput (u) in megabits/second and latency (l) in milliseconds.',
-    DEFAULT_NETWORK_CONDITIONS_ARG
+    '--throttling <config>',
+    'JSON object to to throttle network conditions for download throughput in megabits/second, upload throughput in megabits/second and latency in milliseconds.',
+    JSON.parse,
+    DEFAULT_THROTTLING_OPTIONS
   )
   .option('--no-throttling', 'Turns off default network throttling.')
   .option(
@@ -139,12 +140,22 @@ program
   });
 
 program
-  .command('push')
+  .command('push [files...]')
   .description(
     'Push monitors to create new montors with Kibana monitor management UI'
   )
-  .action(() => {
-    throw new Error('TODO: Implement me');
+  .action(async (files, cmdOpts) => {
+    try {
+      const cliArgs = { inline: false };
+      await loadTestFiles(cliArgs, files);
+      const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
+      console.log('Options', options);
+
+      // TODO: Push logic will be implemened in subsequent PR's
+    } catch (e) {
+      console.error(e);
+      process.exit(1);
+    }
   });
 
 program.parse(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@
 import { program, Option } from 'commander';
 import { CliArgs } from './common_types';
 import { reporters } from './reporters';
-import { normalizeOptions } from './options';
+import { normalizeOptions, parseThrottling } from './options';
 import { loadTestFiles } from './loader';
 import { run } from './';
 import { runner } from './core';
@@ -107,7 +107,7 @@ program
   .option(
     '--throttling <config>',
     'JSON object to throttle network conditions for download and upload throughput in megabits/second and latency in milliseconds. Ex: { "download": 10, "upload": 5, "latency": 200 }.',
-    JSON.parse,
+    parseThrottling,
     {}
   )
   .option('--no-throttling', 'Turns off default network throttling.')

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -33,6 +33,7 @@ import {
 } from 'playwright-chromium';
 import { Step } from './dsl';
 import { BuiltInReporterName, ReporterInstance } from './reporters';
+import { MonitorConfig } from './dsl/monitor';
 
 export type VoidCallback = () => void;
 export type Location = {
@@ -188,6 +189,12 @@ export type PluginOutput = {
 
 export type ScreenshotOptions = 'on' | 'off' | 'only-on-failure';
 
+export type ThrottlingOptions = {
+  download: number;
+  upload: number;
+  latency: number;
+};
+
 type BaseArgs = {
   params?: Params;
   screenshots?: ScreenshotOptions;
@@ -213,7 +220,7 @@ export type CliArgs = BaseArgs & {
   richEvents?: boolean;
   capability?: Array<string>;
   ignoreHttpsErrors?: boolean;
-  throttling?: boolean | string;
+  throttling?: boolean | ThrottlingOptions;
 };
 
 export type RunOptions = BaseArgs & {
@@ -232,6 +239,7 @@ export type PlaywrightOptions = LaunchOptions & BrowserContextOptions;
 export type SyntheticsConfig = {
   params?: Params;
   playwrightOptions?: PlaywrightOptions;
+  monitor?: MonitorConfig;
 };
 
 /** Runner Payload types */

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -33,7 +33,7 @@ import {
 } from 'playwright-chromium';
 import { Step } from './dsl';
 import { BuiltInReporterName, ReporterInstance } from './reporters';
-import { MonitorConfig } from './dsl/monitor';
+import { MonitorConfig, SyntheticsLocations } from './dsl/monitor';
 
 export type VoidCallback = () => void;
 export type Location = {
@@ -190,9 +190,9 @@ export type PluginOutput = {
 export type ScreenshotOptions = 'on' | 'off' | 'only-on-failure';
 
 export type ThrottlingOptions = {
-  download: number;
-  upload: number;
-  latency: number;
+  download?: number;
+  upload?: number;
+  latency?: number;
 };
 
 type BaseArgs = {
@@ -207,6 +207,9 @@ type BaseArgs = {
   ignoreHttpsErrors?: boolean;
   playwrightOptions?: PlaywrightOptions;
   quietExitCode?: boolean;
+  throttling?: ThrottlingOptions;
+  schedule?: string;
+  locations?: SyntheticsLocations[];
 };
 
 export type CliArgs = BaseArgs & {

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -26,7 +26,7 @@
 import { chromium, ChromiumBrowser, BrowserContext } from 'playwright-chromium';
 import { PluginManager } from '../plugins';
 import { log } from './logger';
-import { Driver, RunOptions } from '../common_types';
+import { Driver, NetworkConditions, RunOptions } from '../common_types';
 
 /**
  * Purpose of the Gatherer is to set up the necessary browser driver
@@ -75,7 +75,7 @@ export class Gatherer {
 
   static setNetworkConditions(
     context: BrowserContext,
-    networkConditions: RunOptions['networkConditions']
+    networkConditions: NetworkConditions
   ) {
     if (networkConditions) {
       context.on('page', page => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -28,6 +28,7 @@ import Runner from './runner';
 import { VoidCallback, HooksCallback, Location } from '../common_types';
 import { wrapFnWithLocation } from '../helpers';
 import { log } from './logger';
+import { MonitorConfig } from '../dsl/monitor';
 
 /**
  * Use a gloabl Runner which would be accessed by the runtime and
@@ -62,6 +63,12 @@ export const step = wrapFnWithLocation(
     return runner.currentJourney?.addStep(name, callback, location);
   }
 );
+
+export const monitor = {
+  use: wrapFnWithLocation((location: Location, config: MonitorConfig) => {
+    return runner.currentJourney?.addMonitor(config);
+  }),
+};
 
 export const beforeAll = (callback: HooksCallback) => {
   runner.addHook('beforeAll', callback);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -66,7 +66,15 @@ export const step = wrapFnWithLocation(
 
 export const monitor = {
   use: wrapFnWithLocation((location: Location, config: MonitorConfig) => {
-    return runner.currentJourney?.addMonitor(config);
+    /**
+     * If the context is inside journey, then set it to journey context
+     * otherwise set to the global monitor which will be used for all journeys
+     */
+    if (runner.currentJourney) {
+      runner.currentJourney.updateMonitor(config);
+    } else {
+      runner.updateMonitor(config);
+    }
   }),
 };
 

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -374,6 +374,17 @@ export default class Runner {
     await mkdirAsync(CACHE_PATH, { recursive: true });
   }
 
+  async push() {
+    for (const journey of this.journeys) {
+      /**
+       * Execute dummy callback to get all monitor specific
+       * configurations for the current journey
+       */
+      journey.callback({} as any);
+      console.log(journey);
+    }
+  }
+
   async run(options: RunOptions) {
     const result: RunResult = {};
     if (this.#active) {

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -27,6 +27,7 @@ import { Browser, Page, BrowserContext, CDPSession } from 'playwright-chromium';
 import micromatch, { isMatch } from 'micromatch';
 import { Step } from './step';
 import { VoidCallback, HooksCallback, Params, Location } from '../common_types';
+import { Monitor, MonitorConfig } from './monitor';
 
 export type JourneyOptions = {
   name: string;
@@ -52,6 +53,7 @@ export class Journey {
   location?: Location;
   steps: Step[] = [];
   hooks: Hooks = { before: [], after: [] };
+  monitor: Monitor;
 
   constructor(
     options: JourneyOptions,
@@ -73,6 +75,11 @@ export class Journey {
 
   addHook(type: HookType, callback: HooksCallback) {
     this.hooks[type].push(callback);
+  }
+
+  addMonitor(config: MonitorConfig) {
+    this.monitor = new Monitor({ name: this.name, id: this.id });
+    this.monitor.merge(config);
   }
   /**
    * Matches journeys based on the provided args. Proitize tags over match

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -65,6 +65,7 @@ export class Journey {
     this.tags = options.tags;
     this.callback = callback;
     this.location = location;
+    this.monitor = new Monitor({ name: this.name, id: this.id });
   }
 
   addStep(name: string, callback: VoidCallback, location?: Location) {
@@ -77,10 +78,13 @@ export class Journey {
     this.hooks[type].push(callback);
   }
 
-  addMonitor(config: MonitorConfig) {
-    this.monitor = new Monitor({ name: this.name, id: this.id });
-    this.monitor.merge(config);
+  updateMonitor(config: MonitorConfig) {
+    /**
+     * Use defaults values from journey for monitor like `name` and `id`
+     */
+    this.monitor = new Monitor({ name: this.name, id: this.id, ...config });
   }
+
   /**
    * Matches journeys based on the provided args. Proitize tags over match
    * - tags pattern that matches only tags

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -1,0 +1,42 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { ThrottlingOptions } from '../common_types';
+
+export type MonitorConfig = {
+  id?: string;
+  name?: string;
+  schedule?: string;
+  location?: string;
+  throttling?: ThrottlingOptions;
+};
+
+export class Monitor {
+  constructor(public config: MonitorConfig) {}
+
+  merge(useConfig: MonitorConfig) {
+    this.config = { ...this.config, ...useConfig };
+  }
+}

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -23,20 +23,29 @@
  *
  */
 
+import merge from 'deepmerge';
 import { ThrottlingOptions } from '../common_types';
 
+export type SyntheticsLocations = 'US East' | 'EU West';
 export type MonitorConfig = {
   id?: string;
   name?: string;
   schedule?: string;
-  location?: string;
+  locations?: SyntheticsLocations[];
   throttling?: ThrottlingOptions;
 };
 
 export class Monitor {
-  constructor(public config: MonitorConfig) {}
-
-  merge(useConfig: MonitorConfig) {
-    this.config = { ...this.config, ...useConfig };
+  constructor(public config: MonitorConfig = {}) {}
+  /**
+   * Treat the creation time config with `monitor.use` as source of truth by
+   * merging the values coming from CLI and Synthetics config file
+   */
+  update(globalOpts: MonitorConfig = {}) {
+    this.config = merge(globalOpts, this.config, {
+      arrayMerge(target, source) {
+        return [...new Set(source)];
+      },
+    });
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -281,14 +281,10 @@ export const DEFAULT_THROTTLING_OPTIONS: ThrottlingOptions = {
 export function getNetworkConditions(
   throttlingOpts: ThrottlingOptions
 ): NetworkConditions {
-  const { download, upload, latency } = {
-    ...DEFAULT_THROTTLING_OPTIONS,
-    ...throttlingOpts,
-  };
   return {
-    downloadThroughput: megabitsToBytes(download),
-    uploadThroughput: megabitsToBytes(upload), // Devtools CDP expects format to be in bytes/second
-    latency, // milliseconds,
+    downloadThroughput: megabitsToBytes(throttlingOpts.download),
+    uploadThroughput: megabitsToBytes(throttlingOpts.upload), // Devtools CDP expects format to be in bytes/second
+    latency: throttlingOpts.latency, // milliseconds,
     offline: false,
   };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,6 +35,7 @@ import {
   HooksCallback,
   NetworkConditions,
   Location,
+  ThrottlingOptions,
 } from './common_types';
 
 const lstatAsync = promisify(fs.lstat);
@@ -267,62 +268,31 @@ export function megabitsToBytes(megabytes: number) {
   return (megabytes * 1024 * 1024) / 8;
 }
 
-export function bytesToMegabits(bytes: number) {
-  return (bytes / 1024 / 1024) * 8;
-}
-
-export const DEFAULT_NETWORK_CONDITIONS: NetworkConditions = {
-  downloadThroughput: megabitsToBytes(5), // Devtools CDP expects format to be in bytes/second
-  uploadThroughput: megabitsToBytes(3), // Devtools CDP expects format to be in bytes/second
-  latency: 20, // milliseconds,
-  offline: false,
+export const DEFAULT_THROTTLING_OPTIONS: ThrottlingOptions = {
+  download: 5,
+  upload: 3,
+  latency: 20,
 };
 
-// Tranforms CDP dev tools format back to cli args format
-export function formatNetworkConditionsArgs(
-  networkConditions: NetworkConditions
-) {
-  const d = bytesToMegabits(networkConditions.downloadThroughput);
-  const u = bytesToMegabits(networkConditions.uploadThroughput);
-  const l = networkConditions.latency;
-  return `${d}d/${u}u/${l}l`;
-}
-
-export const DEFAULT_NETWORK_CONDITIONS_ARG = formatNetworkConditionsArgs(
-  DEFAULT_NETWORK_CONDITIONS
-);
-
-export function parseNetworkConditions(args: string): NetworkConditions {
-  const uploadToken = 'u';
-  const downloadToken = 'd';
-  const latencyToken = 'l';
-  const networkConditions = {
-    ...DEFAULT_NETWORK_CONDITIONS,
+/**
+ * Transforms the CLI throttling arguments in to format
+ * expected by Chrome devtools protocol NetworkConditions
+ */
+export function getNetworkConditions(
+  throttlingOpts: ThrottlingOptions
+): NetworkConditions {
+  const { download, upload, latency } = {
+    ...DEFAULT_THROTTLING_OPTIONS,
+    ...throttlingOpts,
   };
-
-  const conditions = args.split('/');
-
-  conditions.forEach(condition => {
-    const value = condition.slice(0, condition.length - 1);
-    const token = condition.slice(-1);
-
-    switch (token) {
-      case uploadToken:
-        networkConditions.uploadThroughput = megabitsToBytes(Number(value));
-        break;
-      case downloadToken:
-        networkConditions.downloadThroughput = megabitsToBytes(Number(value));
-        break;
-      case latencyToken:
-        networkConditions.latency = Number(value);
-        break;
-    }
-  });
-
-  return networkConditions;
+  return {
+    downloadThroughput: megabitsToBytes(download),
+    uploadThroughput: megabitsToBytes(upload), // Devtools CDP expects format to be in bytes/second
+    latency, // milliseconds,
+    offline: false,
+  };
 }
 
-// default stack trace limit
 const dstackTraceLimit = 10;
 
 // Uses the V8 Stacktrace API to get the function location

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,15 @@ export async function run(options: RunOptions) {
 /**
  * Export all core module functions
  */
-export { beforeAll, afterAll, journey, step, before, after } from './core';
+export {
+  journey,
+  step,
+  monitor,
+  beforeAll,
+  afterAll,
+  before,
+  after,
+} from './core';
 export { expect } from './core/expect';
 /**
  * Export all the driver related types to be consumed

--- a/src/options.ts
+++ b/src/options.ts
@@ -25,8 +25,8 @@
 
 import merge from 'deepmerge';
 import { readConfig } from './config';
-import { parseNetworkConditions } from './helpers';
-import type { CliArgs, RunOptions } from './common_types';
+import { getNetworkConditions } from './helpers';
+import type { CliArgs, RunOptions, ThrottlingOptions } from './common_types';
 
 /**
  * Set debug based on DEBUG ENV and -d flags
@@ -107,8 +107,8 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
   ]);
 
   if (cliArgs.throttling) {
-    options.networkConditions = parseNetworkConditions(
-      cliArgs.throttling as string
+    options.networkConditions = getNetworkConditions(
+      cliArgs.throttling as ThrottlingOptions
     );
   }
 


### PR DESCRIPTION
+ Part of #470
+ Expose the new Monitor DSL that will be used alongside `journey, step` which can be used to configure the monitor settings/configuration before uploading via the `push` command.
+ Instead of exposing it through the callback arguments which we agreed on earlier, `monitor` API sits similar to `journey/step` level which improves the DX by allowing users to set the configuration across all journeys or via file level if we decide to change it in future. 
    - Allows for future extensibility to tune it based on file - depending on which file the `monitor.use` API is called, the journeys sits inside those files will get those defaults.
    - Extensible that allows the configuration to be exposed via `journey.use`. 
```ts
import { journey, step, monitor } from '@elastic/synthetics';

// Applied to all journeys that are pushed
monitor.use({
  locations: ['EU West'],
  throttling: {
    download: 200,
  },
});

journey('check if title is present', ({ page, params }) => {
  // Applied only to this specific journey
  monitor.use({
    schedule: '15m',
    throttling: { latency: 100 },
  });
  step('launch app', async () => {
    await page.goto(params.url);
  });
});
```
+ Every option that is configurable for monitor is available via `Synthetics configuration file`, `CLI Flags` and `monitor.use` API and the order of preference is  API > CLI Flags > Synthetics config file. 
+ Throttling flag is backwards compatibile which means it should work with the previous format `<5d/3l/10u>` and also the newer JSON format.
+ Push commands gets new flags `schedule` and `locations` that are relevant for the monitors to be pushed. However `throttling` is used differently based on the context. 
     - While running, gets applied to Network throttling using Chrome devtools protocol.
     - While pushing, gets applied to the monitor configuration.

### Examples

Example to configure monitor settings which will be used for uploading to Kibana. 

#### Synthetics config file
```ts
// synthetics.config.ts
export default env => {
  monitors: {
    throttling: {
      download: 200,
      upload: 100,
      latency: 50,
    },
    schedule: '5m',
  },
}
```

### CLI Flags
```
npx @elastic/synthetics push examples/todos --schedule 5m --throttling '{"upload": 30}' --locations="US East"
```

### Monitor.use API
```
journey('Test, ({ }) => {
  monitor.use({
    schedule: '15m',
    throttling: { latency: 100 },
  });
  // steps
});
```
