### PR TITLE
Fix for broken win push

### DIFF
--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -52,6 +52,9 @@ export function MultiAssetPlugin(callback: PluginCallback): esbuild.Plugin {
   // Check that the path isn't in an external package by making sure it's at a standard
   // local filesystem location
   const isBare = (str: string) => {
+    // Note that we use `isAbsolute` to handle UNC/windows style paths like C:\path\to\thing
+    // This is not necessary for relative directories since `.\file` is not supported as an import
+    // nor is `~/path/to/file`.
     if (path.isAbsolute(str) || str.startsWith('./') || str.startsWith('../')) {
       return true;
     }

--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -68,12 +68,6 @@ export function MultiAssetPlugin(callback: PluginCallback): esbuild.Plugin {
           build.initialOptions.external?.includes(args.path) ||
           !isBare(args.path)
         ) {
-          console.log('MARKING AS EXTERNAL', {
-            match: build.initialOptions.external?.includes(args.path),
-            inoext: build.initialOptions,
-            ibare: !isBare(args.path),
-            ap: args.path,
-          });
           return {
             external: true,
           };

--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -49,8 +49,10 @@ export type PluginData = {
 export type PluginCallback = (data: PluginData) => void;
 
 export function MultiAssetPlugin(callback: PluginCallback): esbuild.Plugin {
+  // Check that the path isn't in an external package by making sure it's at a standard
+  // local filesystem location
   const isBare = (str: string) => {
-    if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../')) {
+    if (path.isAbsolute(str) || str.startsWith('./') || str.startsWith('../')) {
       return true;
     }
     return false;
@@ -66,6 +68,12 @@ export function MultiAssetPlugin(callback: PluginCallback): esbuild.Plugin {
           build.initialOptions.external?.includes(args.path) ||
           !isBare(args.path)
         ) {
+          console.log('MARKING AS EXTERNAL', {
+            match: build.initialOptions.external?.includes(args.path),
+            inoext: build.initialOptions,
+            ibare: !isBare(args.path),
+            ap: args.path,
+          });
           return {
             external: true,
           };


### PR DESCRIPTION
Fixes #550 , our custom multi-asset plugin couldn't handle windows paths that start with `C:\` and similar. Switched to FS agnostic code. The errors this caused were somewhat confusing because this only causes `esbuild` to fail later in its process with the message described in #550 .

Should work on linux and windows now.

The easiest way to test this is to use `npx @elastic-synthetics init` to create an example project, then switch to a relative import for synthetics as shown below for `package.json`.

```json
{
  "dependencies": {
    "@elastic/synthetics": "file:..\\synthetics"
  }
}
```

Tested locally on my windows box and WSL linux boxes