### PR TITLE
chore: e2e tests - pull logs from docker containers when unhealthy and temporarily disable alerts

### DIFF
--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -78,6 +78,7 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true)
     }
+    // Temporarily disabled until https://github.com/elastic/uptime-dev/issues/99 is resolved
     // unsuccessful {
     //   notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] e2e failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
     // }

--- a/.ci/e2e-synthetics.groovy
+++ b/.ci/e2e-synthetics.groovy
@@ -78,9 +78,9 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true)
     }
-    unsuccessful {
-      notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] e2e failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
-    }
+    // unsuccessful {
+    //   notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] e2e failed", body: "(<${env.RUN_DISPLAY_URL}|Open>)")
+    // }
     // success {
     //   notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] e2e ran successfully", body: "Great news, the e2e for synthetics has finished successfully. (<${env.RUN_DISPLAY_URL}|Open>).")
     // }

--- a/__tests__/e2e/scripts/setup_integration.sh
+++ b/__tests__/e2e/scripts/setup_integration.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 # Update elastic-package
 go install github.com/elastic/elastic-package@latest
@@ -11,3 +10,15 @@ elastic-package stack down
 
 # start elastic-package
 env ELASTICSEARCH_IMAGE_REF=$1 ELASTIC_AGENT_IMAGE_REF=$1 KIBANA_IMAGE_REF=$1 elastic-package stack up -d -v --version $1
+
+status=$?
+
+if [ $status -eq 1 ]; then
+    echo "Fetching Fleet server logs... \n$(docker logs elastic-package-stack_fleet-server_1)"
+
+    echo "Fetching Elastic Agent logs... \n$(docker logs elastic-package-stack_elastic-agent_1)"
+
+    echo "Fetching Kibana logs... \n$(docker logs elastic-package-stack_kibana_1)"
+
+    exit $status
+fi


### PR DESCRIPTION
Currently, Kibana is failing to start for Fleet e2e tests. See the issue encapsulated here. https://github.com/elastic/uptime-dev/issues/99

This PR does two things
1. Pulls logs from Fleet Server, Elastic Agent, and Kibana in the event that `elastic-package stack up` exits with status 1
2. Temporarily disables alerts for these tests