### PR TITLE
feat: allow setting navigation and action timeouts

### DIFF
--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -27,7 +27,7 @@ import { ChildProcess, spawn } from 'child_process';
 import { join } from 'path';
 import { Monitor } from '../../src/dsl/monitor';
 
-export const wsEndpoint = process.env.WSENDPOINT;
+export const wsEndpoint = process.env.WSENDPOINT || '';
 
 const FIXTURES_DIR = join(__dirname, '..', 'fixtures');
 export function createTestMonitor(filename: string, type = 'browser') {
@@ -93,9 +93,9 @@ export class CLIMock {
     );
 
     if (this.stdinStr) {
-      this.process.stdin.setDefaultEncoding('utf8');
-      this.process.stdin.write(this.stdinStr);
-      this.process.stdin.end();
+      this.process.stdin?.setDefaultEncoding('utf8');
+      this.process.stdin?.write(this.stdinStr);
+      this.process.stdin?.end();
     }
 
     const dataListener = data => {
@@ -106,21 +106,21 @@ export class CLIMock {
       this.chunks.push(this.data);
       if (this.waitForPromise && this.data.includes(this.waitForText)) {
         if (!this.debug) {
-          this.process.stdout.off('data', dataListener);
+          this.process.stdout?.off('data', dataListener);
         }
         this.waitForPromise();
       }
     };
-    this.process.stdout.on('data', dataListener);
+    this.process.stdout?.on('data', dataListener);
 
     this.exitCode = new Promise(res => {
-      this.process.stderr.on('data', data => {
+      this.process.stderr?.on('data', data => {
         this.stderrStr += data;
         if (this.debug) {
           console.log('CLIMock.stderr:', data.toString());
         }
       });
-      this.process.on('exit', code => res(code));
+      this.process.on('exit', code => res(code ?? 0));
     });
 
     return this;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -255,7 +255,11 @@ export type ProjectSettings = {
 };
 
 export type PlaywrightOptions = LaunchOptions &
-  BrowserContextOptions & { testIdAttribute?: string };
+  BrowserContextOptions & {
+    testIdAttribute?: string;
+    actionTimeout?: number;
+    navigationTimeout?: number;
+  };
 export type SyntheticsConfig = {
   params?: Params;
   playwrightOptions?: PlaywrightOptions;

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -34,6 +34,9 @@ import { PluginManager } from '../plugins';
 import { log } from './logger';
 import { Driver, NetworkConditions, RunOptions } from '../common_types';
 
+// Default timeout for Playwright actions and Navigations
+const DEFAULT_TIMEOUT = 50000;
+
 /**
  * Purpose of the Gatherer is to set up the necessary browser driver
  * related capabilities for the runner to run all journeys
@@ -63,8 +66,15 @@ export class Gatherer {
       ...playwrightOptions,
       userAgent: await Gatherer.getUserAgent(playwrightOptions?.userAgent),
     });
-    Gatherer.setNetworkConditions(context, networkConditions);
+    // Set timeouts for actions and navigations
+    context.setDefaultTimeout(
+      playwrightOptions?.actionTimeout ?? DEFAULT_TIMEOUT
+    );
+    context.setDefaultNavigationTimeout(
+      playwrightOptions?.navigationTimeout ?? DEFAULT_TIMEOUT
+    );
 
+    Gatherer.setNetworkConditions(context, networkConditions);
     if (playwrightOptions?.testIdAttribute) {
       selectors.setTestIdAttribute(playwrightOptions.testIdAttribute);
     }


### PR DESCRIPTION
+ fix #738
+ PR changes the default navigation timeout for all journeys to `50 seconds` instead of `30 seconds`. Same applies to all actions as well which is controlled by `actionTimeout`. 
+ Allow setting the timeouts mainly `navigationTimeout` and `actionTimeout` via the `playwrightOptions` configuration. These are  prioritized over the default timeout of `50 seconds` which is set by the agent.
+ This is backwards compatible meaning, individual method timeouts would still be preferred over both of these timeouts. Ex: `page.go("url", {timeout: 2000})` would be preferred over `playwrightOptions.navigationTimeout` and `default 50 seconds` timeout. 