### PR TITLE
fix: remove trailing slash from kibana host

### DIFF
--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -39,8 +39,10 @@ export type APISchema = {
 };
 
 function getAPIUrl(options: PushOptions) {
+  // remove trialing / as well
   return (
-    options.url + `/s/${options.space}/api/synthetics/service/project/monitors`
+    options.url.replace(/\/+$/, '') +
+    `/s/${options.space}/api/synthetics/service/project/monitors`
   );
 }
 


### PR DESCRIPTION
Remove trailing slash from kibana url option of push command using regex

fixes https://github.com/elastic/synthetics/issues/535