### PR TITLE
fix: only append 'Elastic/Synthetics' to default UA

### DIFF
--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -65,12 +65,12 @@ export class Gatherer {
   }
 
   static async getUserAgent(userAgent?: string) {
-    const syntheticsIdentifier = ' Elastic/Synthetics';
     if (!userAgent) {
       const session = await Gatherer.browser.newBrowserCDPSession();
       ({ userAgent } = await session.send('Browser.getVersion'));
+      return userAgent + ' Elastic/Synthetics';
     }
-    return userAgent + syntheticsIdentifier;
+    return userAgent;
   }
 
   static setNetworkConditions(


### PR DESCRIPTION
When we originally implemented https://github.com/elastic/synthetics/issues/232 it appears we didn't implement the third AC, allowing users to override our custom UA string "Elastic/Synthetics" which is appended.

Some users need to fully replace the UA, this allows them to do that. Rather than adding a boolean, this assumes that if you're overriding the UA you want full control, which is more in line with the principle of least surprise.

CC @paulb-elastic @drewpost 

PS this is currently a draft because there are no tests, I'll add tests if we agree on this approach.