### PR TITLE
fix: update hash when monitor content changes

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -78,24 +78,22 @@ describe('Monitors', () => {
       schedule: 10,
       type: 'http',
       enabled: true,
-      hash: 'fS9hbiqcopwk3gMeDrqMgyp0mEpeyFWy6F/YFSnfWPE=',
+      hash: 'igo/MKAypnRGwHGRMPdZI9pQ3AFR7bP2Jqa7nacpNsk=',
       locations: ['europe-west2-a', 'australia-southeast1-a'],
       privateLocations: ['germany'],
     });
   });
 
   it('build browser monitor schema', async () => {
-    const schema = await buildMonitorSchema(
-      [createTestMonitor('example.journey.ts')],
-      true
-    );
+    const monitor = createTestMonitor('example.journey.ts');
+    const schema = await buildMonitorSchema([monitor], true);
     expect(schema[0]).toEqual({
       id: 'test-monitor',
       name: 'test',
       schedule: 10,
       type: 'browser',
       enabled: true,
-      hash: 'I+bYcE74C35IaKpHeN04wBfinO3qEiqlcaksKFAmkBg=',
+      hash: 'ZdPp+3TMq4vdxSzFWOgyt6m/NeouY4y4U+jeizdlejI=',
       locations: ['europe-west2-a', 'australia-southeast1-a'],
       privateLocations: ['germany'],
       content: expect.any(String),
@@ -103,6 +101,9 @@ describe('Monitors', () => {
         match: 'test',
       },
     });
+    monitor.setContent('foo');
+    const schema1 = await buildMonitorSchema([monitor], true);
+    expect(schema1[0].hash).not.toEqual(schema[0].hash);
   });
 
   it('parse @every schedule format', async () => {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -397,7 +397,6 @@ export default class Runner {
     });
 
     const { match, tags } = options;
-
     const monitors: Monitor[] = [];
     for (const journey of this.journeys) {
       if (!journey.isMatch(match, tags)) {

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -97,6 +97,7 @@ export class Journey {
       ...config,
     });
     this.monitor.setSource(this.location);
+    this.monitor.setContent(this.callback.toString());
     this.monitor.setFilter({ match: this.name });
   }
 

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -63,6 +63,7 @@ type MonitorFilter = {
 };
 
 export class Monitor {
+  content?: string;
   source?: Location;
   filter: MonitorFilter;
   constructor(public config: MonitorConfig = {}) {}
@@ -85,6 +86,14 @@ export class Monitor {
   setSource(source: Location) {
     this.source = source;
   }
+
+  /**
+   * The underlying journey code of the monitor
+   */
+  setContent(content = '') {
+    this.content = content;
+  }
+
   /**
    * If journey files are colocated within the same file during
    * push command, when we invoke synthetics from HB we rely on
@@ -95,9 +104,20 @@ export class Monitor {
     this.filter = filter;
   }
 
+  /**
+   * Hash is used to identify if the monitor has changed since the last time
+   * it was pushed to Kibana. Change is based on three factors:
+   * - Monitor configuration
+   * - Code changes
+   * - File path changes
+   */
   hash(): string {
     const hash = createHash('sha256');
-    return hash.update(JSON.stringify(this.config)).digest('base64');
+    return hash
+      .update(JSON.stringify(this.config))
+      .update(this.content || '')
+      .update(this.source?.file || '')
+      .digest('base64');
   }
 
   validate() {


### PR DESCRIPTION
+ Make sure the code changes for a given monitor updates the hash which would update the Monitors being pushed to Kibana instead of skipping them.
+ With this PR, Hash is changed to be based on three factors:
    - Monitor configuration 
    - Code changes (Any change in the code would need to be factored in as we will be using that showcase the stack trace)
    - File path changes (No need to check for line and column as they are irrelevant)