### PR TITLE
Add jjbb jenkins job definition for dist-tag job

### DIFF
--- a/.ci/jobs/dist-tag-mbp.yml
+++ b/.ci/jobs/dist-tag-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-origin: merge-current
           discover-tags: false
           disable-pr-notifications: true
-          head-filter-regex: '^main|PR-562$'
+          head-filter-regex: '^(main|PR-562)$'
           notification-context: 'elastic-synthetics'
           repo: synthetics
           repo-owner: elastic

--- a/.ci/jobs/dist-tag-mbp.yml
+++ b/.ci/jobs/dist-tag-mbp.yml
@@ -1,0 +1,42 @@
+---
+- job:
+    name: apm-agent-rum/dist-tag-mbp
+    display-name: Dist tag a version for Elastic Synthetics
+    description: Dist tag a version for Elastic Synthetics.
+    project-type: multibranch
+    script-path: .ci/dist-tag.groovy
+    scm:
+      - github:
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: merge-current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: merge-current
+          discover-tags: false
+          disable-pr-notifications: true
+          head-filter-regex: '^main|PR-562$'
+          notification-context: 'elastic-synthetics'
+          repo: synthetics
+          repo-owner: elastic
+          credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+          ssh-checkout:
+            credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+          build-strategies:
+            - regular-branches: true
+          property-strategies:
+            all-branches:
+              - suppress-scm-triggering: true
+          clean:
+              after: true
+              before: true
+          prune: true
+          shallow-clone: true
+          depth: 3
+          do-not-fetch-tags: true
+          submodule:
+              disable: false
+              recursive: true
+              parent-credentials: true
+              timeout: 100
+          timeout: '15'
+          use-author: true
+          wipe-workspace: true


### PR DESCRIPTION
## Description

* Add jjbb jenkins job definition for dist-tag job.

Ref: https://github.com/elastic/observability-robots/issues/1248

Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>