### PR TITLE
fix: capture trace metrics including web-vitals for failed steps

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -627,6 +627,7 @@ describe('runner', () => {
           <img src=${server.PREFIX}/favicon.png>
         `);
         await page.waitForLoadState('networkidle');
+        throw 'step error';
       });
     });
     const runOptions = { ...defaultRunOptions, trace: true };
@@ -639,9 +640,8 @@ describe('runner', () => {
     expect(step2.traces?.length).toBeGreaterThan(0);
     expect(step2.metrics).toMatchObject({
       cls: 0,
-      fcp: {
-        us: expect.any(Number),
-      },
+      fcp: { us: expect.any(Number) },
+      load: { us: expect.any(Number) },
     });
   });
 

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -302,7 +302,7 @@ export class NetworkManager {
      * Playwright. So we log and drop these events once the test run is completed
      */
     if (this._barrierPromises.size > 0) {
-      log(`Plugins: dropping ${this._barrierPromises.size} network events}`);
+      log(`Plugins: dropping ${this._barrierPromises.size} network events`);
     }
     const context = this.driver.context;
     context.off('request', this._onRequest.bind(this));


### PR DESCRIPTION
+ fix https://github.com/elastic/synthetics/issues/734
+ This PR fixes the problem when the runner discards the trace events for failed steps. Now, we include all the trace metrics and web vitals including FCP, CLS, LCP for all steps even if they are succeeded or failed. 