### PR TITLE
fix: write .gitnore files for scaffolding

### DIFF
--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -24,7 +24,7 @@
  */
 
 import { existsSync } from 'fs';
-import { rm } from 'fs/promises';
+import { readFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { CLIMock } from '../utils/test-config';
 
@@ -49,6 +49,15 @@ describe('Generator', () => {
     expect(existsSync(join(scaffoldDir, 'package.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, 'package-lock.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, '.gitignore'))).toBeTruthy();
+
+    // Verify gitignore contents
+    expect(await readFile(join(scaffoldDir, '.gitignore'), 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "node_modules/
+      .synthetics/
+      "
+    `);
+
     expect(
       existsSync(join(scaffoldDir, 'journeys', 'example.journey.ts'))
     ).toBeTruthy();

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -59,11 +59,6 @@ export class Generator {
       journeyFile,
       await readFile(join(templateDir, journeyFile), 'utf-8')
     );
-    // Setup gitignore
-    fileMap.set(
-      '.gitignore',
-      await readFile(join(templateDir, '.gitignore'), 'utf-8')
-    );
 
     // Create files
     for (const [relativePath, content] of fileMap) {
@@ -131,6 +126,20 @@ export class Generator {
     );
   }
 
+  async patchGitIgnore() {
+    const gitIgnorePath = join(this.projectDir, '.gitignore');
+    let gitIgnore = '';
+    if (existsSync(gitIgnorePath)) {
+      const contents = await readFile(gitIgnorePath, 'utf-8');
+      gitIgnore += contents.trimEnd() + '\n';
+    }
+    if (!gitIgnore.includes('node_modules')) {
+      gitIgnore += 'node_modules/\n';
+    }
+    gitIgnore += '.synthetics/\n';
+    await writeFile(gitIgnorePath, gitIgnore, 'utf-8');
+  }
+
   banner() {
     stdWrite(
       bold(`
@@ -154,6 +163,7 @@ Visit https://www.elastic.co/guide/en/observability/master/synthetics-journeys.h
     await this.package();
     await this.files();
     await this.patchPkgJSON();
+    await this.patchGitIgnore();
     this.banner();
   }
 }

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,2 +1,0 @@
-node_modules
-.synthetics

--- a/templates/synthetics.config.ts
+++ b/templates/synthetics.config.ts
@@ -8,6 +8,10 @@ export default env => {
     playwrightOptions: {
       ignoreHTTPSErrors: false,
     },
+    /**
+     * Configure global monitor settings
+     */
+    monitor: {},
   };
   if (env !== 'development') {
     /**


### PR DESCRIPTION
+ fix #509 
+ We update the `.gitignore` contents if the init is called on an existing directory and override it instead of using it from the templates directory. 