### PR TITLE
fix: produce screenshots data always

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "micromatch": "^4.0.5",
         "playwright-chromium": "=1.26.0",
         "playwright-core": "=1.26.0",
-        "sharp": "^0.31.0",
+        "sharp": "^0.31.1",
         "snakecase-keys": "^4.0.0",
         "sonic-boom": "^3.2.0",
         "ts-node": "^10.9.1",
@@ -5897,9 +5897,9 @@
       "dev": true
     },
     "node_modules/sharp": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.0.tgz",
-      "integrity": "sha512-ft96f8WzGxavg0rkLpMw90MTPMUZDyf0tHjPPh8Ob59xt6KzX8EqtotcqZGUm7kwqpX2pmYiyYX2LL0IZ/FDEw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
@@ -11016,9 +11016,9 @@
       "dev": true
     },
     "sharp": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.0.tgz",
-      "integrity": "sha512-ft96f8WzGxavg0rkLpMw90MTPMUZDyf0tHjPPh8Ob59xt6KzX8EqtotcqZGUm7kwqpX2pmYiyYX2LL0IZ/FDEw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
       "requires": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "micromatch": "^4.0.5",
     "playwright-chromium": "=1.26.0",
     "playwright-core": "=1.26.0",
-    "sharp": "^0.31.0",
+    "sharp": "^0.31.1",
     "snakecase-keys": "^4.0.0",
     "sonic-boom": "^3.2.0",
     "ts-node": "^10.9.1",

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -224,8 +224,7 @@ function stepInfo(
 }
 
 export async function getScreenshotBlocks(screenshot: Buffer) {
-  const img = sharp(screenshot, { sequentialRead: true });
-  const { width, height } = await img.metadata();
+  const { width, height } = await sharp(screenshot).metadata();
   /**
    * Chop the screenshot image (1280*720) which is the default
    * viewport size in to 64 equal blocks for a given image
@@ -248,7 +247,7 @@ export async function getScreenshotBlocks(screenshot: Buffer) {
     const top = row * blockHeight;
     for (let col = 0; col < divisions; col++) {
       const left = col * blockWidth;
-      const buf = await img
+      const buf = await sharp(screenshot, { sequentialRead: true })
         .extract({ top, left, width: blockWidth, height: blockHeight })
         .jpeg()
         .toBuffer();


### PR DESCRIPTION
+ With the new released patch version of `sharp@0.31.1`, we started to get errors when extracting data from the main screenshots. Original issue here - https://github.com/lovell/sharp/issues/3352
+ This would be seen in prior releases versions of the synthetics agent if we relied on sharp library with `^0.31.0`, as the patch version `v0.31.0` would get automatically installed whenever users install or update the synthetics agent. This is the way NPM installation works. 
+ Other problem is that we were not seeing it on the local main branch, as we relied on `lock files`, which was using the `sharp@v0.31.0` which did not have the problem. 
+ As a result of this issue, all new Heartbeat images which baked in the latest synthetics agent release `v0.1.0-beta.36` is unable to produce screenshots as the agent was not writing them correctly. 
+ The fix here was to not reuse the old sharp instance, instead create a new sharp instance every-time during extraction which seems to be fix the orientation problem yielding correct results. There is no perf impact due to this change. 

### Testing
1. Create a journey file `inline.ts` with the below journey
```ts
step("Test step", async () => {
  await page.goto("https://www.example.com");
});
```
2. Run command `cat inline.ts | node dist/cli.js --inline --rich-events | jq .type | uniq` to check if you are getting the new screenshots data.
3. Install this version globally by `npm i -g .`  and check if you can see the data in Kibana by running an inline Heartbeat monitor. 
4. To reproduce the old issue, Use the old sharp version `v0.31.0` by `npm install sharp@0.31.0` - Make sure its updated in lock files as well.
5. Run the same command, you would not see the screenshot type in output. 