### PR TITLE
chore: override project settings and locations

### DIFF
--- a/__tests__/fixtures/locationinfo.ts
+++ b/__tests__/fixtures/locationinfo.ts
@@ -32,6 +32,11 @@ export const LOCATIONS: LocationAPIResponse['locations'] = [
     isServiceManaged: true,
   },
   {
+    id: 'new-location',
+    label: 'New Location',
+    isServiceManaged: true,
+  },
+  {
     id: 'private-node-1',
     label: 'custom location 1',
     isServiceManaged: false,

--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -27,7 +27,11 @@ import { existsSync } from 'fs';
 import { readFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { CLIMock } from '../utils/test-config';
-import { regularFiles } from '../../src/generator';
+import {
+  REGULAR_FILES_PATH,
+  CONFIG_PATH,
+  SETTINGS_PATH,
+} from '../../src/generator';
 
 describe('Generator', () => {
   const scaffoldDir = join(__dirname, 'scaffold-test');
@@ -64,9 +68,7 @@ describe('Generator', () => {
     }
 
     // Project setup file
-    expect(
-      existsSync(join(scaffoldDir, '.synthetics', 'project.json'))
-    ).toBeTruthy();
+    expect(existsSync(join(scaffoldDir, SETTINGS_PATH))).toBeTruthy();
 
     // Verify files
     expect(existsSync(join(scaffoldDir, 'package.json'))).toBeTruthy();
@@ -81,15 +83,12 @@ describe('Generator', () => {
       "
     `);
 
-    regularFiles.forEach(fn => {
+    REGULAR_FILES_PATH.forEach(fn => {
       expect(existsSync(join(scaffoldDir, fn))).toBeTruthy();
     });
-    expect(existsSync(join(scaffoldDir, 'synthetics.config.ts'))).toBeTruthy();
+    expect(existsSync(join(scaffoldDir, CONFIG_PATH))).toBeTruthy();
     // Verify schedule and locations
-    const configFile = await readFile(
-      join(scaffoldDir, 'synthetics.config.ts'),
-      'utf-8'
-    );
+    const configFile = await readFile(join(scaffoldDir, CONFIG_PATH), 'utf-8');
     expect(configFile).toContain(`locations: ['us_east']`);
     expect(configFile).toContain(`privateLocations: ['custom']`);
     expect(configFile).toContain(`schedule: 30`);

--- a/__tests__/locations/index.test.ts
+++ b/__tests__/locations/index.test.ts
@@ -49,7 +49,7 @@ describe('Locations', () => {
       url: `${server.PREFIX}`,
       auth: 'apiKey',
     });
-    expect(locations.length).toBe(4);
+    expect(locations.length).toBe(5);
   });
 
   it('format and group locations by labels', async () => {
@@ -60,13 +60,14 @@ describe('Locations', () => {
     const formatted = formatLocations(locations);
     expect(formatted).toEqual([
       'japan',
+      'new_location',
       'custom location 1(private)',
       'custom location 2(private)',
       'us_west',
     ]);
 
     expect(groupLocations(formatted)).toEqual({
-      locations: ['japan', 'us_west'],
+      locations: ['japan', 'new_location', 'us_west'],
       privateLocations: ['custom location 1', 'custom location 2'],
     });
   });

--- a/src/locations/index.ts
+++ b/src/locations/index.ts
@@ -71,7 +71,7 @@ export function formatLocations(locations: Array<LocationMetadata>) {
   for (const location of locations) {
     let name = location.label;
     if (location.isServiceManaged) {
-      [, name] = name.split('-');
+      [, name] = name.includes('-') ? name.split('-') : [, name];
       name = name.toLowerCase().trim().split(' ').join('_');
     } else {
       name = `${name}${PRIVATE_KEYWORD}`;

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -46,7 +46,7 @@ type APISchema = {
 
 function translateLocation(locations?: MonitorConfig['locations']) {
   if (!locations) return [];
-  return locations.map(loc => LocationsMap[loc]).filter(Boolean);
+  return locations.map(loc => LocationsMap[loc] || loc).filter(Boolean);
 }
 
 export async function buildMonitorSchema(monitors: Monitor[]) {


### PR DESCRIPTION
This PR solves two UX issues
+ Allows the push command to work with Dev and Staging Kibana instances where the location naming scheme might be bit different. `Contitent - Location` to `Location`. 
+ Overrides synthetics project settings and configuration with updated locations when `init` command is run multiple times.


### Testing
+ Build the project `npm run build`
+ Initialize the new synthetics project - `node dist/cli.js init [dir]`
+ Run init again on the same directory and notice how Synthetics project and config gets updated without asking user override prompts. 