### PR TITLE
feat: support params for lw monitors with push

### DIFF
--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -34,6 +34,7 @@ import { CLIMock } from '../utils/test-config';
 import { THROTTLING_WARNING_MSG } from '../../src/helpers';
 
 describe('Push', () => {
+  let server: Server;
   const PROJECT_DIR = join(__dirname, 'new-project');
   const DEFAULT_ARGS = ['--auth', 'foo'];
 
@@ -55,10 +56,12 @@ describe('Push', () => {
   }
 
   beforeAll(async () => {
+    server = await createKibanaTestServer('8.6.0');
     await mkdir(PROJECT_DIR, { recursive: true });
   });
   afterAll(async () => {
     process.env.NO_COLOR = '';
+    await server.close();
     await rm(PROJECT_DIR, { recursive: true, force: true });
   });
 
@@ -134,7 +137,7 @@ journey('journey 1', () => monitor.use({ id: 'j1', schedule: 8 }));`
 
   it('errors on duplicate browser monitors', async () => {
     await fakeProjectSetup(
-      { id: 'test-project' },
+      { id: 'test-project', space: 'dummy', url: server.PREFIX },
       { locations: ['test-loc'], schedule: 3 }
     );
 
@@ -173,7 +176,7 @@ journey('duplicate name', () => monitor.use({ schedule: 15 }));`
 
   it('errors on duplicate lightweight monitors', async () => {
     await fakeProjectSetup(
-      { id: 'test-project' },
+      { id: 'test-project', space: 'dummy', url: server.PREFIX },
       { locations: ['test-loc'], schedule: 3 }
     );
 

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -261,6 +261,35 @@ heartbeat.monitors:
       });
     });
 
+    it('use params from config', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: icmp
+  id: foo
+  name: without schedule
+      `);
+      const [monitor1] = await createLightweightMonitors(
+        PROJECT_DIR,
+        {} as PushOptions
+      );
+      expect(monitor1.config).toMatchObject({
+        id: 'foo',
+        name: 'without schedule',
+        type: 'icmp',
+      });
+
+      const [monitor2] = await createLightweightMonitors(PROJECT_DIR, {
+        params: { foo: 'bar' },
+        kibanaVersion: '8.8.0',
+      } as any);
+      expect(monitor2.config).toEqual({
+        id: 'foo',
+        name: 'without schedule',
+        type: 'icmp',
+        params: { foo: 'bar' },
+      });
+    });
+
     it('parses monitor config correctly', async () => {
       await writeHBFile(`
 heartbeat.monitors:

--- a/__tests__/utils/kibana-test-server.ts
+++ b/__tests__/utils/kibana-test-server.ts
@@ -30,7 +30,7 @@ import {
 } from '../../src/push/kibana_api';
 
 export const createKibanaTestServer = async (kibanaVersion: string) => {
-  const server = await Server.create({ port: 54455 });
+  const server = await Server.create({ port: 0 });
   server.route('/s/dummy/api/status', (req, res) =>
     res.end(JSON.stringify({ version: { number: kibanaVersion } }))
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import { Generator } from './generator';
 import { error } from './helpers';
 import { LocationsMap } from './locations/public-locations';
 import { createLightweightMonitors } from './push/monitor';
+import { getVersion } from './push/kibana_api';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
@@ -214,6 +215,7 @@ program
       if ((options as CliArgs).throttling == null) {
         warnIfThrottled(monitors);
       }
+      options.kibanaVersion = await getVersion(options);
       monitors.push(...(await createLightweightMonitors(workDir, options)));
       await push(monitors, options);
     } catch (e) {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -245,6 +245,7 @@ export type PushOptions = Partial<ProjectSettings> & {
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
   params?: MonitorConfig['params'];
+  kibanaVersion?: number;
   yes?: boolean;
   pattern?: string;
   match?: string;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -244,6 +244,7 @@ export type PushOptions = Partial<ProjectSettings> & {
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
+  params?: MonitorConfig['params'];
   yes?: boolean;
   pattern?: string;
   match?: string;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -389,7 +389,7 @@ export function warn(message: string) {
   write(bold(yellow(`${symbols['warning']} ${message}`)));
 }
 
-export function removeTrailingSlash(url: string) {
+export function removeTrailingSlash(url = '') {
   return url.replace(/\/+$/, '');
 }
 

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -241,6 +241,7 @@ export function buildMonitorFromYaml(
     ...config,
     privateLocations,
     schedule: schedule || options.schedule,
+    params: options.params,
     alert: alertConfig,
   });
 }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -32,6 +32,7 @@ import { SYNTHETICS_PATH, totalist, indent, warn, isMatch } from '../helpers';
 import { LocationsMap } from '../locations/public-locations';
 import { ALLOWED_SCHEDULES, Monitor, MonitorConfig } from '../dsl/monitor';
 import { PushOptions } from '../common_types';
+import { isParamOptionSupported } from './utils';
 
 // Allowed extensions for lightweight monitor files
 const ALLOWED_LW_EXTENSIONS = ['.yml', '.yaml'];
@@ -235,15 +236,22 @@ export function buildMonitorFromYaml(
   delete config['private_locations'];
 
   const alertConfig = parseAlertConfig(config);
-
-  return new Monitor({
+  const mon = new Monitor({
     locations: options.locations,
     ...config,
     privateLocations,
     schedule: schedule || options.schedule,
-    params: options.params,
     alert: alertConfig,
   });
+
+  /**
+   * Params support is only available for lighweight monitors
+   * post 8.7.2 stack
+   */
+  if (isParamOptionSupported(options.kibanaVersion)) {
+    mon.config.params = options.params;
+  }
+  return mon;
 }
 
 export const parseAlertConfig = (config: MonitorConfig) => {

--- a/src/push/utils.ts
+++ b/src/push/utils.ts
@@ -23,9 +23,11 @@
  *
  */
 
+import semver from 'semver';
 import { progress, removeTrailingSlash } from '../helpers';
 import { green, red, grey, yellow } from 'kleur/colors';
 import { PushOptions } from '../common_types';
+import { Monitor } from '../dsl/monitor';
 
 export function logDiff<T extends Set<string>>(
   newIDs: T,
@@ -74,4 +76,33 @@ export function generateURL(options: PushOptions, operation: Operation) {
     default:
       throw new Error('Invalid operation');
   }
+}
+
+/**
+ * Bulk API is supported for push monitors only from 8.6.0 and above
+ */
+export function isBulkAPISupported(version: number) {
+  return semver.satisfies(version, '>=8.6.0');
+}
+
+/**
+ * Lightweight monitors are supported only from 8.5.0 and above
+ */
+export function isLightweightMonitorSupported(
+  monitors: Monitor[],
+  options: PushOptions
+) {
+  const version = options.kibanaVersion;
+  return (
+    semver.satisfies(version, '<8.5.0') &&
+    monitors.some(monitor => monitor.type !== 'browser')
+  );
+}
+
+/**
+ * Lighweight monitor param options are supported only from
+ * 8.7.2 and above
+ */
+export function isParamOptionSupported(version: number) {
+  return semver.satisfies(version, '>=8.7.2');
 }


### PR DESCRIPTION
+ fix #725 
+ Add support for pushing params for Lightweight monitors when used in
    - Synthetics config file 
    - CLI flags `--params {"foo": "bar"}`
 + Added a backwards compatibility check to drop `params` config if the push is performed on stack `<8.7.2`. 
+ Check the changes with Kibana PR - https://github.com/elastic/kibana/pull/157226