### PR TITLE
fix: allow disabling throttling in project monitors

### DIFF
--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -75,7 +75,7 @@ describe('options', () => {
 
   it('normalize monitor configs', () => {
     expect(normalizeOptions({ throttling: false })).toMatchObject({
-      throttling: {},
+      throttling: false,
     });
 
     expect(

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -209,7 +209,7 @@ type BaseArgs = {
   ignoreHttpsErrors?: boolean;
   playwrightOptions?: PlaywrightOptions;
   quietExitCode?: boolean;
-  throttling?: ThrottlingOptions;
+  throttling?: MonitorConfig['throttling'];
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
@@ -226,7 +226,6 @@ export type CliArgs = BaseArgs & {
   richEvents?: boolean;
   capability?: Array<string>;
   ignoreHttpsErrors?: boolean;
-  throttling?: boolean | ThrottlingOptions;
 };
 
 export type RunOptions = BaseArgs & {

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -51,7 +51,7 @@ export type MonitorConfig = {
   enabled?: boolean;
   locations?: SyntheticsLocationsType[];
   privateLocations?: string[];
-  throttling?: ThrottlingOptions;
+  throttling?: boolean | ThrottlingOptions;
   screenshot?: ScreenshotOptions;
   params?: Params;
   playwrightOptions?: PlaywrightOptions;


### PR DESCRIPTION
+ fix #689 
+ PR fixes the types and allows throttling to be disabled via
  - CLI - `--no-throttling`
  - Synthetics Config File - `monitor.throttling: false`
  - Monitor API - `monitor.use({ throttling: false })`
+ Needs Kibana fix to work End to End - https://github.com/elastic/kibana/issues/148344