### PR TITLE
fix: delete stale monitors by default on push command

### DIFF
--- a/__tests__/push/__snapshots__/request.test.ts.snap
+++ b/__tests__/push/__snapshots__/request.test.ts.snap
@@ -18,8 +18,3 @@ exports[`Push api request format failed monitors 1`] = `
 
 "
 `;
-
-exports[`Push api request stale monitor error 1`] = `
-"⚠ Found stale monitors
-   Pass --delete to remove all the stale monitors."
-`;

--- a/__tests__/push/request.test.ts
+++ b/__tests__/push/request.test.ts
@@ -73,6 +73,7 @@ describe('Push api request', () => {
     expect(statusCode).toBe(200);
     expect(await body.json()).toEqual({
       project: 'blah',
+      keep_stale: false,
       monitors: schema,
     });
   });

--- a/__tests__/push/request.test.ts
+++ b/__tests__/push/request.test.ts
@@ -32,7 +32,6 @@ import {
   formatAPIError,
   formatFailedMonitors,
   formatNotFoundError,
-  formatStaleMonitors,
 } from '../../src/push/request';
 import { Server } from '../utils/server';
 import { createTestMonitor } from '../utils/test-config';
@@ -69,13 +68,11 @@ describe('Push api request', () => {
       auth: 'foo:bar',
       project: 'blah',
       space: 'dummy',
-      delete: false,
     });
 
     expect(statusCode).toBe(200);
     expect(await body.json()).toEqual({
       project: 'blah',
-      keep_stale: true,
       monitors: schema,
     });
   });
@@ -110,9 +107,5 @@ describe('Push api request', () => {
     ];
 
     expect(formatFailedMonitors(errors)).toMatchSnapshot();
-  });
-
-  it('stale monitor error', () => {
-    expect(formatStaleMonitors()).toMatchSnapshot();
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -188,7 +188,6 @@ program
     'the target Kibana spaces for the pushed monitors — spaces help you organise pushed monitors.',
     'default'
   )
-  .option('--delete', 'automatically delete the stale monitors.')
   .action(async (cmdOpts: PushOptions) => {
     try {
       await loadTestFiles({ inline: false }, [cwd()]);

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -243,7 +243,6 @@ export type PushOptions = {
   url: string;
   project: string;
   space: string;
-  delete: boolean;
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
 };

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -28,13 +28,12 @@ import {
   ok,
   formatAPIError,
   formatFailedMonitors,
-  formatStaleMonitors,
   formatNotFoundError,
 } from './request';
 import { Monitor } from '../dsl/monitor';
 import { PushOptions } from '../common_types';
 import { buildMonitorSchema } from './monitor';
-import { progress, error, done, write } from '../helpers';
+import { progress, error, done } from '../helpers';
 
 export async function push(monitors: Monitor[], options: PushOptions) {
   progress(`preparing all monitors`);

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -49,12 +49,9 @@ export async function push(monitors: Monitor[], options: PushOptions) {
       const { error, message } = await body.json();
       throw formatAPIError(statusCode, error, message);
     }
-    const { staleMonitors, failedMonitors } = await body.json();
+    const { failedMonitors } = await body.json();
     if (failedMonitors.length > 0) {
       throw formatFailedMonitors(failedMonitors);
-    }
-    if (staleMonitors.length > 0) {
-      write(formatStaleMonitors());
     }
     done('Pushed');
   } catch (e) {

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { bold, gray, yellow } from 'kleur/colors';
+import { bold } from 'kleur/colors';
 import { request } from 'undici';
 import { PushOptions } from '../common_types';
 import { indent, symbols } from '../helpers';
@@ -34,6 +34,7 @@ const { version } = require('../../package.json');
 
 export type APISchema = {
   project: string;
+  keep_stale: boolean;
   monitors: MonitorSchema[];
 };
 
@@ -53,6 +54,7 @@ export async function createMonitors(
 ) {
   const schema: APISchema = {
     project: options.project,
+    keep_stale: false,
     monitors,
   };
 

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -105,10 +105,3 @@ export function formatFailedMonitors(errors: APIMonitorError[]) {
   }
   return outer;
 }
-
-export function formatStaleMonitors() {
-  let outer = bold(yellow(`${symbols['warning']} Found stale monitors\n`));
-  const inner = gray(`Pass --delete to remove all the stale monitors.`);
-  outer += indent(inner, '   ');
-  return outer;
-}

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -34,7 +34,6 @@ const { version } = require('../../package.json');
 
 export type APISchema = {
   project: string;
-  keep_stale: boolean;
   monitors: MonitorSchema[];
 };
 
@@ -54,7 +53,6 @@ export async function createMonitors(
 ) {
   const schema: APISchema = {
     project: options.project,
-    keep_stale: !options.delete,
     monitors,
   };
 


### PR DESCRIPTION
fixes https://github.com/elastic/synthetics/issues/533

Remove --delete option