### PR TITLE
feat: update new synthetics test node locations

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -679,7 +679,7 @@ describe('runner', () => {
     j1.updateMonitor({
       id: 'test-j1',
       schedule: 2,
-      locations: ['United Kingdom'],
+      locations: ['Europe - United Kingdom'],
     });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
@@ -693,14 +693,14 @@ describe('runner', () => {
       id: 'test-j1',
       name: 'j1',
       tags: [],
-      locations: ['United Kingdom'],
+      locations: ['Europe - United Kingdom'],
       schedule: 2,
       params: undefined,
       playwrightOptions: undefined,
       throttling: { download: 5, latency: 20, upload: 3 },
     });
     expect(monitors[1].config).toMatchObject({
-      locations: ['US East'],
+      locations: ['North America - US East'],
       schedule: 10,
       throttling: { latency: 1000 },
     });
@@ -719,7 +719,7 @@ describe('runner', () => {
     j1.updateMonitor({
       id: 'test-j1',
       schedule: 2,
-      locations: ['United Kingdom'],
+      locations: ['Europe - United Kingdom'],
     });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
@@ -733,14 +733,14 @@ describe('runner', () => {
       id: 'test-j1',
       name: 'j1',
       tags: ['foo*'],
-      locations: ['United Kingdom'],
+      locations: ['Europe - United Kingdom'],
       schedule: 2,
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },
       throttling: { download: 100, latency: 20, upload: 50 },
     });
     expect(monitors[1].config).toMatchObject({
-      locations: ['US East'],
+      locations: ['North America - US East'],
       schedule: 5,
       throttling: { latency: 1000 },
     });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -676,7 +676,11 @@ describe('runner', () => {
   it('runner - build monitors with local config', async () => {
     const j1 = new Journey({ name: 'j1' }, noop);
     const j2 = new Journey({ name: 'j2' }, noop);
-    j1.updateMonitor({ id: 'test-j1', schedule: 2, locations: ['EU West'] });
+    j1.updateMonitor({
+      id: 'test-j1',
+      schedule: 2,
+      locations: ['United Kingdom'],
+    });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
     runner.addJourney(j2);
@@ -689,7 +693,7 @@ describe('runner', () => {
       id: 'test-j1',
       name: 'j1',
       tags: [],
-      locations: ['EU West'],
+      locations: ['United Kingdom'],
       schedule: 2,
       params: undefined,
       playwrightOptions: undefined,
@@ -712,7 +716,11 @@ describe('runner', () => {
 
     const j1 = new Journey({ name: 'j1', tags: ['foo*'] }, noop);
     const j2 = new Journey({ name: 'j2' }, noop);
-    j1.updateMonitor({ id: 'test-j1', schedule: 2, locations: ['EU West'] });
+    j1.updateMonitor({
+      id: 'test-j1',
+      schedule: 2,
+      locations: ['United Kingdom'],
+    });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
     runner.addJourney(j2);
@@ -725,7 +733,7 @@ describe('runner', () => {
       id: 'test-j1',
       name: 'j1',
       tags: ['foo*'],
-      locations: ['EU West'],
+      locations: ['United Kingdom'],
       schedule: 2,
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -679,7 +679,7 @@ describe('runner', () => {
     j1.updateMonitor({
       id: 'test-j1',
       schedule: 2,
-      locations: ['Europe - United Kingdom'],
+      locations: ['united_kingdom'],
     });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
@@ -693,14 +693,14 @@ describe('runner', () => {
       id: 'test-j1',
       name: 'j1',
       tags: [],
-      locations: ['Europe - United Kingdom'],
+      locations: ['united_kingdom'],
       schedule: 2,
       params: undefined,
       playwrightOptions: undefined,
       throttling: { download: 5, latency: 20, upload: 3 },
     });
     expect(monitors[1].config).toMatchObject({
-      locations: ['North America - US East'],
+      locations: ['us_east'],
       schedule: 10,
       throttling: { latency: 1000 },
     });
@@ -719,7 +719,7 @@ describe('runner', () => {
     j1.updateMonitor({
       id: 'test-j1',
       schedule: 2,
-      locations: ['Europe - United Kingdom'],
+      locations: ['united_kingdom'],
     });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
@@ -733,14 +733,14 @@ describe('runner', () => {
       id: 'test-j1',
       name: 'j1',
       tags: ['foo*'],
-      locations: ['Europe - United Kingdom'],
+      locations: ['united_kingdom'],
       schedule: 2,
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },
       throttling: { download: 100, latency: 20, upload: 50 },
     });
     expect(monitors[1].config).toMatchObject({
-      locations: ['North America - US East'],
+      locations: ['us_east'],
       schedule: 5,
       throttling: { latency: 1000 },
     });

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -75,7 +75,7 @@ describe('options', () => {
 
   it('normalize monitor configs', () => {
     expect(normalizeOptions({ throttling: false })).toMatchObject({
-      locations: ['US East'],
+      locations: ['North America - US East'],
       schedule: 10,
       throttling: {},
     });
@@ -83,7 +83,7 @@ describe('options', () => {
     expect(
       normalizeOptions({ throttling: { download: 50 }, schedule: 2 })
     ).toMatchObject({
-      locations: ['US East'],
+      locations: ['North America - US East'],
       schedule: 2,
       throttling: {
         download: 50,

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -75,7 +75,7 @@ describe('options', () => {
 
   it('normalize monitor configs', () => {
     expect(normalizeOptions({ throttling: false })).toMatchObject({
-      locations: ['North America - US East'],
+      locations: ['us_east'],
       schedule: 10,
       throttling: {},
     });
@@ -83,7 +83,7 @@ describe('options', () => {
     expect(
       normalizeOptions({ throttling: { download: 50 }, schedule: 2 })
     ).toMatchObject({
-      locations: ['North America - US East'],
+      locations: ['us_east'],
       schedule: 2,
       throttling: {
         download: 50,

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -35,7 +35,7 @@ describe('Monitor schema', () => {
       name: 'test',
       schedule: 10,
       enabled: true,
-      locations: ['europe-west2-a'],
+      locations: ['europe-west2-a', 'australia-southeast1-a'],
       content: expect.any(String),
       filter: {
         match: 'test',

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -36,7 +36,7 @@ export function createTestMonitor(filename: string) {
     name: 'test',
     schedule: 10,
     enabled: true,
-    locations: ['United Kingdom', 'Australia East'],
+    locations: ['Europe - United Kingdom', 'Asia/Pacific - Australia East'],
   });
   monitor.setSource({
     file: join(FIXTURES_DIR, filename),

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -36,7 +36,7 @@ export function createTestMonitor(filename: string) {
     name: 'test',
     schedule: 10,
     enabled: true,
-    locations: ['Europe - United Kingdom', 'Asia/Pacific - Australia East'],
+    locations: ['united_kingdom', 'australia_east'],
   });
   monitor.setSource({
     file: join(FIXTURES_DIR, filename),

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -36,7 +36,7 @@ export function createTestMonitor(filename: string) {
     name: 'test',
     schedule: 10,
     enabled: true,
-    locations: ['EU West'],
+    locations: ['United Kingdom', 'Australia East'],
   });
   monitor.setSource({
     file: join(FIXTURES_DIR, filename),

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "clean": "rimraf dist",
     "prepublish": "npm run clean && npm run build",
     "build": "tsc",
+    "build:locations": "sh utils/update_locations.sh",
     "watch": "tsc -w",
     "lint": "eslint . --rulesdir utils/eslint-rules",
     "lint:fix": "npm run lint -- --fix",

--- a/src/dsl/locations.ts
+++ b/src/dsl/locations.ts
@@ -1,0 +1,38 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+// DO NOT EDIT - UPDATE WITH `npm run build:locations`
+export const LocationsMap = {
+  japan: 'asia-northeast1-a',
+  india: 'asia-south1-a',
+  singapore: 'asia-southeast1-a',
+  australia_east: 'australia-southeast1-a',
+  united_kingdom: 'europe-west2-a',
+  germany: 'europe-west3-a',
+  canada_east: 'northamerica-northeast1-a',
+  brazil: 'southamerica-east1-a',
+  us_east: 'us-east4-a',
+  us_west: 'us-west1-a',
+};

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -32,20 +32,9 @@ import {
   PlaywrightOptions,
 } from '../common_types';
 
-// Internal representation of Locations that would be used when
-// talking to the Kibana API
-export const LocationsMap = {
-  Japan: 'asia-northeast1-a',
-  India: 'asia-south1-a',
-  Singapore: 'asia-southeast1-a',
-  'Australia East': 'australia-southeast1-a',
-  'United Kingdom': 'europe-west2-a',
-  Germany: 'europe-west3-a',
-  'Canada East': 'northamerica-northeast1-a',
-  Brazil: 'southamerica-east1-a',
-  'US East': 'us-east4-a',
-  'US West': 'us-west1-a',
-};
+import { LocationsMap } from './locations';
+export { LocationsMap } from './locations';
+
 export type SyntheticsLocationsType = keyof typeof LocationsMap;
 export const SyntheticsLocations = Object.keys(
   LocationsMap

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -32,8 +32,25 @@ import {
   PlaywrightOptions,
 } from '../common_types';
 
-export const SyntheticsLocations = ['US East', 'EU West'] as const;
-export type SyntheticsLocationsType = typeof SyntheticsLocations[number];
+// Internal representation of Locations that would be used when
+// talking to the Kibana API
+export const LocationsMap = {
+  Japan: 'asia-northeast1-a',
+  India: 'asia-south1-a',
+  Singapore: 'asia-southeast1-a',
+  'Australia East': 'australia-southeast1-a',
+  'United Kingdom': 'europe-west2-a',
+  Germany: 'europe-west3-a',
+  'Canada East': 'northamerica-northeast1-a',
+  Brazil: 'southamerica-east1-a',
+  'US East': 'us-east4-a',
+  'US West': 'us-west1-a',
+};
+export type SyntheticsLocationsType = keyof typeof LocationsMap;
+export const SyntheticsLocations = Object.keys(
+  LocationsMap
+) as SyntheticsLocationsType[];
+
 export type MonitorConfig = {
   id?: string;
   name?: string;

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -31,9 +31,7 @@ import {
   Params,
   PlaywrightOptions,
 } from '../common_types';
-
 import { LocationsMap } from './locations';
-export { LocationsMap } from './locations';
 
 export type SyntheticsLocationsType = keyof typeof LocationsMap;
 export const SyntheticsLocations = Object.keys(

--- a/src/options.ts
+++ b/src/options.ts
@@ -141,7 +141,7 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
 export function getDefaultMonitorConfig(): MonitorConfig {
   return {
     throttling: DEFAULT_THROTTLING_OPTIONS,
-    locations: ['US East'],
+    locations: ['North America - US East'],
     schedule: 10,
   };
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -141,7 +141,7 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
 export function getDefaultMonitorConfig(): MonitorConfig {
   return {
     throttling: DEFAULT_THROTTLING_OPTIONS,
-    locations: ['North America - US East'],
+    locations: ['us_east'],
     schedule: 10,
   };
 }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -27,11 +27,7 @@ import { mkdir } from 'fs/promises';
 import { join } from 'path';
 import { Bundler } from './bundler';
 import { CACHE_PATH } from '../helpers';
-import {
-  Monitor,
-  MonitorConfig,
-  SyntheticsLocationsType,
-} from '../dsl/monitor';
+import { Monitor, MonitorConfig, LocationsMap } from '../dsl/monitor';
 
 export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
   content: string;
@@ -39,12 +35,6 @@ export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
   filter: Monitor['filter'];
 };
 
-// Internal representation of Locations that would be used when
-// talking to the Kibana API
-const LocationsMap: Record<SyntheticsLocationsType, string> = {
-  'US East': 'us-east4-a',
-  'EU West': 'europe-west2-a',
-};
 function translateLocation(locations: MonitorConfig['locations']) {
   return locations.map(loc => LocationsMap[loc]).filter(Boolean);
 }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -27,7 +27,8 @@ import { mkdir } from 'fs/promises';
 import { join } from 'path';
 import { Bundler } from './bundler';
 import { CACHE_PATH } from '../helpers';
-import { Monitor, MonitorConfig, LocationsMap } from '../dsl/monitor';
+import { LocationsMap } from '../dsl/locations';
+import { Monitor, MonitorConfig } from '../dsl/monitor';
 
 export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
   content: string;

--- a/utils/update_locations.sh
+++ b/utils/update_locations.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -ex
+TARGET=src/dsl/locations.ts 
+echo '// DO NOT EDIT - UPDATE WITH `npm run build:locations`' > $TARGET 
+echo -n 'export const LocationsMap =' >> $TARGET
+curl -s https://manifest.synthetics.elastic-cloud.com/v1/manifest.json | jq '.locations | to_entries | map({(.value.geo.name | split(" - ")[1] | ascii_downcase | split(" ") | join("_") ) : .key } ) | add' >> $TARGET
+# Add license and other headers
+npm run lint -- --fix $TARGET

--- a/utils/update_locations.sh
+++ b/utils/update_locations.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -ex
-TARGET=src/dsl/locations.ts 
-echo '// DO NOT EDIT - UPDATE WITH `npm run build:locations`' > $TARGET 
-echo -n 'export const LocationsMap =' >> $TARGET
+TARGET=src/dsl/locations.ts
+echo '// DO NOT EDIT - UPDATE WITH `npm run build:locations`' > $TARGET
+echo 'export const LocationsMap =' >> $TARGET
 curl -s https://manifest.synthetics.elastic-cloud.com/v1/manifest.json | jq '.locations | to_entries | map({(.value.geo.name | split(" - ")[1] | ascii_downcase | split(" ") | join("_") ) : .key } ) | add' >> $TARGET
 # Add license and other headers
-npm run lint -- --fix $TARGET
+npm run lint:fix


### PR DESCRIPTION
+ Part of #513 
+ Updates the locations array with new locations list that are part of the global manifest. 
+ Adds a utility script to update the locations from the manifest automatically. Thanks to @andrewvc 