### PR TITLE
feat: use apiKey instead of basic auth

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,7 +158,7 @@ program
   .addOption(
     new Option(
       '--locations <locations...>',
-      'The default list of locations from which your monitors will run.'
+      'default list of locations from which your monitors will run.'
     ).choices(SyntheticsLocations)
   )
   .requiredOption(
@@ -168,7 +168,7 @@ program
   .requiredOption('--url <url>', 'kibana URL to upload the monitors')
   .requiredOption(
     '--auth <auth>',
-    'user authentication (in user:password format) or API key that will be used to communicate with Kibana.'
+    'API key used for Kibana authentication(https://www.elastic.co/guide/en/kibana/master/api-keys.html).'
   )
   .option(
     '--space <space>',

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -122,7 +122,7 @@ export class Generator {
 
     // Add push command
     const project = basename(this.projectDir);
-    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth basic-auth`;
+    pkgJSON.scripts.push = `npx @elastic/synthetics push journeys --project ${project} --url http://localhost:5601 --auth apiKey`;
 
     await this.createFile(
       filename,
@@ -141,7 +141,7 @@ All set, you can run below commands inside: ${this.projectDir}:
   Push monitors to Kibana: ${cyan(runCommand(this.pkgManager, 'push'))}
 
   ${yellow(
-    'Make sure to update the Kibana url and authentication info before pushing monitors to Kibana.'
+    'Make sure to update the Kibana url and api keys before pushing monitors to Kibana.'
   )}
 
 Visit https://www.elastic.co/guide/en/observability/master/synthetics-journeys.html to learn more.

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -38,13 +38,6 @@ export type APISchema = {
   monitors: MonitorSchema[];
 };
 
-function encodeAuth(auth: string) {
-  if (auth.includes(':')) {
-    return Buffer.from(auth).toString('base64');
-  }
-  return auth;
-}
-
 function getAPIUrl(options: PushOptions) {
   return (
     options.url + `/s/${options.space}/api/synthetics/service/project/monitors`
@@ -69,7 +62,7 @@ export async function createMonitors(
     method: 'PUT',
     body: JSON.stringify(schema),
     headers: {
-      authorization: `Basic ${encodeAuth(options.auth)}`,
+      authorization: `ApiKey ${options.auth}`,
       'content-type': 'application/json',
       'user-agent': `Elastic/Synthetics ${version}`,
       'kbn-xsrf': 'true',


### PR DESCRIPTION
+ fix #511 
+ Sends the push request using the format `Authorization: APiKey <token>` instead of basic auth headers - https://www.elastic.co/guide/en/kibana/master/api-keys.html