### PR TITLE
fix: parse buffered NDJSON response from kibana correctly

### DIFF
--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -263,6 +263,12 @@ heartbeat.monitors:
           req.on('data', chunks => {
             const schema = JSON.parse(chunks.toString()) as APISchema;
             res.write(JSON.stringify(schema.monitors[0].name) + '\n');
+            if (!schema.keep_stale) {
+              // write more than the stream buffer to check the broken NDJSON data
+              res.write(
+                JSON.stringify(Buffer.from('a'.repeat(70000)).toString()) + '\n'
+              );
+            }
           });
           req.on('end', () => {
             res.end(JSON.stringify(apiRes));

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -322,10 +322,10 @@ export function wrapFnWithLocation<A extends unknown[], R>(
 }
 
 // Safely parse ND JSON (Newline delimitted JSON) chunks
-export function safeNDJSONParse(chunks: string[]) {
-  // chunks may not be at proper newline boundaries, so we make sure everything is split
+export function safeNDJSONParse(data: string | string[]) {
+  // data may not be at proper newline boundaries, so we make sure everything is split
   // on proper newlines
-  chunks = Array.isArray(chunks) ? chunks : [chunks];
+  const chunks = Array.isArray(data) ? data : [data];
   const lines = chunks.join('\n').split(/\r?\n/);
   return lines
     .filter(l => l.match(/\S/)) // remove blank lines


### PR DESCRIPTION
+ fix #660 
+ When Kibana NDJSON responses are buffered, this would result in parsing error on the chunking code as buffer length can be different when working on local vs on cloud (proxies).
+ To account for these varying buffer lengths, We consume all the stream body from Kibana as buffers and then parse the NDJSON response to avoid intereleaved parsing errors. 