### PR TITLE
feat: interactive scaffolding for picking default monitor config

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -29,10 +29,13 @@ import Runner from '../../src/core/runner';
 import { step, journey } from '../../src/core';
 import { Journey, Step } from '../../src/dsl';
 import { Server } from '../utils/server';
-import { generateTempPath, noop } from '../../src/helpers';
+import {
+  DEFAULT_THROTTLING_OPTIONS,
+  generateTempPath,
+  noop,
+} from '../../src/helpers';
 import { wsEndpoint } from '../utils/test-config';
 import { Reporter } from '../../src/reporters';
-import { getDefaultMonitorConfig } from '../../src/options';
 import {
   JourneyEndResult,
   JourneyStartResult,
@@ -686,7 +689,7 @@ describe('runner', () => {
     runner.addJourney(j2);
 
     const monitors = runner.buildMonitors({
-      ...getDefaultMonitorConfig(),
+      throttling: DEFAULT_THROTTLING_OPTIONS,
     });
     expect(monitors.length).toBe(2);
     expect(monitors[0].config).toEqual({
@@ -700,8 +703,6 @@ describe('runner', () => {
       throttling: { download: 5, latency: 20, upload: 3 },
     });
     expect(monitors[1].config).toMatchObject({
-      locations: ['us_east'],
-      schedule: 10,
       throttling: { latency: 1000 },
     });
   });
@@ -709,6 +710,7 @@ describe('runner', () => {
   it('runner - build monitors with global config', async () => {
     runner.updateMonitor({
       schedule: 5,
+      locations: ['us_east'],
       throttling: { download: 100, upload: 50 },
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },
@@ -726,7 +728,7 @@ describe('runner', () => {
     runner.addJourney(j2);
 
     const monitors = runner.buildMonitors({
-      ...getDefaultMonitorConfig(),
+      throttling: DEFAULT_THROTTLING_OPTIONS,
     });
     expect(monitors.length).toBe(2);
     expect(monitors[0].config).toEqual({

--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -42,7 +42,15 @@ describe('Generator', () => {
     });
   });
   it('generate synthetics project - NPM', async () => {
-    const cli = new CLIMock().args(['init', scaffoldDir]).run();
+    const cli = new CLIMock().args(['init', scaffoldDir]).run({
+      env: {
+        ...process.env,
+        TEST_QUESTIONS: JSON.stringify({
+          locations: 'US East',
+          schedule: 30,
+        }),
+      },
+    });
     expect(await cli.exitCode).toBe(0);
 
     // Verify files
@@ -62,6 +70,13 @@ describe('Generator', () => {
       existsSync(join(scaffoldDir, 'journeys', 'example.journey.ts'))
     ).toBeTruthy();
     expect(existsSync(join(scaffoldDir, 'synthetics.config.ts'))).toBeTruthy();
+    // Verify schedule and locations
+    const configFile = await readFile(
+      join(scaffoldDir, 'synthetics.config.ts'),
+      'utf-8'
+    );
+    expect(configFile).toContain(`locations: ["US East"]`);
+    expect(configFile).toContain(`schedule: 30`);
 
     // Verify stdout
     const stderr = cli.stderr();

--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -46,7 +46,7 @@ describe('Generator', () => {
       env: {
         ...process.env,
         TEST_QUESTIONS: JSON.stringify({
-          locations: 'US East',
+          locations: 'us_east',
           schedule: 30,
         }),
       },
@@ -75,7 +75,7 @@ describe('Generator', () => {
       join(scaffoldDir, 'synthetics.config.ts'),
       'utf-8'
     );
-    expect(configFile).toContain(`locations: ["US East"]`);
+    expect(configFile).toContain(`locations: ["us_east"]`);
     expect(configFile).toContain(`schedule: 30`);
 
     // Verify stdout

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -75,15 +75,12 @@ describe('options', () => {
 
   it('normalize monitor configs', () => {
     expect(normalizeOptions({ throttling: false })).toMatchObject({
-      locations: ['us_east'],
-      schedule: 10,
       throttling: {},
     });
 
     expect(
       normalizeOptions({ throttling: { download: 50 }, schedule: 2 })
     ).toMatchObject({
-      locations: ['us_east'],
       schedule: 2,
       throttling: {
         download: 50,

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -1,0 +1,67 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { join } from 'path';
+import { CLIMock } from '../utils/test-config';
+
+const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
+
+describe('Push CLI', () => {
+  const args = [
+    '--url',
+    'http://localhost:8000',
+    '--auth',
+    'foo',
+    '--project',
+    'test',
+  ];
+  const journeyFile = join(FIXTURES_DIR, 'example.journey.ts');
+  it('erorr when no journey files are passed', async () => {
+    const cli = new CLIMock().args(['push', ...args]).run();
+    expect(await cli.exitCode).toBe(1);
+
+    expect(cli.stderr()).toContain(
+      `error: missing required argument 'journeys'`
+    );
+  });
+
+  it('erorr when schedule option is empty', async () => {
+    const cli = new CLIMock().args(['push', journeyFile, ...args]).run();
+    expect(await cli.exitCode).toBe(1);
+
+    expect(cli.stderr()).toContain(
+      `Set default schedule in minutes for all monitors`
+    );
+  });
+
+  it('erorr when locations option is empty', async () => {
+    const cli = new CLIMock()
+      .args(['push', journeyFile, ...args, '--schedule', '20'])
+      .run();
+    expect(await cli.exitCode).toBe(1);
+
+    expect(cli.stderr()).toContain(`Set default location for all monitors`);
+  });
+});

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -38,7 +38,7 @@ describe('Push CLI', () => {
     'test',
   ];
   const journeyFile = join(FIXTURES_DIR, 'example.journey.ts');
-  it('erorr when no journey files are passed', async () => {
+  it('errors when no journey files are passed', async () => {
     const cli = new CLIMock().args(['push', ...args]).run();
     expect(await cli.exitCode).toBe(1);
 
@@ -56,7 +56,7 @@ describe('Push CLI', () => {
     );
   });
 
-  it('erorr when locations option is empty', async () => {
+  it('errors when locations option is empty', async () => {
     const cli = new CLIMock()
       .args(['push', journeyFile, ...args, '--schedule', '20'])
       .run();

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -75,7 +75,7 @@ export class CLIMock {
     return this;
   }
 
-  run(spawnOverrides?: { cwd?: string }): CLIMock {
+  run(spawnOverrides?: { cwd?: string; env?: NodeJS.ProcessEnv }): CLIMock {
     this.process = spawn(
       'node',
       [join(__dirname, '..', '..', 'dist', 'cli.js'), ...this.cliArgs],

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -55,7 +55,7 @@ export class CLIMock {
   private waitForPromise: () => void;
   private cliArgs: string[] = [];
   private stdinStr?: string;
-  private stderrStr: string;
+  private stderrStr = '';
   exitCode: Promise<number>;
 
   constructor(public debug: boolean = false) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "archiver": "^5.3.0",
         "commander": "^9.0.0",
         "deepmerge": "^4.2.2",
+        "enquirer": "^2.3.6",
         "esbuild": "^0.14.27",
         "expect": "^27.0.2",
         "http-proxy": "^1.18.1",
@@ -1981,7 +1982,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2991,7 +2991,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -9899,8 +9898,7 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -10659,7 +10657,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "archiver": "^5.3.0",
     "commander": "^9.0.0",
     "deepmerge": "^4.2.2",
+    "enquirer": "^2.3.6",
     "esbuild": "^0.14.27",
     "expect": "^27.0.2",
     "http-proxy": "^1.18.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@
  *
  */
 
-import { program, Option } from 'commander';
+import { program, Option, Argument } from 'commander';
 import { CliArgs, PushOptions } from './common_types';
 import { reporters } from './reporters';
 import { normalizeOptions, parseThrottling } from './options';
@@ -146,9 +146,15 @@ program
 
 // Push command
 program
-  .command('push [files...]')
+  .command('push')
+  .addArgument(
+    new Argument(
+      '[journeys...]',
+      'file path to journey directory and individual files'
+    ).argRequired()
+  )
   .description(
-    'Push monitors to create new montors with Kibana monitor management UI'
+    'Push journeys to create montors within Kibana monitor management UI'
   )
   .option(
     '--schedule <time-in-minutes>',
@@ -176,10 +182,9 @@ program
     'default'
   )
   .option('--delete', 'automatically delete the stale monitors.')
-  .action(async (files, cmdOpts: PushOptions) => {
+  .action(async (journeys, cmdOpts: PushOptions) => {
     try {
-      const cliArgs = { inline: false };
-      await loadTestFiles(cliArgs, files);
+      await loadTestFiles({ inline: false }, journeys);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
       if (!options.schedule) {
         throw error(`Set default schedule in minutes for all monitors via '--schedule <time-in-minutes>' OR

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -169,7 +169,7 @@ program
   )
   .requiredOption(
     '--project <project-id>',
-    'project/repository id that will be used for grouping the monitors.'
+    'id that will be used for logically grouping monitors'
   )
   .requiredOption('--url <url>', 'kibana URL to upload the monitors')
   .requiredOption(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,8 +162,8 @@ program
     ).choices(SyntheticsLocations)
   )
   .requiredOption(
-    '--project <id/name>',
-    'project/repository that will be used for grouping the monitors.'
+    '--project <project-id>',
+    'project/repository id that will be used for grouping the monitors.'
   )
   .requiredOption('--url <url>', 'kibana URL to upload the monitors')
   .requiredOption(
@@ -184,7 +184,7 @@ program
       const monitors = runner.buildMonitors(options);
       await push(monitors, cmdOpts);
     } catch (e) {
-      console.error(e);
+      e && console.error(e);
       process.exit(1);
     }
   });
@@ -198,7 +198,7 @@ program
       const generator = await new Generator(resolve(process.cwd(), dir));
       await generator.setup();
     } catch (e) {
-      error(e);
+      e && error(e);
       process.exit(1);
     }
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -181,6 +181,15 @@ program
       const cliArgs = { inline: false };
       await loadTestFiles(cliArgs, files);
       const options = normalizeOptions({ ...program.opts(), ...cmdOpts });
+      if (!options.schedule) {
+        throw error(`Set default schedule in minutes for all monitors via '--schedule <time-in-minutes>' OR
+  configure via Synthetics config file under 'monitors.schedule' field.`);
+      }
+
+      if (!options.locations) {
+        throw error(`Set default location for all monitors via CLI as '--locations <locations...>' OR
+  configure via Synthetics config file under 'monitors.locations' field.`);
+      }
       const monitors = runner.buildMonitors(options);
       await push(monitors, cmdOpts);
     } catch (e) {

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -27,12 +27,19 @@ import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { bold, cyan, yellow } from 'kleur/colors';
 import { join, relative, dirname, basename } from 'path';
+import { prompt } from 'enquirer';
+import { SyntheticsLocations } from '../dsl/monitor';
 import { progress, write as stdWrite } from '../helpers';
-import { getPackageManager, runCommand } from './utils';
+import { getPackageManager, replaceTemplates, runCommand } from './utils';
 
 // Templates that are required for setting up new
 // synthetics project
 const templateDir = join(__dirname, '..', '..', 'templates');
+
+type PromptOptions = {
+  locations: string;
+  schedule: number;
+};
 
 export class Generator {
   pkgManager = 'npm';
@@ -44,13 +51,35 @@ export class Generator {
     }
   }
 
-  async files() {
+  async questions() {
+    const question = [
+      {
+        type: 'select',
+        name: 'locations',
+        message:
+          'Select the default location from which your monitors will run.',
+        choices: SyntheticsLocations,
+      },
+      {
+        type: 'numeral',
+        name: 'schedule',
+        message: 'Set default schedule in minutes for all monitors',
+        initial: 10,
+      },
+    ];
+    return await prompt<PromptOptions>(question);
+  }
+
+  async files(answers: PromptOptions) {
     const fileMap = new Map<string, string>();
     // Setup Synthetics config file
     const configFile = 'synthetics.config.ts';
     fileMap.set(
       configFile,
-      await readFile(join(templateDir, configFile), 'utf-8')
+      replaceTemplates(
+        await readFile(join(templateDir, configFile), 'utf-8'),
+        answers
+      )
     );
 
     // Setup example journey file
@@ -161,7 +190,8 @@ Visit https://www.elastic.co/guide/en/observability/master/synthetics-journeys.h
   async setup() {
     await this.directory();
     await this.package();
-    await this.files();
+    const answers = await this.questions();
+    await this.files(answers);
     await this.patchPkgJSON();
     await this.patchGitIgnore();
     this.banner();

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -52,12 +52,14 @@ export class Generator {
   }
 
   async questions() {
+    if (process.env.TEST_QUESTIONS) {
+      return JSON.parse(process.env.TEST_QUESTIONS);
+    }
     const question = [
       {
         type: 'select',
         name: 'locations',
-        message:
-          'Select the default location from which your monitors will run.',
+        message: 'Select the default location where you want to run monitors.',
         choices: SyntheticsLocations,
       },
       {
@@ -189,8 +191,8 @@ Visit https://www.elastic.co/guide/en/observability/master/synthetics-journeys.h
 
   async setup() {
     await this.directory();
-    await this.package();
     const answers = await this.questions();
+    await this.package();
     await this.files(answers);
     await this.patchPkgJSON();
     await this.patchGitIgnore();

--- a/src/generator/utils.ts
+++ b/src/generator/utils.ts
@@ -39,3 +39,16 @@ export function runCommand(pkgManager: string, command: string) {
   }
   return `npm run ${command}`;
 }
+
+export function replaceTemplates(input: string, literals: Record<string, any>) {
+  for (const key in literals) {
+    const finalValue = literals[key];
+    input = input.replace(new RegExp(`'{{` + key + `}}'`, 'g'), () => {
+      if (typeof finalValue == 'number') {
+        return Number(finalValue);
+      }
+      return finalValue;
+    });
+  }
+  return input;
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -25,11 +25,7 @@
 
 import merge from 'deepmerge';
 import { readConfig } from './config';
-import {
-  getNetworkConditions,
-  DEFAULT_THROTTLING_OPTIONS,
-  error,
-} from './helpers';
+import { getNetworkConditions, DEFAULT_THROTTLING_OPTIONS } from './helpers';
 import type { CliArgs, RunOptions, ThrottlingOptions } from './common_types';
 
 /**
@@ -130,16 +126,7 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
   }
 
   options.schedule = cliArgs.schedule ?? monitor?.schedule;
-  if (!options.schedule) {
-    throw error(`Set default schedule in minutes for all monitors via '--schedule <time-in-minutes>' OR
-configure via Synthetics config file under 'monitors.schedule' field.`);
-  }
-
   options.locations = cliArgs.locations ?? monitor?.locations;
-  if (!options.locations) {
-    throw error(`Set default location for all monitors via CLI as '--locations <locations...>' OR
-configure via Synthetics config file under 'monitors.locations' field.`);
-  }
 
   return options;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -109,11 +109,14 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
     },
   ]);
 
-  const defaults = getDefaultMonitorConfig();
+  /**
+   * Get the default monitor config from synthetics.config.ts file
+   */
+  const monitor = config.monitor;
   if (cliArgs.throttling) {
     const throttleConfig = merge.all([
-      defaults.throttling,
-      config.monitor?.throttling || {},
+      DEFAULT_THROTTLING_OPTIONS,
+      monitor?.throttling || {},
       cliArgs.throttling as ThrottlingOptions,
     ]);
     options.throttling = throttleConfig;
@@ -129,17 +132,6 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
   options.locations = cliArgs.locations ?? monitor?.locations;
 
   return options;
-}
-
-/**
- * Get the default monitor configuration for all journeys
- */
-export function getDefaultMonitorConfig(): MonitorConfig {
-  return {
-    throttling: DEFAULT_THROTTLING_OPTIONS,
-    locations: ['us_east'],
-    schedule: 10,
-  };
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -25,7 +25,11 @@
 
 import merge from 'deepmerge';
 import { readConfig } from './config';
-import { getNetworkConditions, DEFAULT_THROTTLING_OPTIONS } from './helpers';
+import {
+  getNetworkConditions,
+  DEFAULT_THROTTLING_OPTIONS,
+  error,
+} from './helpers';
 import type { CliArgs, RunOptions, ThrottlingOptions } from './common_types';
 
 /**
@@ -125,11 +129,17 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
     options.throttling = {};
   }
 
-  options.locations =
-    cliArgs.locations ?? config.monitor?.locations ?? defaults.locations;
+  options.schedule = cliArgs.schedule ?? monitor?.schedule;
+  if (!options.schedule) {
+    throw error(`Set default schedule in minutes for all monitors via '--schedule <time-in-minutes>' OR
+configure via Synthetics config file under 'monitors.schedule' field.`);
+  }
 
-  options.schedule =
-    cliArgs.schedule ?? config.monitor?.schedule ?? defaults.schedule;
+  options.locations = cliArgs.locations ?? monitor?.locations;
+  if (!options.locations) {
+    throw error(`Set default location for all monitors via CLI as '--locations <locations...>' OR
+configure via Synthetics config file under 'monitors.locations' field.`);
+  }
 
   return options;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -27,7 +27,6 @@ import merge from 'deepmerge';
 import { readConfig } from './config';
 import { getNetworkConditions, DEFAULT_THROTTLING_OPTIONS } from './helpers';
 import type { CliArgs, RunOptions, ThrottlingOptions } from './common_types';
-import { MonitorConfig } from './dsl/monitor';
 
 /**
  * Set debug based on DEBUG ENV and -d flags

--- a/templates/synthetics.config.ts
+++ b/templates/synthetics.config.ts
@@ -11,7 +11,10 @@ export default env => {
     /**
      * Configure global monitor settings
      */
-    monitor: {},
+    monitor: {
+      schedule: '{{schedule}}',
+      locations: ["'{{locations}}'"],
+    },
   };
   if (env !== 'development') {
     /**


### PR DESCRIPTION
+ fix https://github.com/elastic/synthetics-dev/issues/119
+ part of #513 
+ `init` command scaffolding asks interactive questions for both `Locations` and `Schedule` which would be set as default on the Synthetics.config.ts file to be used when pushing the monitors. 
+ Error out when push command is invoked without passing the journey file paths
+ Make the location and schedule option as required `--locations <>` in the CLI and error out when not set. 
+ Allow users to configure the default values via `synthetics.config.ts` file


### How to test
1. Build the agent `npm run build`
2. Run `node dist/cli.js init test-directory`
3. Verify if it sets up all the default schedule and locations in the `synthetics.config.ts` generated file. 