### PR TITLE
chore: set screenshots to off unless enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Experimental Synthetics Agent
 
 Synthetic Monitoring with Real Browsers.
-**Please note this is an unsupported experimental project. Expect things to break and change!**
+**Please note this is project is in beta status. Expect things to break and change!**
 
 ## Usage
 

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -53,7 +53,7 @@ export class CLIMock {
   private chunks: Array<string> = [];
   private waitForText: string;
   private waitForPromise: () => void;
-  private cliArgs: string[];
+  private cliArgs: string[] = [];
   private stdinStr?: string;
   private stderrStr: string;
   exitCode: Promise<number>;
@@ -61,7 +61,12 @@ export class CLIMock {
   constructor(public debug: boolean = false) {}
 
   args(a: string[]): CLIMock {
-    this.cliArgs = a;
+    this.cliArgs.push(...a);
+    // Screenshots is `on` by default in CLI, so we
+    // disable it for all tests, unless enabled explicity
+    if (!(a.includes('--rich-events') || a.includes('--screenshots'))) {
+      this.cliArgs.push('--screenshots', 'off');
+    }
     return this;
   }
 


### PR DESCRIPTION
+ With the way our CLI tests run and screenshot being written to the stdout when the reporter is `json` - breaking on new lines might not be always correct as sometimes the underlying stream explicitly buffers everything till a specific length. 
+ So we set screenshots to `off` by default unless the tests are asking to test that functionality explicitly. 