### PR TITLE
fix: use correct loader for journey files

### DIFF
--- a/__tests__/push/bundler.test.ts
+++ b/__tests__/push/bundler.test.ts
@@ -78,11 +78,15 @@ describe('Bundler', () => {
 import isPositive from 'is-positive';
 
 journey('journey 1', () => {
-  monitor.use({ id: 'duplicate id' })
+  monitor.use({ id: 'duplicate id' });
+  launchStep(-1);
+});
+
+const launchStep = (no: number) => {
   step("step1", () => {
-    isPositive(-1);
+    isPositive(no);
   })
-});`
+};`
     );
   });
 


### PR DESCRIPTION
-  fix #625 
- When journey files are pushed, We treat these files differently when bundling 
    1. Entry paths - Journey files
    2. Imported paths - Other deps / local files imported by the journey files itself. 

- When the journey files are loaded by the bundler, the underlying loader in the `ES build` was defaulting to `JS` which throws error when `Typescript types` are used inside the journey files. This PR fixes the problem by using appropriate loader for the journey files when `push` command is invoked. The test is also added to ensure this does not break in the future. 

### Testing
1. Build the PR - `npm run build`
2. Create an example journey, `example.journey.ts`
3. Use the example below which relies on TS typings 
```ts
const createJourney = (name: string) => {  // TS types
  journey(name, ({ page, params }) => {
    step('launch application', async () => {
      await page.goto(params.url);
    });
  });
};

['a', 'b'].forEach(a => createJourney(a));
``` 
4. Run `SYNTHETICS_API_KEY="" npm run push`

