### PR TITLE
fix: drop network events once test runs to completion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git@github.com:pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v4.4.0
     hooks:
     -   id: check-case-conflict
     -   id: check-executables-have-shebangs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git@github.com:pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
     -   id: check-case-conflict

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -39,7 +39,6 @@ import { Driver, NetworkConditions, RunOptions } from '../common_types';
  * related capabilities for the runner to run all journeys
  */
 export class Gatherer {
-  static isClosing = false;
   static browser: ChromiumBrowser;
 
   static async setupDriver(options: RunOptions): Promise<Driver> {
@@ -117,8 +116,7 @@ export class Gatherer {
 
   static async closeBrowser() {
     log(`Gatherer: closing browser`);
-    if (Gatherer.browser && !Gatherer.isClosing) {
-      Gatherer.isClosing = true;
+    if (Gatherer.browser) {
       await Gatherer.browser.close();
       Gatherer.browser = null;
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -47,7 +47,7 @@ export const journey = wrapFnWithLocation(
     options: JourneyOptions | string,
     callback: JourneyCallback
   ) => {
-    log(`register journey: ${JSON.stringify(options)}`);
+    log(`Journey register: ${JSON.stringify(options)}`);
     if (typeof options === 'string') {
       options = { name: options, id: options };
     }
@@ -59,7 +59,7 @@ export const journey = wrapFnWithLocation(
 
 export const step = wrapFnWithLocation(
   (location: Location, name: string, callback: VoidCallback) => {
-    log(`register step: ${name}`);
+    log(`Step register: ${name}`);
     return runner.currentJourney?.addStep(name, callback, location);
   }
 );

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -41,5 +41,5 @@ export function log(msg) {
     msg = JSON.stringify(msg);
   }
   const time = dim(cyan(`at ${parseInt(String(now()))} ms `));
-  console.log(time + italic(grey(msg)));
+  process.stderr.write(time + italic(grey(msg)) + '\n');
 }


### PR DESCRIPTION
+ Addition to what we did on #719 
+ Upstream bug in Chrome - https://bugs.chromium.org/p/chromium/issues/detail?id=1427331
+ Avoid Waiting for all network events as its error prone and might hang the tests from getting closed forever when there are upstream bugs in browsers or Playwright. So we log and drop these events once the test run is completed
+ Added a sig int handler to handle uncaught errors when not run in HB mode. 