### PR TITLE
feat: improve validation for monitor schedules

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -715,7 +715,7 @@ describe('runner', () => {
       schedule: 3,
       locations: ['united_kingdom'],
     });
-    j2.updateMonitor({ throttling: { latency: 1000 } });
+    j2.updateMonitor({ throttling: { latency: 1000 }, schedule: 1 });
     runner.addJourney(j1);
     runner.addJourney(j2);
 
@@ -792,7 +792,7 @@ describe('runner', () => {
     runner.addJourney(j1);
     runner.addJourney(j2);
 
-    const monitors = runner.buildMonitors({ match: 'j1' });
+    const monitors = runner.buildMonitors({ match: 'j1', schedule: 1 });
     expect(monitors.length).toBe(1);
     expect(monitors[0].config.name).toBe('j1');
   });
@@ -805,7 +805,7 @@ describe('runner', () => {
     runner.addJourney(j2);
     runner.addJourney(j3);
 
-    const monitors = runner.buildMonitors({ tags: ['first'] });
+    const monitors = runner.buildMonitors({ tags: ['first'], schedule: 1 });
     expect(monitors.length).toBe(1);
     expect(monitors[0].config.name).toBe('j1');
   });

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -712,7 +712,7 @@ describe('runner', () => {
     const j2 = new Journey({ name: 'j2' }, noop);
     j1.updateMonitor({
       id: 'test-j1',
-      schedule: 2,
+      schedule: 3,
       locations: ['united_kingdom'],
     });
     j2.updateMonitor({ throttling: { latency: 1000 } });
@@ -730,7 +730,7 @@ describe('runner', () => {
       tags: [],
       locations: ['united_kingdom'],
       privaateLocations: undefined,
-      schedule: 2,
+      schedule: 3,
       params: undefined,
       playwrightOptions: undefined,
       throttling: { download: 5, latency: 20, upload: 3 },
@@ -754,7 +754,7 @@ describe('runner', () => {
     const j2 = new Journey({ name: 'j2' }, noop);
     j1.updateMonitor({
       id: 'test-j1',
-      schedule: 2,
+      schedule: 3,
       locations: ['united_kingdom'],
       privateLocations: ['spain'],
     });
@@ -773,7 +773,7 @@ describe('runner', () => {
       tags: ['foo*'],
       locations: ['united_kingdom'],
       privateLocations: ['spain'],
-      schedule: 2,
+      schedule: 3,
       params: { env: 'test' },
       playwrightOptions: { ignoreHTTPSErrors: true },
       throttling: { download: 100, latency: 20, upload: 50 },

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -79,9 +79,9 @@ describe('options', () => {
     });
 
     expect(
-      normalizeOptions({ throttling: { download: 50 }, schedule: 2 })
+      normalizeOptions({ throttling: { download: 50 }, schedule: 3 })
     ).toMatchObject({
-      schedule: 2,
+      schedule: 3,
       throttling: {
         download: 50,
         upload: 3,

--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -43,7 +43,7 @@ Run 'npx @elastic/synthetics init' to create project with default settings.
 exports[`Push error on invalid schedule 1`] = `
 "Aborted. Invalid synthetics project settings.
 
-Set default schedule(12) to one of the allowed values - 3,5,10,15,30,60,120,240
+Set default schedule(12) to one of the allowed values - 1,3,5,10,15,30,60
 
 Run 'npx @elastic/synthetics init' to create project with default settings.
 "

--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -43,6 +43,15 @@ Run 'npx @elastic/synthetics init' to create project with default settings.
 exports[`Push error on invalid schedule 1`] = `
 "Aborted. Invalid synthetics project settings.
 
+Set default schedule(12) to one of the allowed values - 3,5,10,15,30,60,120,240
+
+Run 'npx @elastic/synthetics init' to create project with default settings.
+"
+`;
+
+exports[`Push error when schedule is not present 1`] = `
+"Aborted. Invalid synthetics project settings.
+
 Set default schedule in minutes for all monitors via
   - CLI '--schedule <mins>'
   - Config file 'monitors.schedule' field

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -85,14 +85,16 @@ describe('Monitors', () => {
       `Monitor schedule format(* * * *) not supported: use '@every' syntax instead`
     );
     expect(parseSchedule('@every 4s')).toBe(1);
-    expect(parseSchedule('@every 60s')).toBe(1);
-    expect(parseSchedule('@every 70s')).toBe(2);
+    expect(parseSchedule('@every 70s')).toBe(1);
     expect(parseSchedule('@every 121s')).toBe(3);
     expect(parseSchedule('@every 1m')).toBe(1);
-    expect(parseSchedule('@every 1m10s')).toBe(2);
-    expect(parseSchedule('@every 2m')).toBe(2);
-    expect(parseSchedule('@every 1h2m')).toBe(62);
-    expect(parseSchedule('@every 1h2m10s')).toBe(63);
+    expect(parseSchedule('@every 2m10s')).toBe(3);
+    expect(parseSchedule('@every 4m25s')).toBe(5);
+    expect(parseSchedule('@every 16m')).toBe(15);
+    expect(parseSchedule('@every 25m')).toBe(15);
+    expect(parseSchedule('@every 45m')).toBe(30);
+    expect(parseSchedule('@every 1h2m')).toBe(60);
+    expect(parseSchedule('@every 10h2m10s')).toBe(60);
   });
 
   it('api schema', async () => {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -412,6 +412,7 @@ export default class Runner {
        */
       journey.callback({ params: options.params } as any);
       journey.monitor.update(this.monitor?.config);
+      journey.monitor.validate();
       monitors.push(journey.monitor);
     }
     return monitors;

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -39,7 +39,7 @@ export type SyntheticsLocationsType = keyof typeof LocationsMap;
 export const SyntheticsLocations = Object.keys(
   LocationsMap
 ) as SyntheticsLocationsType[];
-export const ALLOWED_SCHEDULES = [3, 5, 10, 15, 30, 60, 120, 240] as const;
+export const ALLOWED_SCHEDULES = [1, 3, 5, 10, 15, 30, 60] as const;
 
 export type MonitorConfig = {
   id?: string;
@@ -96,7 +96,7 @@ export class Monitor {
 
   validate() {
     const schedule = this.config.schedule;
-    if (ALLOWED_SCHEDULES.includes(schedule) || !this.source) {
+    if (ALLOWED_SCHEDULES.includes(schedule)) {
       return;
     }
     const { config, source } = this;
@@ -105,8 +105,10 @@ export class Monitor {
         ','
       )}\n`
     );
-    const inner = `* ${config.id} - ${source.file}:${source.line}:${source.column}\n`;
-    outer += indent(inner);
+    if (source) {
+      const inner = `* ${config.id} - ${source.file}:${source.line}:${source.column}\n`;
+      outer += indent(inner);
+    }
     throw red(outer);
   }
 }

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -96,7 +96,7 @@ export class Monitor {
 
   validate() {
     const schedule = this.config.schedule;
-    if (ALLOWED_SCHEDULES.includes(schedule)) {
+    if (ALLOWED_SCHEDULES.includes(schedule) || !this.source) {
       return;
     }
     const { config, source } = this;

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -137,7 +137,7 @@ export class Generator {
         type: 'select',
         name: 'schedule',
         message: 'Set default schedule in minutes for all monitors',
-        initial: 2, // Index of the second array item
+        initial: 3, // Index of the third array item which is 10 minutes
         choices: ALLOWED_SCHEDULES.map(String),
         required: true,
         result(value) {

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -37,6 +37,7 @@ import {
   cloudIDToKibanaURL,
 } from './utils';
 import { formatLocations, getLocations, groupLocations } from '../locations';
+import { ALLOWED_SCHEDULES } from '../dsl/monitor';
 import type { ProjectSettings } from '../common_types';
 
 // Templates that are required for setting up new synthetics project
@@ -133,10 +134,15 @@ export class Generator {
         },
       },
       {
-        type: 'numeral',
+        type: 'select',
         name: 'schedule',
         message: 'Set default schedule in minutes for all monitors',
-        initial: 10,
+        initial: 2, // Index of the second array item
+        choices: ALLOWED_SCHEDULES.map(String),
+        required: true,
+        result(value) {
+          return Number(value) as any;
+        },
       },
       {
         type: 'input',

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -34,7 +34,7 @@ import {
   formatStaleMonitors,
 } from './request';
 import { buildMonitorSchema, createMonitors, MonitorSchema } from './monitor';
-import { Monitor } from '../dsl/monitor';
+import { ALLOWED_SCHEDULES, Monitor } from '../dsl/monitor';
 import {
   progress,
   apiProgress,
@@ -192,6 +192,10 @@ export function validateSettings(opts: PushOptions) {
     reason = `Set default schedule in minutes for all monitors via
   - CLI '--schedule <mins>'
   - Config file 'monitors.schedule' field`;
+  } else if (opts.schedule && !ALLOWED_SCHEDULES.includes(opts.schedule)) {
+    reason = `Set default schedule(${
+      opts.schedule
+    }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
   }
 
   if (!reason) return;

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -37,7 +37,7 @@ import {
   warn,
 } from '../helpers';
 import { LocationsMap } from '../locations/public-locations';
-import { Monitor, MonitorConfig } from '../dsl/monitor';
+import { ALLOWED_SCHEDULES, Monitor, MonitorConfig } from '../dsl/monitor';
 import { PushOptions } from '../common_types';
 
 export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
@@ -195,7 +195,26 @@ export function parseSchedule(schedule: string) {
         break;
     }
   }
-  return minutes as MonitorConfig['schedule'];
+  return nearestSchedule(minutes);
+}
+
+// Find the nearest schedule that is supported by the platform
+// from the parsed schedule value
+export function nearestSchedule(schedule: number) {
+  let start = 0;
+  let end = ALLOWED_SCHEDULES.length - 1;
+  while (start <= end) {
+    const mid = Math.floor((start + end) / 2);
+    const midValue = ALLOWED_SCHEDULES[mid];
+    if (midValue === schedule) {
+      return midValue;
+    } else if (midValue < schedule) {
+      start = mid + 1;
+    } else {
+      end = mid - 1;
+    }
+  }
+  return ALLOWED_SCHEDULES[end];
 }
 
 export async function createMonitors(


### PR DESCRIPTION
+ fix #620 
+ PR Adds couple of things to make the schedule validation intact for lightweight and browser monitors. 
+ When users scafolds the project using `init` command, we default to showing the available schedule choices based on the browser schedule instead of defaulting to 10, Keeping the initial value still at 10. 
<img width="562" alt="Screen Shot 2022-10-05 at 2 35 40 PM" src="https://user-images.githubusercontent.com/3902525/194168481-9e1b6b49-7200-41aa-ab54-d9920534c5bc.png">

+ Validates the `synthetics.config.ts` file for schedule if its not using the default available schedules - This helps to prevent users who are already using custom schedules to move towards the available ones once they have upgraded to the new version of the agent. 
<img width="707" alt="Screen Shot 2022-10-05 at 2 38 12 PM" src="https://user-images.githubusercontent.com/3902525/194168822-c5c8e46e-aa9e-4828-abd1-d9a38db8a8be.png">

+  Improve the typings of the `monitor.use({ schedule: 10 })` to only accept the acceptable browser values. 
+  Throws validation error when users are using any other invalid values that is not part of the acceptable list. 
<img width="839" alt="Screen Shot 2022-10-05 at 2 40 05 PM" src="https://user-images.githubusercontent.com/3902525/194169085-f19a0936-b841-4ecf-aa65-35631a1b0432.png">

+  Added warning for lightweight monitor schedules only if we see a valid heartbeat monitor configuration and these schedules are rounded off to the nearest minute values. 

### Testing
1. Build the local project using - npm run build
2. Run npm link
3. Setup a brand new Synthetics project - node dist/cli.js init [optional-dir]
4. Navigate to the new directory created with init and run npm link @elastic/synthetics
5. Follow along and check if project settings have been initialized properly
6. Try going through the above scenarios with `npm run push` command. 