### PR TITLE
add url and api key options to init command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,6 +49,7 @@ import {
   getLocations,
   renderLocations,
   LocationCmdOptions,
+  InitCmdOptions,
 } from './locations';
 import { resolve } from 'path';
 import { Generator } from './generator';
@@ -216,9 +217,18 @@ program
 program
   .command('init [dir]')
   .description('Initialize Elastic synthetics project')
-  .action(async (dir = '') => {
+  .option('--url <url>', 'Kibana URL to fetch all public and private locations')
+  .option(
+    '--api-key <apiKey>',
+    'API key used for Kibana authentication(https://www.elastic.co/guide/en/kibana/master/api-keys.html).'
+  )
+  .action(async (dir = '', cmdOpts: InitCmdOptions) => {
     try {
-      const generator = await new Generator(resolve(process.cwd(), dir));
+      const generator = await new Generator(
+        resolve(process.cwd(), dir),
+        cmdOpts.apiKey,
+        cmdOpts.url
+      );
       await generator.setup();
     } catch (e) {
       e && error(e);

--- a/src/locations/index.ts
+++ b/src/locations/index.ts
@@ -32,6 +32,12 @@ export type LocationCmdOptions = {
   url: string;
 };
 
+export type InitCmdOptions = {
+  apiKey?: string;
+  url?: string;
+  dir: string;
+};
+
 type LocationMetadata = {
   id: string;
   label: string;


### PR DESCRIPTION
This allow it easy to bootstrap project by providing opts and api key via options. 

This will allow us to show command in kibana for user, where they are getting api key like this


`npx @elastic/synthetics init --url <url> --api-key <apiKey>`