### PR TITLE
feat: support private locations in dsl and push command arguments

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -741,6 +741,7 @@ describe('runner', () => {
     runner.updateMonitor({
       schedule: 5,
       locations: ['us_east'],
+      privateLocations: ['germany'],
       throttling: { download: 100, upload: 50 },
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },
@@ -752,6 +753,7 @@ describe('runner', () => {
       id: 'test-j1',
       schedule: 2,
       locations: ['united_kingdom'],
+      privateLocations: ['spain'],
     });
     j2.updateMonitor({ throttling: { latency: 1000 } });
     runner.addJourney(j1);
@@ -766,6 +768,7 @@ describe('runner', () => {
       name: 'j1',
       tags: ['foo*'],
       locations: ['united_kingdom'],
+      privateLocations: ['spain'],
       schedule: 2,
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },
@@ -773,6 +776,7 @@ describe('runner', () => {
     });
     expect(monitors[1].config).toMatchObject({
       locations: ['us_east'],
+      privateLocations: ["germany"],
       schedule: 5,
       throttling: { latency: 1000 },
     });

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -36,6 +36,7 @@ describe('Monitor schema', () => {
       schedule: 10,
       enabled: true,
       locations: ['europe-west2-a', 'australia-southeast1-a'],
+      privateLocations: ["germany"],
       content: expect.any(String),
       filter: {
         match: 'test',

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -37,6 +37,7 @@ export function createTestMonitor(filename: string) {
     schedule: 10,
     enabled: true,
     locations: ['united_kingdom', 'australia_east'],
+    privateLocations: ['germany'],
   });
   monitor.setSource({
     file: join(FIXTURES_DIR, filename),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,9 +203,9 @@ program
   configure via Synthetics config file under 'monitors.schedule' field.`);
       }
 
-      if (!options.locations) {
-        throw error(`Set default location for all monitors via CLI as '--locations <locations...>' OR
-  configure via Synthetics config file under 'monitors.locations' field.`);
+      if (!options.locations && !options.privateLocations) {
+        throw error(`Set default location for all monitors via CLI as '--locations <locations...> or --privateLocations <locations...>' OR
+  configure via Synthetics config file under 'monitors.locations'| 'monitors.privateLocations' field.`);
       }
       const monitors = runner.buildMonitors(options);
       await push(monitors, cmdOpts);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -174,6 +174,12 @@ program
       'default list of locations from which your monitors will run.'
     ).choices(SyntheticsLocations)
   )
+  .addOption(
+    new Option(
+      '--privateLocations <locations...>',
+      'default list of private locations from which your monitors will run.'
+    )
+  )
   .requiredOption(
     '--project <project-id>',
     'id that will be used for logically grouping monitors'

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -210,6 +210,7 @@ type BaseArgs = {
   throttling?: ThrottlingOptions;
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
+  privateLocations?: MonitorConfig['privateLocations'];
 };
 
 export type CliArgs = BaseArgs & {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -393,6 +393,7 @@ export default class Runner {
       throttling: options.throttling,
       schedule: options.schedule,
       locations: options.locations,
+      privateLocations: options.privateLocations,
       params: options.params,
       playwrightOptions: options.playwrightOptions,
     });

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -45,6 +45,7 @@ export type MonitorConfig = {
   schedule?: number;
   enabled?: boolean;
   locations?: SyntheticsLocationsType[];
+  privateLocations?: string[];
   throttling?: ThrottlingOptions;
   screenshot?: ScreenshotOptions;
   params?: Params;

--- a/src/options.ts
+++ b/src/options.ts
@@ -136,6 +136,7 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
 
   options.schedule = cliArgs.schedule ?? monitor?.schedule;
   options.locations = cliArgs.locations ?? monitor?.locations;
+  options.privateLocations = cliArgs.privateLocations ?? monitor?.privateLocations;
 
   return options;
 }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -36,7 +36,8 @@ export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
   filter: Monitor['filter'];
 };
 
-function translateLocation(locations: MonitorConfig['locations']) {
+function translateLocation(locations?: MonitorConfig['locations']) {
+  if (!locations) return [];
   return locations.map(loc => LocationsMap[loc]).filter(Boolean);
 }
 


### PR DESCRIPTION
Relates to https://github.com/elastic/synthetics/issues/557

If desired, this PR can be tested e2e via the corresponding Kibana PR: https://github.com/elastic/kibana/pull/136777

Enables the ability to define `privateLocations` via the monitor dsl or the `push` command arguments. 

Example usage via `monitor.use`

```
journey('check-if-title-is-present', ({ page, params }) => {
  monitor.use({
    schedule: 3,
    privateLocations: ["YOUR_LOCATION_NAME"],
  })
  step('launch app', async () => {
    await page.goto(params.url);
  });

  step('assert title', async () => {
    const header = await page.$('h1');
    expect(await header.textContent()).toBe('todos');
  });
});
```

Example usage via command-line.
`npx @elastic/synthetics --url YOUR_KIBANA_URL --project test-project --auth YOUR_AUTH_KEY --schedule 3 --locations us_east --privateLocations "YOUR_DEFAULT_PRIVATE_LOCATION_NAME"`