### PR TITLE
feat: delete entire project via push command

### DIFF
--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -18,11 +18,6 @@ exports[`Push API handle sync response 1`] = `
 "
 `;
 
-exports[`Push abort on push with different project id 1`] = `
-"⚠ Push command Aborted
-"
-`;
-
 exports[`Push error on empty project id 1`] = `
 "Aborted. Invalid synthetics project settings.
 

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -73,7 +73,7 @@ export async function push(monitors: Monitor[], options: PushOptions) {
       ({ deleteAll } = await prompt<{ deleteAll: boolean }>({
         type: 'confirm',
         name: 'deleteAll',
-        message: `Pushing without any monitors would delete all monitors associated with the project.\n Do you want to continue?`,
+        message: `Pushing without any monitors will delete all monitors associated with the project.\n Do you want to continue?`,
         initial: false,
       }));
     }

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import { bold } from 'kleur/colors';
+import { bold, red, yellow } from 'kleur/colors';
 import { Dispatcher, request } from 'undici';
 import { indent, symbols } from '../helpers';
 
@@ -47,7 +47,7 @@ export async function sendRequest(options: APIRequestOptions) {
       'user-agent': `Elastic/Synthetics ${version}`,
       'kbn-xsrf': 'true',
     },
-    headersTimeout: 60 * 1000
+    headersTimeout: 60 * 1000,
   });
 }
 
@@ -62,8 +62,10 @@ export type APIMonitorError = {
 };
 
 export function formatNotFoundError(message: string) {
-  return bold(
-    `${symbols['failed']} Please check your kibana url and try again - 404:${message}`
+  return red(
+    bold(
+      `${symbols['failed']} Please check your kibana url and try again - 404:${message}`
+    )
   );
 }
 
@@ -78,7 +80,7 @@ export function formatAPIError(
   );
   inner += indent(message, '    ');
   outer += indent(inner);
-  return outer;
+  return red(outer);
 }
 
 function formatMonitorError(errors: APIMonitorError[]) {
@@ -95,10 +97,10 @@ function formatMonitorError(errors: APIMonitorError[]) {
 
 export function formatFailedMonitors(errors: APIMonitorError[]) {
   const heading = bold(`${symbols['failed']} Error\n`);
-  return heading + formatMonitorError(errors);
+  return red(heading + formatMonitorError(errors));
 }
 
 export function formatStaleMonitors(errors: APIMonitorError[]) {
   const heading = bold(`${symbols['warning']} Warnings\n`);
-  return heading + formatMonitorError(errors);
+  return yellow(heading + formatMonitorError(errors));
 }


### PR DESCRIPTION
+ fix #581 
+ users would be promoted with a dialog when pushing with empty monitors which then clicking `Yes` would nuke the entire project in Kibana. 
+ Also fixed a bug where we kept pushing even on auth errors, now we immediately exit when we find errors during pushing. 