### PR TITLE
fix: use timeout specified in playwright options

### DIFF
--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -164,6 +164,26 @@ describe('Gatherer', () => {
     });
   });
 
+  describe('Playwright override default timeout', () => {
+    it('sets the passed value as timeout', async () => {
+      const timeout = 1000;
+      const driver = await Gatherer.setupDriver({
+        wsEndpoint,
+        playwrightOptions: { timeout },
+      });
+      expect(await driver.context['_options']['timeout']).toEqual(timeout);
+
+      await driver.page.goto(server.TEST_PAGE);
+      try {
+        await driver.page.waitForSelector('h1');
+      } catch (e) {
+        expect(e.message).toContain(`Timeout ${timeout}ms exceeded`);
+      }
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
+    });
+  });
+
   describe('Network emulation', () => {
     const networkConditions = {
       downloadThroughput: megabitsToBytes(3),

--- a/examples/todos/basic.journey.ts
+++ b/examples/todos/basic.journey.ts
@@ -2,7 +2,7 @@ import { journey, step, expect } from '@elastic/synthetics';
 
 journey('check if title is present', ({ page, params }) => {
   step('launch app', async () => {
-    await page.goto(params.url);
+    await page.goto('https://www.elastic.co/');
   });
 
   step('assert title', async () => {

--- a/examples/todos/basic.journey.ts
+++ b/examples/todos/basic.journey.ts
@@ -2,7 +2,7 @@ import { journey, step, expect } from '@elastic/synthetics';
 
 journey('check if title is present', ({ page, params }) => {
   step('launch app', async () => {
-    await page.goto('https://www.elastic.co/');
+    await page.goto(params.url);
   });
 
   step('assert title', async () => {

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -62,6 +62,10 @@ export class Gatherer {
       ...playwrightOptions,
       userAgent: await Gatherer.getUserAgent(playwrightOptions?.userAgent),
     });
+    if (playwrightOptions?.timeout) {
+      context.setDefaultTimeout(playwrightOptions.timeout);
+    }
+
     Gatherer.setNetworkConditions(context, networkConditions);
 
     const page = await context.newPage();


### PR DESCRIPTION
We needed this in kibana tests where often timout can increae from 30 seconds, so changing value in each selector is annoying 

fixes  https://github.com/elastic/synthetics/issues/662