### PR TITLE
fix: add warnings for stale monitors

### DIFF
--- a/__tests__/push/__snapshots__/request.test.ts.snap
+++ b/__tests__/push/__snapshots__/request.test.ts.snap
@@ -18,3 +18,14 @@ exports[`Push api request format failed monitors 1`] = `
 
 "
 `;
+
+exports[`Push api request format failed stale monitors 1`] = `
+"⚠ Warnings
+   > Failed to delete monitor.: monitor(monitor-1)
+       downstream erorr
+
+   > Failed to delete monitor.: monitor(monitor-2)
+       downstream erorr
+
+"
+`;

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -164,10 +164,11 @@ journey('duplicate name', () => monitor.use({ schedule: 20 }));`
     let server: Server;
     beforeAll(async () => {
       server = await Server.create();
+      const apiRes = { failedMonitors: [], failedStaleMonitors: [] };
       server.route(
         '/sync/s/dummy/api/synthetics/service/project/monitors',
         (req, res) => {
-          res.end(JSON.stringify({ failedMonitors: [] }));
+          res.end(JSON.stringify(apiRes));
         }
       );
       server.route(
@@ -178,7 +179,7 @@ journey('duplicate name', () => monitor.use({ schedule: 20 }));`
           // Interleaved
           res.write(JSON.stringify('chunk 2') + '\n');
           res.write(JSON.stringify('chunk 3') + '\n');
-          res.end(JSON.stringify({ failedMonitors: [] }));
+          res.end(JSON.stringify(apiRes));
         }
       );
       await fakeProjectSetup(

--- a/__tests__/push/request.test.ts
+++ b/__tests__/push/request.test.ts
@@ -30,6 +30,7 @@ import {
   formatAPIError,
   formatFailedMonitors,
   formatNotFoundError,
+  formatStaleMonitors,
 } from '../../src/push/request';
 
 describe('Push api request', () => {
@@ -63,5 +64,22 @@ describe('Push api request', () => {
     ];
 
     expect(formatFailedMonitors(errors)).toMatchSnapshot();
+  });
+
+  it('format failed stale monitors', () => {
+    const errors: APIMonitorError[] = [
+      {
+        id: 'monitor-1',
+        reason: 'Failed to delete monitor.',
+        details: `downstream erorr`,
+      },
+      {
+        id: 'monitor-2',
+        reason: 'Failed to delete monitor.',
+        details: `downstream erorr`,
+      },
+    ];
+
+    expect(formatStaleMonitors(errors)).toMatchSnapshot();
   });
 });

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -27,12 +27,13 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
 import { prompt } from 'enquirer';
-import { bold } from 'kleur/colors';
+import { bold, yellow } from 'kleur/colors';
 import {
   ok,
   formatAPIError,
   formatFailedMonitors,
   formatNotFoundError,
+  formatStaleMonitors,
 } from './request';
 import { buildMonitorSchema, createMonitors } from './monitor';
 import { ProjectSettings } from '../generator';
@@ -82,9 +83,12 @@ export async function push(monitors: Monitor[], options: PushOptions) {
           progress(chunk);
           continue;
         }
-        const { failedMonitors } = chunk;
+        const { failedMonitors, failedStaleMonitors } = chunk;
         if (failedMonitors && failedMonitors.length > 0) {
           throw formatFailedMonitors(failedMonitors);
+        }
+        if (failedStaleMonitors.length > 0) {
+          write(yellow(formatStaleMonitors(failedStaleMonitors)));
         }
       }
     }

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -80,8 +80,8 @@ export function formatAPIError(
   return outer;
 }
 
-export function formatFailedMonitors(errors: APIMonitorError[]) {
-  let outer = bold(`${symbols['failed']} Error\n`);
+function formatMonitorError(errors: APIMonitorError[]) {
+  let outer = '';
   for (const error of errors) {
     const monitorId = error.id ? `: monitor(${error.id})` : '';
     let inner = bold(`> ${error.reason}${monitorId}\n`);
@@ -90,4 +90,14 @@ export function formatFailedMonitors(errors: APIMonitorError[]) {
     outer += '\n';
   }
   return outer;
+}
+
+export function formatFailedMonitors(errors: APIMonitorError[]) {
+  const heading = bold(`${symbols['failed']} Error\n`);
+  return heading + formatMonitorError(errors);
+}
+
+export function formatStaleMonitors(errors: APIMonitorError[]) {
+  const heading = bold(`${symbols['warning']} Warnings\n`);
+  return heading + formatMonitorError(errors);
 }


### PR DESCRIPTION
+ fix #565 
+ Creates warnings for the stale monitors if the push succeeded without any failures. If there are errors then these warnings are dropped on the floor to make room for users to fix the errors first before checking the warnings. 