### PR TITLE
chore: check build directory instead of root

### DIFF
--- a/src/push/plugin.ts
+++ b/src/push/plugin.ts
@@ -27,8 +27,12 @@ import { isAbsolute, dirname, extname, join } from 'path';
 import fs from 'fs/promises';
 import * as esbuild from 'esbuild';
 
-const SOURCE_DIR = join(__dirname, '..', '..');
-const SOURCE_NODE_MODULES = join(SOURCE_DIR, 'node_modules');
+// ROOT directory of the Package - /
+const ROOT_DIR = join(__dirname, '..', '..');
+// Source of the package - /src, /dist, etc.
+const SOURCE_DIR = join(__dirname, '..');
+// Node modules directory of the package - /node_modules
+const SOURCE_NODE_MODULES = join(ROOT_DIR, 'node_modules');
 
 export function commonOptions(): esbuild.BuildOptions {
   return {


### PR DESCRIPTION
+ Currently for dev purposes, if we end up creating the Synthetics project as part of the Synthetics agent directory, it would result in locally imported helper files marked as `external` which when run on HB would result in this error. 
```
{
    "code": "BAD_CMD_STATUS",
    "stack_trace": null,
    "type": "io",
    "message": "journey did not finish executing, 0 steps ran: command '/tmp/elastic-synthetics-unzip-1725738249/node_modules/.bin/elastic-synthetics /tmp/elastic-synthetics-unzip-1725738249/node_modules/.bin/elastic-synthetics /tmp/elastic-synthetics-unzip-1725738249 --playwright-options {\"headless\":true,\"ignoreHTTPSErrors\":true} --screenshots on --throttling {\"download\":5,\"latency\":20,\"upload\":3} --rich-events --match addition and completion of single task been 2 4 --params \"{1 hidden params}\"' exited unexpectedly with code: 1"
}
```

This PR solves the above issue by skipping bundler (marked as external) only for
+ Source files of Synthetics package - `/@elastic/synthetics/dist`
+ Node modules that are part of the package - `/@elastic/synthetics/node_modules`