### PR TITLE
fix: allow controlling timeouts via actions

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -97,11 +97,11 @@ export default class Runner {
   }
 
   async captureScreenshot(page: Driver['page'], step: Step) {
-    await page.waitForLoadState('load');
     const buffer = await page
       .screenshot({
         type: 'jpeg',
         quality: 80,
+        timeout: 5000,
       })
       .catch(() => {});
     /**


### PR DESCRIPTION
+ Playwright by default waits for action timeouts which is set to 30 seconds. So if the user calls `page.go` without explicitly setting timeout, then synthetics agent would wait for that timeout of 30 seconds plus the timeout that the synthetics agent set for the action `page.waitForLoadEvent`. This was a legacy code which was put there to make sure we capture the screenshot after page load for all steps. 
+ The PR addresses the problem by not waiting for the page load as not each step would end up in a load event and we explicitly set a screenshot timeout of 5 seconds. If the agent cannot capture the screenshot within that timeframe, it would end up not writing that document. 
+ Source of this issue is found from the Synthetics service.


### How to test
1. Use an inline journey
```
step('timeout step', async () => {
  await page.goto('http://www.elastic.co', {timeout: 5000});
});
```
2. Check if the step waits only for the above timeout + screenshot timeout (which can vary depending on how long it takes - but no more than 5000ms)
3. Make sure, we dont wait for the default 30 seconds timeout. 