### PR TITLE
feat: abort push on duplicate monitors

### DIFF
--- a/__tests__/fixtures/duplicate.journey.ts
+++ b/__tests__/fixtures/duplicate.journey.ts
@@ -25,6 +25,8 @@
 
 import { journey, monitor } from '../../src';
 
-journey('journey 1', () => monitor.use({ id: 'duplicate' }));
+journey('journey 1', () => monitor.use({ id: 'duplicate id' }));
+journey('journey 2', () => monitor.use({ id: 'duplicate id' }));
 
-journey('journey 2', () => monitor.use({ id: 'duplicate' }));
+journey('duplicate name', () => monitor.use({ schedule: 10 }));
+journey('duplicate name', () => monitor.use({ schedule: 20 }));

--- a/__tests__/fixtures/duplicate.journey.ts
+++ b/__tests__/fixtures/duplicate.journey.ts
@@ -1,0 +1,30 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { journey, monitor } from '../../src';
+
+journey('journey 1', () => monitor.use({ id: 'duplicate' }));
+
+journey('journey 2', () => monitor.use({ id: 'duplicate' }));

--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Push format duplicate monitors 1`] = `
+"Aborted: Duplicate monitors found
+   * test - journey1.ts:2:5
+   * test - journey2.ts:10:5
+   "
+`;

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -70,8 +70,10 @@ describe('Push', () => {
       .args(['push', ...args, '--schedule', '20', '--locations', 'us_east'])
       .run({ cwd: FIXTURES_DIR });
     expect(await cli.exitCode).toBe(1);
-
-    expect(cli.stderr()).toContain(`Aborted: Duplicate monitors found`);
+    const error = cli.stderr();
+    expect(error).toContain(`Aborted: Duplicate monitors found`);
+    expect(error).toContain(`duplicate id`);
+    expect(error).toContain(`duplicate name`);
   });
 
   it('format duplicate monitors', () => {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -42,9 +42,6 @@ function translateLocation(locations?: MonitorConfig['locations']) {
 }
 
 export async function buildMonitorSchema(monitors: Monitor[]) {
-  if (monitors.length == 0) {
-    throw new Error('No Monitors found');
-  }
   /**
    * Set up the bundle artifacts path which can be used to
    * create the bundles required for uploading journeys


### PR DESCRIPTION
+ fix #442 
+ Aborts the push command if any of the monitors contain duplicate ids with a clean error message and also linking users to the duplicate monitor files where required. 
+ Decided to handle the logic here as Kibana currently does not have any way to know if there are any duplicates without looking up the saved objects which is not performant when we have all the list already available via the agent. 

<img width="790" alt="Screen Shot 2022-08-01 at 3 30 41 PM" src="https://user-images.githubusercontent.com/3902525/182256462-1b0c50cb-ebd2-4033-a7bf-227e7f6d60e3.png">



### Testing.
- Build the local project using - npm run build
2. Setup a brand new Synthetics project - node dist/cli.js init [optional-dir]
3. Change the monitior ids for some of the monitors. 
4. Run push command - node dist/cli.js push --auth <> 
