### PR TITLE
feat: show monitor management link once pushed

### DIFF
--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Push API handle streamed response 1`] = `
 > journey 1
 > journey 2
 > deleting all stale monitors
-✓ Pushed
+✓ Pushed: http://localhost:54455/stream/app/uptime/manage-monitors/all
 "
 `;
 
@@ -14,7 +14,7 @@ exports[`Push API handle sync response 1`] = `
 "> preparing all monitors
 > creating all monitors
 > deleting all stale monitors
-✓ Pushed
+✓ Pushed: http://localhost:54455/sync/app/uptime/manage-monitors/all
 "
 `;
 

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -248,7 +248,7 @@ heartbeat.monitors:
   describe('API', () => {
     let server: Server;
     beforeAll(async () => {
-      server = await Server.create();
+      server = await Server.create({ port: 54455 });
       const apiRes = { failedMonitors: [], failedStaleMonitors: [] };
       server.route(
         '/sync/s/dummy/api/synthetics/service/project/monitors',

--- a/__tests__/utils/server.ts
+++ b/__tests__/utils/server.ts
@@ -30,7 +30,7 @@ import { createReadStream, readFileSync } from 'fs';
 import { join } from 'path';
 import { AddressInfo } from 'net';
 
-type CreateOpts = { tls?: boolean };
+type CreateOpts = { tls?: boolean; port?: number };
 
 export class Server {
   PREFIX: string;
@@ -59,7 +59,7 @@ export class Server {
     }
 
     this._server = srvConstructor(this._onRequest.bind(this));
-    this._server.listen(0);
+    this._server.listen(opts?.port || 0);
     const { port } = this._server.address() as AddressInfo;
     const proto = opts?.tls ? 'https' : 'http';
     this.PREFIX = `${proto}://localhost:${port}`;

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -29,7 +29,11 @@ import { bold, cyan, yellow } from 'kleur/colors';
 import { join, relative, dirname, basename } from 'path';
 // @ts-ignore-next-line: has no exported member 'Input'
 import { prompt, Input } from 'enquirer';
-import { progress, removeTrailingSlash, write as stdWrite } from '../helpers';
+import {
+  getMonitorManagementURL,
+  progress,
+  write as stdWrite,
+} from '../helpers';
 import {
   getPackageManager,
   replaceTemplates,
@@ -107,9 +111,7 @@ export class Generator {
     const auth = await new Input({
       name: 'auth',
       header: yellow(
-        `Generate API key from Kibana ${removeTrailingSlash(
-          url
-        )}/app/uptime/manage-monitors/all`
+        `Generate API key from Kibana ${getMonitorManagementURL(url)}`
       ),
       required: true,
       message: 'What is your API key',

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -366,3 +366,7 @@ export function warn(message: string) {
 export function removeTrailingSlash(url: string) {
   return url.replace(/\/+$/, '');
 }
+
+export function getMonitorManagementURL(url) {
+  return removeTrailingSlash(url) + '/app/uptime/manage-monitors/all';
+}

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -44,7 +44,6 @@ import {
   indent,
   safeNDJSONParse,
   done,
-  removeTrailingSlash,
   getMonitorManagementURL,
 } from '../helpers';
 import type { PushOptions, ProjectSettings } from '../common_types';

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -25,7 +25,7 @@
 
 import { readFile, writeFile } from 'fs/promises';
 import { prompt } from 'enquirer';
-import { bold } from 'kleur/colors';
+import { bold, grey } from 'kleur/colors';
 import {
   ok,
   formatAPIError,
@@ -44,6 +44,8 @@ import {
   indent,
   safeNDJSONParse,
   done,
+  removeTrailingSlash,
+  getMonitorManagementURL,
 } from '../helpers';
 import type { PushOptions, ProjectSettings } from '../common_types';
 import { findSyntheticsConfig, readConfig } from '../config';
@@ -85,7 +87,7 @@ export async function push(monitors: Monitor[], options: PushOptions) {
   progress(`deleting all stale monitors`);
   await pushMonitors({ schemas, keepStale: false, options });
 
-  done('Pushed');
+  done(`Pushed: ${grey(getMonitorManagementURL(options.url))}`);
 }
 
 export async function pushMonitors({


### PR DESCRIPTION
+ Takes the user to the monitor management UI where users can see all the pushed monitors
+ Looks like below

<img width="985" alt="Screen Shot 2022-10-25 at 4 18 35 PM" src="https://user-images.githubusercontent.com/3902525/197899816-198bc519-e4bc-4145-b984-329fae25a571.png">


### Testing
1. Build the project - `npm run build`
2. Push a synthetics project - `SYNTHETICS_API_KEY=<> node dist/cli.js push`