### PR TITLE
fix: add monitor heading to lightweight scaffolding template 

### DIFF
--- a/templates/lightweight/heartbeat.yml
+++ b/templates/lightweight/heartbeat.yml
@@ -1,3 +1,4 @@
+heartbeat.monitors:
 - type: http
   name: Todos Lightweight
   id: todos-lightweight


### PR DESCRIPTION
The `lightweight.yml` is not being pushed because it’s missing the `heartbeat.monitors:` heading