### PR TITLE
fix: use headless value from playwrightOptions

### DIFF
--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -33,7 +33,9 @@ describe('options', () => {
       params: {
         foo: 'bar',
       },
-      headless: true,
+      playwrightOptions: {
+        headless: false,
+      },
       sandbox: false,
       screenshots: 'on',
       dryRun: true,
@@ -59,7 +61,7 @@ describe('options', () => {
         defaultBrowserType: 'chromium',
         deviceScaleFactor: 4.5,
         hasTouch: true,
-        headless: true,
+        headless: false,
         ignoreHTTPSErrors: undefined,
         isMobile: true,
         userAgent:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,6 @@ program
   )
   .option('--inline', 'Run inline journeys from heartbeat')
   .option('-r, --require <modules...>', 'module(s) to preload')
-  .option('--no-headless', 'run browser in headful mode')
   .option('--sandbox', 'enable chromium sandboxing')
   .option('--rich-events', 'Mimics a heartbeat run')
   .option(

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -221,7 +221,6 @@ export type CliArgs = BaseArgs & {
   pattern?: string;
   inline?: boolean;
   require?: Array<string>;
-  headless?: boolean;
   sandbox?: boolean;
   richEvents?: boolean;
   capability?: Array<string>;

--- a/src/options.ts
+++ b/src/options.ts
@@ -101,7 +101,6 @@ export function normalizeOptions(cliArgs: CliArgs): RunOptions {
   );
   options.playwrightOptions = {
     ...playwrightOpts,
-    headless: cliArgs.headless,
     chromiumSandbox: cliArgs.sandbox ?? playwrightOpts?.chromiumSandbox,
     ignoreHTTPSErrors:
       cliArgs.ignoreHttpsErrors ?? playwrightOpts?.ignoreHTTPSErrors,


### PR DESCRIPTION
+ fix #740 
+ Fixes the issue with not able to run in non headless mode in any environments. Also removes the unused `no-headless` flag that is not required anymore as we can simulate it based on `--playwright-options '{"headless": false}`