### PR TITLE
fix: bundled monitor content must be idempotent

### DIFF
--- a/__tests__/push/bundler.test.ts
+++ b/__tests__/push/bundler.test.ts
@@ -30,7 +30,7 @@ import { join } from 'path';
 import { generateTempPath } from '../../src/helpers';
 import { Bundler } from '../../src/push/bundler';
 
-async function validateZip(content, file) {
+async function validateZip(content) {
   const decoded = Buffer.from(content, 'base64');
   const pathToZip = generateTempPath();
   await writeFile(pathToZip, decoded);
@@ -70,7 +70,7 @@ journey('journey 1', () => {
 
   it('build journey', async () => {
     const content = await bundler.build(journeyFile, generateTempPath());
-    await validateZip(content, journeyFile);
+    await validateZip(content);
   });
 
   it('bundle should be idempotent', async () => {

--- a/src/push/bundler.ts
+++ b/src/push/bundler.ts
@@ -65,12 +65,17 @@ export class Bundler {
       const archive = archiver('zip', {
         zlib: { level: 9 },
       });
-      archive.on('error', err => reject(err));
+      archive.on('error', reject);
       output.on('close', fulfill);
       archive.pipe(output);
       for (const [path, content] of this.moduleMap.entries()) {
         const relativePath = relativeToCwd(path);
-        archive.append(content, { name: relativePath });
+        // Date is fixed to Unix epoch so the file metadata is
+        // not modified everytime when files are bundled
+        archive.append(content, {
+          name: relativePath,
+          date: new Date('1970-01-01'),
+        });
       }
       archive.finalize();
     });


### PR DESCRIPTION
+ fix #573 
+ With this change, we effectively removed the date property which was set by the zip stream to always refer to the Unix epoch time instead of defaulting to current time in UTC which was causing the zipped contents to be changed everytime when we run push command. 

### Testing
1. Build the files, `npm run build`
2. Initialize a project - `node dist/cli.js init dir`
3. cd into `dir` and change the synthetics package to link to the current one. `@elastic/synthetics: file:../` in package.json file.
4. Install the synthetics package to link - `npm install`
5. Run the push command - `npm run push`