### PR TITLE
fix: avoid hanging on capturing network data

### DIFF
--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -125,11 +125,13 @@ export class Gatherer {
   }
 
   static async dispose(driver: Driver) {
+    log(`Gatherer: closing all contexts`);
     await driver.request.dispose();
     await driver.context.close();
   }
 
   static async stop() {
+    log(`Gatherer: closing browser`);
     if (Gatherer.browser) {
       await Gatherer.browser.close();
       Gatherer.browser = null;

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -26,13 +26,20 @@
 import { grey, cyan, dim, italic } from 'kleur/colors';
 import { now } from '../helpers';
 
+/**
+ * Set debug based on DEBUG ENV and namespace - synthetics
+ */
+if (process.env.DEBUG && process.env.DEBUG.includes('synthetics')) {
+  process.env['__SYNTHETICS__DEBUG__'] = '1';
+}
+
 export function log(msg) {
-  if (!process.env.DEBUG || !msg) {
+  if (!process.env['__SYNTHETICS__DEBUG__'] || !msg) {
     return;
   }
   if (typeof msg === 'object') {
     msg = JSON.stringify(msg);
   }
   const time = dim(cyan(`at ${parseInt(String(now()))} ms `));
-  console.log(time + italic(grey(msg)) + '\n');
+  console.log(time + italic(grey(msg)));
 }

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -118,6 +118,7 @@ export default class Runner {
         join(Runner.screenshotPath, fileName),
         JSON.stringify(screenshot)
       );
+      log(`Runner: captured screenshot for (${step.name})`);
     }
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -29,15 +29,6 @@ import { readConfig } from './config';
 import { getNetworkConditions, DEFAULT_THROTTLING_OPTIONS } from './helpers';
 import type { CliArgs, RunOptions, ThrottlingOptions } from './common_types';
 
-/**
- * Set debug based on DEBUG ENV and -d flags
- * namespace - synthetics
- */
-const namespace = 'synthetics';
-if (process.env.DEBUG && process.env.DEBUG.includes(namespace)) {
-  process.env.DEBUG = '1';
-}
-
 export function normalizeOptions(cliArgs: CliArgs): RunOptions {
   const options: RunOptions = {
     ...cliArgs,

--- a/src/plugins/browser-console.ts
+++ b/src/plugins/browser-console.ts
@@ -24,6 +24,7 @@
  */
 
 import { BrowserMessage, Driver } from '../common_types';
+import { log } from '../core/logger';
 import { Step } from '../dsl';
 import { getTimestamp } from '../helpers';
 
@@ -76,6 +77,7 @@ export class BrowserConsole {
   }
 
   start() {
+    log(`Plugins: started collecting console events`);
     this.driver.page.on('console', this.consoleEventListener);
     this.driver.page.on('pageerror', this.pageErrorEventListener);
   }
@@ -83,6 +85,7 @@ export class BrowserConsole {
   stop() {
     this.driver.page.off('console', this.consoleEventListener);
     this.driver.page.off('pageerror', this.pageErrorEventListener);
+    log(`Plugins: stopped collecting console events`);
     return this.messages;
   }
 }

--- a/src/plugins/plugin-manager.ts
+++ b/src/plugins/plugin-manager.ts
@@ -32,6 +32,7 @@ import {
   TraceOptions,
 } from './';
 import { Step } from '../dsl';
+import { log } from '../core/logger';
 
 type PluginType = 'network' | 'trace' | 'performance' | 'browserconsole';
 type Plugin = NetworkManager | Tracing | PerformanceManager | BrowserConsole;

--- a/src/plugins/tracing.ts
+++ b/src/plugins/tracing.ts
@@ -24,6 +24,7 @@
  */
 
 import { Driver, PluginOutput } from '../common_types';
+import { log } from '../core/logger';
 import { Filmstrips } from '../sdk/trace-metrics';
 import { TraceEvent, TraceProcessor } from '../sdk/trace-processor';
 
@@ -40,6 +41,7 @@ export class Tracing {
   constructor(private driver: Driver, private options: TraceOptions) {}
 
   async start() {
+    log(`Plugins: started collecting trace events`);
     const includedCategories = [
       // exclude all default categories
       '-*',
@@ -97,6 +99,7 @@ export class Tracing {
         ...TraceProcessor.computeTrace(traceEvents as Array<TraceEvent>),
       });
     }
+    log(`Plugins: stopped collecting trace events`);
     return output;
   }
 }


### PR DESCRIPTION
+ Fixes the issue when we might be waiting for the promises to be fulfilled forever if the responses is chunked which might keep out promises to be hanging forever. 
+ This issue is not easily reproducible and so, its quite hard to add a test case for this with chunked response. We already have a test case for capturing chunked request informatiion, so it should cover this already. 
+ Also added more debug logging as it was the only way to identify this issue on our global infrastructure. 
```
DEBUG=synthetics npm run test
```
