### PR TITLE
chore: handle 404 erorrs on push endpoint

### DIFF
--- a/__tests__/push/__snapshots__/request.test.ts.snap
+++ b/__tests__/push/__snapshots__/request.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Push api request format 404 error 1`] = `"✖ Please check your kibana url and try again - 404:Not Found"`;
+
 exports[`Push api request format api error 1`] = `
 "✖ Error
    ✖ monitor creation failed - 401:Unauthorized

--- a/__tests__/push/request.test.ts
+++ b/__tests__/push/request.test.ts
@@ -31,6 +31,7 @@ import {
   createMonitors,
   formatAPIError,
   formatFailedMonitors,
+  formatNotFoundError,
   formatStaleMonitors,
 } from '../../src/push/request';
 import { Server } from '../utils/server';
@@ -88,6 +89,11 @@ describe('Push api request', () => {
     };
 
     expect(formatAPIError(statusCode, error, message)).toMatchSnapshot();
+  });
+
+  it('format 404 error', () => {
+    const message = 'Not Found';
+    expect(formatNotFoundError(message)).toMatchSnapshot();
   });
 
   it('format failed monitors', () => {

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -30,6 +30,7 @@ import {
   formatAPIError,
   formatFailedMonitors,
   formatStaleMonitors,
+  formatNotFoundError,
 } from './request';
 import { Monitor } from '../dsl/monitor';
 import { PushOptions } from '../common_types';
@@ -58,6 +59,9 @@ export async function push(monitors: Monitor[], options: PushOptions) {
   try {
     progress(`creating all monitors`);
     const { body, statusCode } = await createMonitors(schemas, options);
+    if (statusCode === 404) {
+      throw formatNotFoundError(await body.text());
+    }
     if (!ok(statusCode)) {
       const { error, message } = await body.json();
       throw formatAPIError(statusCode, error, message);

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -83,6 +83,12 @@ export type APIMonitorError = {
   details: string;
 };
 
+export function formatNotFoundError(message: string) {
+  return bold(
+    `${symbols['failed']} Please check your kibana url and try again - 404:${message}`
+  );
+}
+
 export function formatAPIError(
   statuCode: number,
   error: string,


### PR DESCRIPTION
+ Part of #470 
+ Handle cases when invalid Kibana endpoint was provided. Most likely happens when development when there is more chance of base path being different between every restart. 