### PR TITLE
fix: round off nearest schedule for lighweight monitors

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -113,19 +113,22 @@ describe('Monitors', () => {
     );
     expect(parseSchedule('@every 4s')).toBe(1);
     expect(parseSchedule('@every 70s')).toBe(1);
-    expect(parseSchedule('@every 121s')).toBe(1);
+    expect(parseSchedule('@every 121s')).toBe(3);
     expect(parseSchedule('@every 1m')).toBe(1);
+    expect(parseSchedule('@every 2m30s')).toBe(3);
     expect(parseSchedule('@every 181s')).toBe(3);
     expect(parseSchedule('@every 2m10s')).toBe(3);
     expect(parseSchedule('@every 4m25s')).toBe(5);
     expect(parseSchedule('@every 16m')).toBe(15);
     expect(parseSchedule('@every 24m')).toBe(20);
     expect(parseSchedule('@every 30m')).toBe(30);
-    expect(parseSchedule('@every 45m')).toBe(30);
+    expect(parseSchedule('@every 45m')).toBe(60);
     expect(parseSchedule('@every 1h2m')).toBe(60);
-    expect(parseSchedule('@every 110m')).toBe(60);
-    expect(parseSchedule('@every 3h50m')).toBe(120);
+    expect(parseSchedule('@every 110m')).toBe(120);
+    expect(parseSchedule('@every 2h20m')).toBe(120);
+    expect(parseSchedule('@every 3h50m')).toBe(240);
     expect(parseSchedule('@every 10h2m10s')).toBe(240);
+    expect(parseSchedule('@every 1d')).toBe(240);
   });
 
   it('parse alert config option', async () => {


### PR DESCRIPTION
+ Round off to the nearest supported schedule instead of picking the lowest scheduled value all the time. 
+ Also, adjust the wording around the Lighweight monitors schedule being adjusted when pushed via project monitors. 