### PR TITLE
chore: fix release gh action script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: npm run clean
-      - run: npm ci
+      - run: npm ci # runs npm prepublish
       - name: Bump the beta version
         run: |
           echo "VERSION=$(npm version prerelease --preid=beta)" >> $GITHUB_ENV


### PR DESCRIPTION
+ The old Jenkins script was cleaning up manually after `npm install` step which is not required. Also, we cant call `npm run clean` as the dependencies wont be available till the environment is prepared with `npm ci`. Example error - https://github.com/elastic/synthetics/actions/runs/4898079942/jobs/8746832489