### PR TITLE
add types for status alert

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ examples
 templates
 __tests__/e2e/tmp/
 src/sdk/lh-trace-processor.ts
+test-projects/

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -124,7 +124,7 @@ describe('Monitors', () => {
     expect(parseSchedule('@every 10h2m10s')).toBe(60);
   });
 
-  it.only('parse alert config option', async () => {
+  it('parse alert config option', async () => {
     expect(parseAlertConfig({})).toBe(undefined);
     expect(parseAlertConfig({ 'alert.status.enabled': true } as any)).toEqual({
       status: { enabled: true },

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -30,6 +30,7 @@ import {
   buildMonitorSchema,
   createLightweightMonitors,
   diffMonitors,
+  parseAlertConfig,
   parseSchedule,
 } from '../../src/push/monitor';
 import { Server } from '../utils/server';
@@ -121,6 +122,16 @@ describe('Monitors', () => {
     expect(parseSchedule('@every 45m')).toBe(30);
     expect(parseSchedule('@every 1h2m')).toBe(60);
     expect(parseSchedule('@every 10h2m10s')).toBe(60);
+  });
+
+  it.only('parse alert config option', async () => {
+    expect(parseAlertConfig({})).toBe(undefined);
+    expect(parseAlertConfig({ 'alert.status.enabled': true } as any)).toEqual({
+      status: { enabled: true },
+    });
+    expect(parseAlertConfig({ alert: { status: { enabled: true } } })).toEqual({
+      status: { enabled: true },
+    });
   });
 
   describe('Lightweight monitors', () => {

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -55,6 +55,11 @@ export type MonitorConfig = {
   screenshot?: ScreenshotOptions;
   params?: Params;
   playwrightOptions?: PlaywrightOptions;
+  alert?: {
+    status: {
+      enabled: boolean;
+    };
+  };
 };
 
 type MonitorFilter = {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -24,7 +24,6 @@
  */
 
 import { mkdir, rm, readFile } from 'fs/promises';
-import get from 'lodash/get';
 import { join } from 'path';
 import { LineCounter, parseDocument, YAMLSeq, YAMLMap } from 'yaml';
 import { bold, red } from 'kleur/colors';
@@ -240,6 +239,7 @@ export const parseAlertConfig = (config: MonitorConfig) => {
       },
     };
   }
+  return config.alert;
 };
 
 export function parseSchedule(schedule: string) {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -24,6 +24,7 @@
  */
 
 import { mkdir, rm, readFile } from 'fs/promises';
+import get from 'lodash/get';
 import { join } from 'path';
 import { LineCounter, parseDocument, YAMLSeq, YAMLMap } from 'yaml';
 import { bold, red } from 'kleur/colors';
@@ -218,13 +219,28 @@ export function buildMonitorFromYaml(
     config['private_locations'] || options.privateLocations;
   delete config['private_locations'];
 
+  const alertConfig = parseAlertConfig(config);
+
   return new Monitor({
     locations: options.locations,
     ...config,
     privateLocations,
     schedule: schedule || options.schedule,
+    alert: alertConfig,
   });
 }
+
+export const parseAlertConfig = (config: MonitorConfig) => {
+  if (config['alert.status.enabled'] !== undefined) {
+    const value = config['alert.status.enabled'];
+    delete config['alert.status.enabled'];
+    return {
+      status: {
+        enabled: value,
+      },
+    };
+  }
+};
 
 export function parseSchedule(schedule: string) {
   const EVERY_SYNTAX = '@every';

--- a/templates/lightweight/heartbeat.yml
+++ b/templates/lightweight/heartbeat.yml
@@ -6,3 +6,4 @@ heartbeat.monitors:
   urls: "https://elastic.github.io/synthetics-demo/"
   schedule: '@every 3m'
   timeout: 16s
+  alert.status.enabled: true


### PR DESCRIPTION
add types for status alert

status alert can be enabled/disable using 
```

    monitor.use({
      schedule: 10,
      alert: {
        status: {
          enabled: false,
        },
      },
    });
```

in lightweight:
```

heartbeat.monitors:
- type: http
  name: Todos Lightweight
  id: todos-lightweight
  enabled: true
  urls: "https://elastic.github.io/synthetics-demo/"
  schedule: '@every 3m'
  timeout: 16s
  alert.status.enabled: true
```