### PR TITLE
chore: remove unused network cdp command

### DIFF
--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -83,7 +83,6 @@ export class NetworkManager {
     const { product } = await client.send('Browser.getVersion');
     const [name, version] = product.split('/');
     this._browser = { name, version };
-    await client.send('Network.enable');
     /**
      * Listen for all network events from PW context
      */


### PR DESCRIPTION
+ We have migrated away from plain CDP `devtools` network events and using PW events, so removing it as its not used. 