### PR TITLE
fix: include header and body for transferSize value

### DIFF
--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -283,12 +283,12 @@ export class NetworkManager {
         networkEntry.request.body = {
           bytes: sizes.requestBodySize,
         };
-        networkEntry.response.bytes =
-          sizes.responseHeadersSize + sizes.responseBodySize;
+        const transferSize = sizes.responseHeadersSize + sizes.responseBodySize;
+        networkEntry.transferSize = transferSize;
+        networkEntry.response.bytes = transferSize;
         networkEntry.response.body = {
           bytes: sizes.responseBodySize,
         };
-        networkEntry.transferSize = sizes.responseBodySize;
       })
     );
   }


### PR DESCRIPTION
+ part of #616 
+ Include the transferred header + body size when calculating the transferSize value for a given network request. 

**NOTE: No explicit testing is necessary as there is a dedicated test validating the transferred sizes of the response.**
