### PR TITLE
chore: fix flaky test with browser close

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -304,8 +304,8 @@ describe('CLI', () => {
       ])
       .run();
     expect(await cli.exitCode).toBe(1);
-    const output = cli.output();
-    expect(JSON.parse(output).error).toMatchObject({
+    const [output] = safeParse([cli.output()]);
+    expect(output.error).toMatchObject({
       name: 'TypeError',
       message: 'Cannot add property foo, object is not extensible',
     });

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -264,8 +264,8 @@ describe('network', () => {
       waitUntil: 'networkidle',
     });
     await driver.page.reload();
-    await Gatherer.stop();
     const netinfo = await network.stop();
+    await Gatherer.stop();
     const resources = netinfo.filter(req =>
       req.url.includes(`${server.PREFIX}/test.js`)
     );

--- a/__tests__/push/bundler.test.ts
+++ b/__tests__/push/bundler.test.ts
@@ -23,7 +23,8 @@
  *
  */
 
-import { createReadStream, createWriteStream, unlinkSync } from 'fs';
+import { createReadStream } from 'fs';
+import { writeFile, unlink } from 'fs/promises';
 import unzipper from 'unzipper';
 import { join } from 'path';
 import { generateTempPath } from '../../src/helpers';
@@ -34,8 +35,7 @@ const journeyFile = join(__dirname, '..', 'e2e', 'uptime.journey.ts');
 async function validateZip(content) {
   const decoded = Buffer.from(content, 'base64');
   const pathToZip = generateTempPath();
-  const writeStr = createWriteStream(pathToZip);
-  writeStr.write(decoded);
+  await writeFile(pathToZip, decoded);
 
   const files = [];
   const entries = createReadStream(pathToZip).pipe(
@@ -46,7 +46,7 @@ async function validateZip(content) {
   }
 
   expect(files).toEqual(['__tests__/e2e/uptime.journey.ts']);
-  unlinkSync(pathToZip);
+  await unlink(pathToZip);
 }
 
 describe('Bundler', () => {


### PR DESCRIPTION
+ Fix this error when reload didnt trigger on time for cached requests when testing via browser service.  
```
  ● network › cached resource timings

    response.allHeaders: Browser has been closed

      184 |     this._addBarrier(
      185 |       page,
    > 186 |       response.allHeaders().then(resHeaders => {
          |                ^
      187 |         networkEntry.response.headers = resHeaders;
      188 |
      189 |         const contentType = resHeaders['content-type'];
```
+ Write file using async instead of stream as we have to deal with when stream has started writing and then have to read otherwise the file wont be present. 