### PR TITLE
feat: support --yes flag to skip and force push

### DIFF
--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -96,9 +96,12 @@ describe('Push', () => {
       { id: 'test-project' },
       { locations: ['test-loc'], schedule: 2 }
     );
-    const output = await runPush([...DEFAULT_ARGS, '--id', 'new-project'], {
-      TEST_OVERRIDE: '',
-    });
+    const output = await runPush(
+      [...DEFAULT_ARGS, '-y', '--id', 'new-project'],
+      {
+        TEST_OVERRIDE: false,
+      }
+    );
     expect(output).toContain('Push command Aborted');
   });
 
@@ -113,9 +116,12 @@ describe('Push', () => {
       `import {journey, monitor} from '../../../src/index';
 journey('journey 1', () => monitor.use({ id: 'j1' }));`
     );
-    const output = await runPush([...DEFAULT_ARGS, '--id', 'new-project'], {
-      TEST_OVERRIDE: 'true',
-    });
+    const output = await runPush(
+      [...DEFAULT_ARGS, '-y', '--id', 'new-project'],
+      {
+        TEST_OVERRIDE: true,
+      }
+    );
     expect(output).toContain('preparing all monitors');
     await rm(testJourney, { force: true });
   });
@@ -162,19 +168,28 @@ journey('duplicate name', () => monitor.use({ schedule: 20 }));`
       { id: 'test-project' },
       { locations: ['test-loc'], schedule: 2 }
     );
-    const output = await runPush([...DEFAULT_ARGS], {
-      TEST_OVERRIDE: '',
+    const output = await runPush([...DEFAULT_ARGS, '-y'], {
+      TEST_OVERRIDE: false,
     });
     expect(output).toContain('Push command Aborted');
   });
 
-  it('delete entire project ', async () => {
+  it('delete entire project with --yes flag', async () => {
     await fakeProjectSetup(
       { id: 'test-project', space: 'dummy', url: 'http://localhost:8080' },
       { locations: ['test-loc'], schedule: 2 }
     );
-    const output = await runPush([...DEFAULT_ARGS], {
-      TEST_OVERRIDE: 'true',
+    const output = await runPush([...DEFAULT_ARGS, '-y']);
+    expect(output).toContain('deleting all stale monitors');
+  });
+
+  it('delete entire project with overrides', async () => {
+    await fakeProjectSetup(
+      { id: 'test-project', space: 'dummy', url: 'http://localhost:8080' },
+      { locations: ['test-loc'], schedule: 2 }
+    );
+    const output = await runPush([...DEFAULT_ARGS, '-y'], {
+      TEST_OVERRIDE: true,
     });
     expect(output).toContain('deleting all stale monitors');
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,6 +184,7 @@ program
     '--space <space>',
     'the target Kibana spaces for the pushed monitors — spaces help you organise pushed monitors.'
   )
+  .option('-y, --yes', 'skip all questionares and do forceful push')
   .addOption(pattern)
   .addOption(tags)
   .addOption(match)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,7 @@ program
     '--space <space>',
     'the target Kibana spaces for the pushed monitors — spaces help you organise pushed monitors.'
   )
-  .option('-y, --yes', 'skip all questionnaires and run non-interactively')
+  .option('-y, --yes', 'skip all questions and run non-interactively')
   .addOption(pattern)
   .addOption(tags)
   .addOption(match)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,7 @@ program
     '--space <space>',
     'the target Kibana spaces for the pushed monitors — spaces help you organise pushed monitors.'
   )
-  .option('-y, --yes', 'skip all questionares and do forceful push')
+  .option('-y, --yes', 'skip all questionnaires and run non-interactively')
   .addOption(pattern)
   .addOption(tags)
   .addOption(match)

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -246,6 +246,7 @@ export type PushOptions = ProjectSettings & {
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
+  yes?: boolean;
 };
 
 export type ProjectSettings = {


### PR DESCRIPTION
+ fix #601 
+ `npx @elastic/synthetics push --auth <key> -y` would skip the questionnare and forcefully push the project monitors during two phases
   - When deleting the entire project
   - When project is pushed with different id than pushed before. 