### PR TITLE
fix: ignore yml files inside node_modules dir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "unzipper": "^0.10.11"
       },
       "engines": {
-        "node": ">14.14.0"
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -148,8 +148,9 @@ export async function createLightweightMonitors(
   options: PushOptions
 ) {
   const lwFiles = new Set<string>();
+  const ignore = /(node_modules|.github)/;
   await totalist(workDir, (rel, abs) => {
-    if (/.(yml|yaml)$/.test(rel)) {
+    if (!ignore.test(rel) && /.(yml|yaml)$/.test(rel)) {
       lwFiles.add(abs);
     }
   });


### PR DESCRIPTION
+ fix #712 
+ Ignores all the yaml files inside `node_modules` and `.github` directory to be defensive from adding the monitors that are added as templates from the Elastic synthetics source package itself. 