### PR TITLE
enable use of custom data-test-id

### DIFF
--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -148,7 +148,7 @@ describe('Gatherer', () => {
         expect(request.headers()['user-agent']).toContain('Elastic/Synthetics');
       });
       await page.setContent(
-        '<a target=_blank rel=noopener href="/popup.html">popup</a>'
+        '<a target=_blank rel=noopener href="/username-page">popup</a>'
       );
       const [page1] = await Promise.all([
         context.waitForEvent('page'),
@@ -159,6 +159,41 @@ describe('Gatherer', () => {
         'Elastic/Synthetics'
       );
       expect(await page1.textContent('body')).toEqual('Not found');
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
+    });
+  });
+
+  describe.only('Set Test ID Attribute', () => {
+    it('uses default when not set', async () => {
+      const driver = await Gatherer.setupDriver({
+        wsEndpoint,
+      });
+      const { page } = driver;
+      await page.goto(server.TEST_PAGE);
+      await page.setContent(
+        '<a target=_blank rel=noopener href="/popup.html" data-testid="username-button">Click me</a>'
+      );
+      expect(await page.getByTestId('username-button').isVisible()).toEqual(
+        true
+      );
+      await Gatherer.dispose(driver);
+      await Gatherer.stop();
+    });
+
+    it('uses custom when provided', async () => {
+      const driver = await Gatherer.setupDriver({
+        wsEndpoint,
+        playwrightOptions: { testIdAttribute: 'data-test-subj' },
+      });
+      const { page } = driver;
+      await page.goto(server.TEST_PAGE);
+      await page.setContent(
+        '<a target=_blank rel=noopener href="/popup.html" data-test-subj="username-button">Click me</a>'
+      );
+      expect(await page.getByTestId('username-button').isVisible()).toEqual(
+        true
+      );
       await Gatherer.dispose(driver);
       await Gatherer.stop();
     });

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -148,7 +148,7 @@ describe('Gatherer', () => {
         expect(request.headers()['user-agent']).toContain('Elastic/Synthetics');
       });
       await page.setContent(
-        '<a target=_blank rel=noopener href="/username-page">popup</a>'
+        '<a target=_blank rel=noopener href="/popup.html">popup</a>'
       );
       const [page1] = await Promise.all([
         context.waitForEvent('page'),

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -164,7 +164,7 @@ describe('Gatherer', () => {
     });
   });
 
-  describe.only('Set Test ID Attribute', () => {
+  describe('Set Test ID Attribute', () => {
     it('uses default when not set', async () => {
       const driver = await Gatherer.setupDriver({
         wsEndpoint,

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -254,7 +254,8 @@ export type ProjectSettings = {
   space: string;
 };
 
-export type PlaywrightOptions = LaunchOptions & BrowserContextOptions;
+export type PlaywrightOptions = LaunchOptions &
+  BrowserContextOptions & { testIdAttribute?: string };
 export type SyntheticsConfig = {
   params?: Params;
   playwrightOptions?: PlaywrightOptions;

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -28,6 +28,7 @@ import {
   ChromiumBrowser,
   BrowserContext,
   request as apiRequest,
+  selectors,
 } from 'playwright-chromium';
 import { PluginManager } from '../plugins';
 import { log } from './logger';
@@ -63,6 +64,10 @@ export class Gatherer {
       userAgent: await Gatherer.getUserAgent(playwrightOptions?.userAgent),
     });
     Gatherer.setNetworkConditions(context, networkConditions);
+
+    if (playwrightOptions?.testIdAttribute) {
+      selectors.setTestIdAttribute(playwrightOptions.testIdAttribute);
+    }
 
     const page = await context.newPage();
     const client = await context.newCDPSession(page);


### PR DESCRIPTION
With this we can provide a custom data-test id like `data-test-subj`, will make life easier with kibana tests specifically. 