### PR TITLE
chore: rename push to project in api endpoint

### DIFF
--- a/__tests__/push/request.test.ts
+++ b/__tests__/push/request.test.ts
@@ -49,7 +49,7 @@ describe('Push api request', () => {
 
   it('api schema', async () => {
     server.route(
-      '/s/dummy/api/synthetics/service/push/monitors',
+      '/s/dummy/api/synthetics/service/project/monitors',
       (req, res) => {
         let data = '';
         req.on('data', chunks => {

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -47,7 +47,7 @@ function encodeAuth(auth: string) {
 
 function getAPIUrl(options: PushOptions) {
   return (
-    options.url + `/s/${options.space}/api/synthetics/service/push/monitors`
+    options.url + `/s/${options.space}/api/synthetics/service/project/monitors`
   );
 }
 


### PR DESCRIPTION
+ the api endpoint changed from `push` to `project` as we have deprecated the other namings around suites and such. 