### PR TITLE
feat: disable throttling and emit warning

### DIFF
--- a/THROTTLING.md
+++ b/THROTTLING.md
@@ -1,1 +1,0 @@
-⚠️ Placeholder for throttling details in Elastic's global managed testing infrastructure (the service) and for Private Locations

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -27,12 +27,7 @@ import { join } from 'path';
 import { devices } from 'playwright-chromium';
 import { Server } from './utils/server';
 import { CLIMock } from './utils/test-config';
-import {
-  DEFAULT_THROTTLING_OPTIONS,
-  getNetworkConditions,
-  megabitsToBytes,
-  safeNDJSONParse,
-} from '../src/helpers';
+import { THROTTLING_WARNING_MSG, safeNDJSONParse } from '../src/helpers';
 
 describe('CLI', () => {
   let server: Server;
@@ -132,25 +127,6 @@ describe('CLI', () => {
       process.env['NODE_ENV'] = 'development';
       expect((await output()).payload).not.toMatchObject({
         params: { url: 'dev' },
-      });
-    });
-
-    it('loads a configuration file when passing a config param', async () => {
-      const cli = new CLIMock(false)
-        .stdin(`step('fake step', async () => {})`)
-        .args([
-          '--reporter',
-          'json',
-          '--inline',
-          '--config',
-          join(FIXTURES_DIR, 'synthetics.config.ts'),
-        ])
-        .run({ cwd: FIXTURES_DIR });
-      await cli.waitFor('synthetics/metadata');
-      expect(await cli.exitCode).toBe(0);
-      const [output] = safeNDJSONParse(cli.output());
-      expect(output.payload).toMatchObject({
-        network_conditions: { latency: 11 },
       });
     });
   });
@@ -272,34 +248,6 @@ describe('CLI', () => {
     expect(screenshotRef).toBeDefined();
     expect(screenshotBlocks.length).toBe(64);
     expect(await cli.exitCode).toBe(0);
-  });
-
-  it('pass dynamic config to journey params', async () => {
-    const getMetadata = async () => {
-      const cli = new CLIMock()
-        .args([
-          join(FIXTURES_DIR, 'fake.journey.ts'),
-          '--reporter',
-          'json',
-          '--config',
-          join(FIXTURES_DIR, 'synthetics.config.ts'),
-        ])
-        .run();
-      await cli.waitFor('synthetics/metadata');
-      expect(await cli.exitCode).toBe(0);
-      return cli.output();
-    };
-
-    let [output] = safeNDJSONParse([await getMetadata()]);
-    expect(output.payload).toMatchObject({
-      network_conditions: { latency: 11 },
-    });
-
-    process.env['NODE_ENV'] = 'development';
-    [output] = safeNDJSONParse([await getMetadata()]);
-    expect(output.payload).toMatchObject({
-      network_conditions: { latency: 10 },
-    });
   });
 
   it('params wins over config params', async () => {
@@ -447,88 +395,30 @@ describe('CLI', () => {
     });
   });
 
-  describe('throttling', () => {
+  describe('Throttling', () => {
     let cliArgs: Array<string>;
-
     beforeAll(async () => {
-      cliArgs = [
-        join(FIXTURES_DIR, 'example.journey.ts'),
-        '--params',
-        JSON.stringify(serverParams),
-        '--reporter',
-        'json',
-      ];
+      cliArgs = ['--reporter', 'json', '--inline'];
     });
 
-    it('applies --no-throttling', async () => {
-      const cli = new CLIMock().args(cliArgs.concat(['--no-throttling'])).run();
-      await cli.waitFor('synthetics/metadata');
-      const journeyStartOutput = JSON.parse(cli.output());
-      expect(await cli.exitCode).toBe(0);
-      expect(journeyStartOutput.payload).toBeUndefined();
-    });
-
-    it('applies default throttling', async () => {
-      const cli = new CLIMock().args(cliArgs).run();
-      await cli.waitFor('synthetics/metadata');
-      const journeyStartOutput = JSON.parse(cli.output());
-      expect(await cli.exitCode).toBe(0);
-      expect(journeyStartOutput.payload).toHaveProperty(
-        'network_conditions',
-        getNetworkConditions(DEFAULT_THROTTLING_OPTIONS)
-      );
-    });
-
-    it('applies custom throttling', async () => {
+    it('warns on --no-throttling', async () => {
       const cli = new CLIMock()
-        .args(
-          cliArgs.concat([
-            '--throttling',
-            JSON.stringify({
-              download: 3,
-              upload: 1,
-              latency: 30,
-            }),
-          ])
-        )
+        .stdin(`step('fake step', async () => {})`)
+        .args(cliArgs.concat('--no-throttling'))
         .run();
-      await cli.waitFor('synthetics/metadata');
-      const journeyStartOutput = JSON.parse(cli.output());
       expect(await cli.exitCode).toBe(0);
-      expect(journeyStartOutput.payload).toHaveProperty('network_conditions', {
-        downloadThroughput: megabitsToBytes(3),
-        uploadThroughput: megabitsToBytes(1),
-        latency: 30,
-        offline: false,
-      });
+      const output = cli.stderr();
+      expect(output).toContain(THROTTLING_WARNING_MSG);
     });
 
-    it('supports older format', async () => {
+    it('warns on --throttling setting', async () => {
       const cli = new CLIMock()
-        .args(cliArgs.concat(['--throttling', '17u/30l/3d']))
+        .stdin(`step('fake step', async () => {})`)
+        .args(cliArgs.concat('--throttling', JSON.stringify({ upload: 10 })))
         .run();
-      await cli.waitFor('synthetics/metadata');
-      const journeyStartOutput = JSON.parse(cli.output());
       expect(await cli.exitCode).toBe(0);
-      expect(journeyStartOutput.payload).toHaveProperty('network_conditions', {
-        downloadThroughput: megabitsToBytes(3),
-        uploadThroughput: megabitsToBytes(17),
-        latency: 30,
-        offline: false,
-      });
-    });
-
-    it('uses default throttling when specific params are not provided', async () => {
-      const cli = new CLIMock()
-        .args(cliArgs.concat(['--throttling', JSON.stringify({ download: 2 })]))
-        .run();
-      await cli.waitFor('synthetics/metadata');
-      const journeyStartOutput = JSON.parse(cli.output());
-      expect(await cli.exitCode).toBe(0);
-      expect(journeyStartOutput.payload).toHaveProperty('network_conditions', {
-        ...getNetworkConditions(DEFAULT_THROTTLING_OPTIONS),
-        downloadThroughput: megabitsToBytes(2),
-      });
+      const output = cli.stderr();
+      expect(output).toContain(THROTTLING_WARNING_MSG);
     });
   });
 

--- a/__tests__/core/gatherer.test.ts
+++ b/__tests__/core/gatherer.test.ts
@@ -199,7 +199,7 @@ describe('Gatherer', () => {
     });
   });
 
-  describe('Network emulation', () => {
+  describe.skip('Network emulation', () => {
     const networkConditions = {
       downloadThroughput: megabitsToBytes(3),
       uploadThroughput: megabitsToBytes(1),

--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -35,9 +35,8 @@ module.exports = env => {
       ...devices['Galaxy S9+'],
     },
   };
-  if (env !== 'development' && config.params && config.monitor) {
+  if (env !== 'development' && config.params) {
     config.params.url = 'non-dev';
-    config.monitor.throttling = { latency: 11 };
   }
   return config;
 };

--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -31,10 +31,6 @@ module.exports = env => {
     params: {
       url: 'dev',
     },
-    monitor: {
-      id: 'monitor-id',
-      throttling: { latency: 10 },
-    },
     playwrightOptions: {
       ...devices['Galaxy S9+'],
     },

--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -32,6 +32,7 @@ module.exports = env => {
       url: 'dev',
     },
     monitor: {
+      id: 'monitor-id',
       throttling: { latency: 10 },
     },
     playwrightOptions: {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -24,7 +24,7 @@
  */
 
 import { CliArgs } from '../src/common_types';
-import { normalizeOptions, parseThrottling } from '../src/options';
+import { normalizeOptions } from '../src/options';
 import { join } from 'path';
 
 describe('options', () => {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -76,32 +76,16 @@ describe('options', () => {
   });
 
   it('normalize monitor configs', () => {
-    expect(normalizeOptions({ throttling: false })).toMatchObject({
-      throttling: false,
-    });
-
     expect(
-      normalizeOptions({ throttling: { download: 50 }, schedule: 3 })
+      normalizeOptions({
+        schedule: 3,
+        privateLocations: ['test'],
+        locations: ['australia_east'],
+      })
     ).toMatchObject({
       schedule: 3,
-      throttling: {
-        download: 50,
-        upload: 3,
-        latency: 20,
-      },
-    });
-  });
-
-  it('parse throttling', () => {
-    expect(parseThrottling('{}')).toEqual({});
-    expect(parseThrottling('{"download": 20, "upload": 10}')).toEqual({
-      download: 20,
-      upload: 10,
-    });
-    expect(parseThrottling('100l/41u/9d')).toEqual({
-      download: 9,
-      upload: 41,
-      latency: 100,
+      privateLocations: ['test'],
+      locations: ['australia_east'],
     });
   });
 });

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -1,0 +1,2 @@
+## Throttling
+

--- a/src/core/gatherer.ts
+++ b/src/core/gatherer.ts
@@ -46,7 +46,7 @@ export class Gatherer {
 
   static async setupDriver(options: RunOptions): Promise<Driver> {
     log('Gatherer: setup driver');
-    const { wsEndpoint, playwrightOptions, networkConditions } = options;
+    const { wsEndpoint, playwrightOptions } = options;
 
     if (Gatherer.browser == null) {
       if (wsEndpoint) {
@@ -74,7 +74,9 @@ export class Gatherer {
       playwrightOptions?.navigationTimeout ?? DEFAULT_TIMEOUT
     );
 
-    Gatherer.setNetworkConditions(context, networkConditions);
+    // TODO: Network throttling via chrome devtools emulation is disabled for now.
+    // See docs/throttling.md for more details.
+    // Gatherer.setNetworkConditions(context, networkConditions);
     if (playwrightOptions?.testIdAttribute) {
       selectors.setTestIdAttribute(playwrightOptions.testIdAttribute);
     }

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -40,7 +40,9 @@ export type SyntheticsLocationsType = keyof typeof LocationsMap;
 export const SyntheticsLocations = Object.keys(
   LocationsMap
 ) as SyntheticsLocationsType[];
-export const ALLOWED_SCHEDULES = [1, 3, 5, 10, 15, 20, 30, 60, 120, 240] as const;
+export const ALLOWED_SCHEDULES = [
+  1, 3, 5, 10, 15, 20, 30, 60, 120, 240,
+] as const;
 
 export type MonitorConfig = {
   id?: string;
@@ -51,6 +53,11 @@ export type MonitorConfig = {
   enabled?: boolean;
   locations?: SyntheticsLocationsType[];
   privateLocations?: string[];
+  /**
+   * @deprecated This option is ignored.
+   * Network throttling via chrome devtools is ignored at the moment.
+   * See https://github.com/elastic/synthetics/blob/main/docs/throttling.md for more details.
+   */
   throttling?: boolean | ThrottlingOptions;
   screenshot?: ScreenshotOptions;
   params?: Params;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -300,6 +300,9 @@ export function getNetworkConditions(
   };
 }
 
+export const THROTTLING_WARNING_MSG = `Throttling may not be active when the tests run - see
+https://github.com/elastic/synthetics/blob/main/docs/throttling.md for more details`;
+
 const dstackTraceLimit = 10;
 
 // Uses the V8 Stacktrace API to get the function location

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -42,6 +42,7 @@ import {
   indent,
   done,
   getMonitorManagementURL,
+  THROTTLING_WARNING_MSG,
 } from '../helpers';
 import type { PushOptions, ProjectSettings } from '../common_types';
 import { findSyntheticsConfig, readConfig } from '../config';
@@ -279,4 +280,12 @@ export async function pushLegacy(
   );
 
   done(`Pushed: ${grey(getMonitorManagementURL(options.url))}`);
+}
+
+// prints warning if any of the monitors has throttling settings enabled during push
+export function warnIfThrottled(monitors: Monitor[]) {
+  const throttled = monitors.some(monitor => monitor.config.throttling != null);
+  if (throttled) {
+    warn(THROTTLING_WARNING_MSG);
+  }
 }


### PR DESCRIPTION
+ fix #756
+ Disables the Network emulation throttling settings via Chrome devtools in the browser CDP session and also provides warnings to the user at different places when users tries
   - Run tests locally with `--throttling` flag
   - Run tests locally with `--no-throttling` flag
   - Push monitors with `--throttling` and `--no-throttling` flag.
   - Push monitors with `monitor.use({throttling: {} )` or `monitor.use({throttling: false})`  on journey level. 
   - Push monitors when `monitor.use({throttling: {}))` set on file level. 
 + Cleaned up the old throttling formatting code as its not required anymore since we have disabled throttling altogether. 