### PR TITLE
feat: scaffold a synthetics node project

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 dist
 examples
+templates
 __tests__/e2e/tmp/
 src/sdk/lh-trace-processor.ts

--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -1,0 +1,63 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { existsSync } from 'fs';
+import { rm } from 'fs/promises';
+import { join } from 'path';
+import { CLIMock } from '../utils/test-config';
+
+describe('Generator', () => {
+  const scaffoldDir = join(__dirname, 'scaffold-test');
+  beforeAll(() => {
+    // Not useful for this particular test and delays the test itself
+    process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = '1';
+  });
+  afterAll(async () => {
+    process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = '0';
+    await rm(scaffoldDir, {
+      recursive: true,
+      force: true,
+    });
+  });
+  it('generate synthetics project - NPM', async () => {
+    const cli = new CLIMock().args(['init', scaffoldDir]).run();
+    expect(await cli.exitCode).toBe(0);
+
+    // Verify files
+    expect(existsSync(join(scaffoldDir, 'package.json'))).toBeTruthy();
+    expect(existsSync(join(scaffoldDir, 'package-lock.json'))).toBeTruthy();
+    expect(existsSync(join(scaffoldDir, '.gitignore'))).toBeTruthy();
+    expect(
+      existsSync(join(scaffoldDir, 'journeys', 'todos.journey.ts'))
+    ).toBeTruthy();
+    expect(existsSync(join(scaffoldDir, 'synthetics.config.ts'))).toBeTruthy();
+
+    // Verify stdout
+    const stderr = cli.stderr();
+    expect(stderr).toContain('Initializing Synthetics project using NPM');
+    expect(stderr).toContain('Installing @elastic/synthetics library');
+    expect(stderr).toContain('All set, you can run below commands');
+  }, 30000);
+});

--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -50,7 +50,7 @@ describe('Generator', () => {
     expect(existsSync(join(scaffoldDir, 'package-lock.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, '.gitignore'))).toBeTruthy();
     expect(
-      existsSync(join(scaffoldDir, 'journeys', 'todos.journey.ts'))
+      existsSync(join(scaffoldDir, 'journeys', 'example.journey.ts'))
     ).toBeTruthy();
     expect(existsSync(join(scaffoldDir, 'synthetics.config.ts'))).toBeTruthy();
 

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -23,6 +23,7 @@
  *
  */
 
+import { ChildProcess, spawn } from 'child_process';
 import { join } from 'path';
 import { Monitor } from '../../dist/dsl/monitor';
 
@@ -44,4 +45,91 @@ export function createTestMonitor(filename: string) {
   });
   monitor.setFilter({ match: 'test' });
   return monitor;
+}
+
+export class CLIMock {
+  private process: ChildProcess;
+  private data = '';
+  private chunks: Array<string> = [];
+  private waitForText: string;
+  private waitForPromise: () => void;
+  private cliArgs: string[];
+  private stdinStr?: string;
+  private stderrStr: string;
+  exitCode: Promise<number>;
+
+  constructor(public debug: boolean = false) {}
+
+  args(a: string[]): CLIMock {
+    this.cliArgs = a;
+    return this;
+  }
+
+  stdin(s: string): CLIMock {
+    this.stdinStr = s;
+    return this;
+  }
+
+  run(spawnOverrides?: { cwd?: string }): CLIMock {
+    this.process = spawn(
+      'node',
+      [join(__dirname, '..', '..', 'dist', 'cli.js'), ...this.cliArgs],
+      {
+        env: process.env,
+        stdio: 'pipe',
+        ...spawnOverrides,
+      }
+    );
+
+    if (this.stdinStr) {
+      this.process.stdin.setDefaultEncoding('utf8');
+      this.process.stdin.write(this.stdinStr);
+      this.process.stdin.end();
+    }
+
+    const dataListener = data => {
+      this.data = data.toString();
+      if (this.debug) {
+        console.log('CLIMock.stdout:', this.data);
+      }
+      this.chunks.push(this.data);
+      if (this.waitForPromise && this.data.includes(this.waitForText)) {
+        this.process.stdout.off('data', dataListener);
+        this.waitForPromise();
+      }
+    };
+    this.process.stdout.on('data', dataListener);
+
+    this.exitCode = new Promise(res => {
+      this.process.stderr.on('data', data => {
+        this.stderrStr += data;
+        if (this.debug) {
+          console.log('CLIMock.stderr:', data.toString());
+        }
+      });
+      this.process.on('exit', code => res(code));
+    });
+
+    return this;
+  }
+
+  async waitFor(text: string): Promise<void> {
+    this.waitForText = text;
+    return new Promise(r => (this.waitForPromise = r));
+  }
+
+  output() {
+    return this.data;
+  }
+
+  buffer() {
+    // Merge all the interleaved chunks from stdout and
+    // split them on new line as synthetics runner writes the
+    // JSON output in separate lines for every event.
+    return this.chunks.join('').split('\n').filter(Boolean);
+  }
+
+  stderr() {
+    return this.stderrStr.toString();
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "templates"
   ],
   "lint-staged": {
     "*.{js,ts}": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,6 +34,9 @@ import { run } from './';
 import { runner } from './core';
 import { SyntheticsLocations } from './dsl/monitor';
 import { push } from './push';
+import { resolve } from 'path';
+import { Generator } from './generator';
+import { error } from './helpers';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
@@ -141,6 +144,7 @@ program
     }
   });
 
+// Push command
 program
   .command('push [files...]')
   .description(
@@ -181,6 +185,20 @@ program
       await push(monitors, cmdOpts);
     } catch (e) {
       console.error(e);
+      process.exit(1);
+    }
+  });
+
+// Init command
+program
+  .command('init <project-dir>')
+  .description('Initalize Elastic synthetics project')
+  .action(async (dir: string) => {
+    try {
+      const generator = await new Generator(resolve(process.cwd(), dir));
+      await generator.setup();
+    } catch (e) {
+      error(e);
       process.exit(1);
     }
   });

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -54,7 +54,7 @@ export class Generator {
     );
 
     // Setup example journey file
-    const journeyFile = 'journeys/todos.journey.ts';
+    const journeyFile = 'journeys/example.journey.ts';
     fileMap.set(
       journeyFile,
       await readFile(join(templateDir, journeyFile), 'utf-8')
@@ -122,7 +122,7 @@ export class Generator {
 
     // Add push command
     const project = basename(this.projectDir);
-    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth <apiKey|basic-auth>`;
+    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth basic-auth`;
 
     await this.createFile(
       filename,

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -25,7 +25,7 @@
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
-import { bold, cyan } from 'kleur/colors';
+import { bold, cyan, yellow } from 'kleur/colors';
 import { join, relative, dirname, basename } from 'path';
 import { progress, write as stdWrite } from '../helpers';
 import { getPackageManager, runCommand } from './utils';
@@ -122,7 +122,7 @@ export class Generator {
 
     // Add push command
     const project = basename(this.projectDir);
-    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth elastic:changeme`;
+    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth <apiKey|basic-auth>`;
 
     await this.createFile(
       filename,
@@ -139,6 +139,10 @@ All set, you can run below commands inside: ${this.projectDir}:
   Run synthetic tests: ${cyan(runCommand(this.pkgManager, 'test'))}
 
   Push monitors to Kibana: ${cyan(runCommand(this.pkgManager, 'push'))}
+
+  ${yellow(
+    'Make sure to update the Kibana url and authentication info before pushing monitors to Kibana.'
+  )}
 
 Visit https://www.elastic.co/guide/en/observability/master/synthetics-journeys.html to learn more.
     `)

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -1,0 +1,155 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { bold, cyan } from 'kleur/colors';
+import { join, relative, dirname, basename } from 'path';
+import { progress, write as stdWrite } from '../helpers';
+import { getPackageManager, runCommand } from './utils';
+
+// Templates that are required for setting up new
+// synthetics project
+const templateDir = join(__dirname, '..', '..', 'templates');
+
+export class Generator {
+  pkgManager = 'npm';
+  constructor(public projectDir: string) {}
+
+  async directory() {
+    if (!existsSync(this.projectDir)) {
+      await mkdir(this.projectDir);
+    }
+  }
+
+  async files() {
+    const fileMap = new Map<string, string>();
+    // Setup Synthetics config file
+    const configFile = 'synthetics.config.ts';
+    fileMap.set(
+      configFile,
+      await readFile(join(templateDir, configFile), 'utf-8')
+    );
+
+    // Setup example journey file
+    const journeyFile = 'journeys/todos.journey.ts';
+    fileMap.set(
+      journeyFile,
+      await readFile(join(templateDir, journeyFile), 'utf-8')
+    );
+    // Setup gitignore
+    fileMap.set(
+      '.gitignore',
+      await readFile(join(templateDir, '.gitignore'), 'utf-8')
+    );
+
+    // Create files
+    for (const [relativePath, content] of fileMap) {
+      await this.createFile(relativePath, content);
+    }
+  }
+
+  async createFile(relativePath: string, content: string, override = false) {
+    const absolutePath = join(this.projectDir, relativePath);
+    if (override || !existsSync(absolutePath)) {
+      progress(`Writing ${relative(process.cwd(), absolutePath)}.`);
+      await mkdir(dirname(absolutePath), { recursive: true });
+      await writeFile(absolutePath, content, 'utf-8');
+    }
+  }
+
+  async package() {
+    this.pkgManager = await getPackageManager(this.projectDir);
+    const commands = new Map<string, string>();
+    commands.set(
+      `Initializing Synthetics project using ${
+        this.pkgManager == 'yarn' ? 'Yarn' : 'NPM'
+      }`,
+      this.pkgManager == 'yarn' ? 'yarn init -y' : 'npm init -y'
+    );
+
+    const pkgName = '@elastic/synthetics';
+    commands.set(
+      `Installing @elastic/synthetics library`,
+      this.pkgManager == 'yarn'
+        ? `yarn add -dev ${pkgName}`
+        : `npm i -d ${pkgName}`
+    );
+
+    // Execute commands
+    for (const [name, command] of commands) {
+      progress(`${name}...`);
+      execSync(command, {
+        stdio: 'inherit',
+        cwd: this.projectDir,
+      });
+    }
+  }
+
+  async patchPkgJSON() {
+    const filename = 'package.json';
+    const pkgJSON = JSON.parse(
+      await readFile(join(this.projectDir, filename), 'utf-8')
+    );
+
+    if (!pkgJSON.scripts) {
+      pkgJSON.scripts = {};
+    }
+    // Add test command
+    pkgJSON.scripts.test = 'npx @elastic/synthetics journeys';
+
+    // Add push command
+    const project = basename(this.projectDir);
+    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth elastic:changeme`;
+
+    await this.createFile(
+      filename,
+      JSON.stringify(pkgJSON, null, 2) + '\n',
+      true
+    );
+  }
+
+  banner() {
+    stdWrite(
+      bold(`
+All set, you can run below commands inside: ${this.projectDir}:
+
+  Run synthetic tests: ${cyan(runCommand(this.pkgManager, 'test'))}
+
+  Push monitors to Kibana: ${cyan(runCommand(this.pkgManager, 'push'))}
+
+Visit https://www.elastic.co/guide/en/observability/master/synthetics-journeys.html to learn more.
+    `)
+    );
+  }
+
+  async setup() {
+    await this.directory();
+    await this.package();
+    await this.files();
+    await this.patchPkgJSON();
+    this.banner();
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { red, green, yellow, cyan } from 'kleur/colors';
+import { red, green, yellow, cyan, bold } from 'kleur/colors';
 import os from 'os';
 import { resolve, join, dirname } from 'path';
 import fs from 'fs';
@@ -320,4 +320,21 @@ export function wrapFnWithLocation<A extends unknown[], R>(
     Error.prepareStackTrace = _prepareStackTrace;
     return func(location, ...args);
   };
+}
+
+// Console helpers
+export function write(message: string) {
+  process.stderr.write(message + '\n');
+}
+
+export function progress(message: string) {
+  write(cyan(bold(`${symbols.progress} ${message}`)));
+}
+
+export function error(message: string) {
+  write(red(message));
+}
+
+export function done(message: string) {
+  write(bold(green(`${symbols['succeeded']} ${message}`)));
 }

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.synthetics

--- a/templates/journeys/example.journey.ts
+++ b/templates/journeys/example.journey.ts
@@ -4,7 +4,7 @@ journey('My Example Journey', ({ page, params }) => {
   // Only relevant for the push command to create
   // monitors in Kibana
   monitor.use({
-    id: 'example',
+    id: 'example-monitor',
     schedule: 10,
   });
   step('launch application', async () => {
@@ -13,6 +13,6 @@ journey('My Example Journey', ({ page, params }) => {
 
   step('assert title', async () => {
     const header = await page.$('h1');
-    expect(await header.textContent()).toBe('Example Domain');
+    expect(await header.textContent()).toBe('todos');
   });
 });

--- a/templates/journeys/todos.journey.ts
+++ b/templates/journeys/todos.journey.ts
@@ -1,6 +1,12 @@
-import { journey, step, expect } from '@elastic/synthetics';
+import { journey, step, monitor, expect } from '@elastic/synthetics';
 
-journey('TodoMVC Synthetics test', ({ page, params }) => {
+journey('TodoMVC Synthetics', ({ page, params }) => {
+  // Only relevant for the push command to create
+  // monitors in Kibana
+  monitor.use({
+    id: 'todomvc',
+    schedule: 10,
+  });
   step('launch application', async () => {
     await page.goto(params.url);
   });

--- a/templates/journeys/todos.journey.ts
+++ b/templates/journeys/todos.journey.ts
@@ -1,0 +1,12 @@
+import { journey, step, expect } from '@elastic/synthetics';
+
+journey('TodoMVC Synthetics test', ({ page, params }) => {
+  step('launch application', async () => {
+    await page.goto(params.url);
+  });
+
+  step('assert title', async () => {
+    const header = await page.$('h1');
+    expect(await header.textContent()).toBe('todos');
+  });
+});

--- a/templates/journeys/todos.journey.ts
+++ b/templates/journeys/todos.journey.ts
@@ -1,10 +1,10 @@
 import { journey, step, monitor, expect } from '@elastic/synthetics';
 
-journey('TodoMVC Synthetics', ({ page, params }) => {
+journey('My Example Journey', ({ page, params }) => {
   // Only relevant for the push command to create
   // monitors in Kibana
   monitor.use({
-    id: 'todomvc',
+    id: 'example',
     schedule: 10,
   });
   step('launch application', async () => {
@@ -13,6 +13,6 @@ journey('TodoMVC Synthetics', ({ page, params }) => {
 
   step('assert title', async () => {
     const header = await page.$('h1');
-    expect(await header.textContent()).toBe('todos');
+    expect(await header.textContent()).toBe('Example Domain');
   });
 });

--- a/templates/synthetics.config.ts
+++ b/templates/synthetics.config.ts
@@ -3,15 +3,17 @@ import type { SyntheticsConfig } from '@elastic/synthetics';
 export default env => {
   const config: SyntheticsConfig = {
     params: {
-      url: 'https://example.com',
+      url: 'https://elastic.github.io/synthetics-demo/',
     },
     playwrightOptions: {
       ignoreHTTPSErrors: false,
     },
   };
   if (env !== 'development') {
-    // Override configuration specific to environment
-    config.params.url = 'https://example.org';
+    /**
+     * Override configuration specific to environment
+     * Ex: config.params.url = ""
+     */
   }
   return config;
 };

--- a/templates/synthetics.config.ts
+++ b/templates/synthetics.config.ts
@@ -1,0 +1,16 @@
+import type { SyntheticsConfig } from '@elastic/synthetics';
+
+export default env => {
+  const config: SyntheticsConfig = {
+    params: {
+      url: 'https://elastic.github.io/synthetics-demo/',
+    },
+    playwrightOptions: {
+      ignoreHTTPSErrors: true,
+    },
+  };
+  if (env !== 'development') {
+    config.params.url = 'https://elastic.github.io/synthetics-demo/';
+  }
+  return config;
+};

--- a/templates/synthetics.config.ts
+++ b/templates/synthetics.config.ts
@@ -3,14 +3,15 @@ import type { SyntheticsConfig } from '@elastic/synthetics';
 export default env => {
   const config: SyntheticsConfig = {
     params: {
-      url: 'https://elastic.github.io/synthetics-demo/',
+      url: 'https://example.com',
     },
     playwrightOptions: {
-      ignoreHTTPSErrors: true,
+      ignoreHTTPSErrors: false,
     },
   };
   if (env !== 'development') {
-    config.params.url = 'https://elastic.github.io/synthetics-demo/';
+    // Override configuration specific to environment
+    config.params.url = 'https://example.org';
   }
   return config;
 };


### PR DESCRIPTION
+ part of #470 
+ Add a new scaffolding command called `init` to the CLI. 
+ `npx @elastic/synthetics init <project-dir>` - You would get everything set up from running tests locally to pushing monitors to the Kibana Monitor management. After scaffolding, the users could do 
      - `npm run test ` - Runs the synthetics tests locally
      - `npm run push` - Pushes the local journeys with configured monitor values to the uptime monitor management UI. 