### PR TITLE
feat: support pattern, match, tags for pushing lightweight

### DIFF
--- a/__tests__/helper.test.ts
+++ b/__tests__/helper.test.ts
@@ -34,6 +34,7 @@ import {
   findPWLogsIndexes,
   microSecsToSeconds,
   wrapFnWithLocation,
+  isMatch,
 } from '../src/helpers';
 
 it('indent message with seperator', () => {
@@ -71,7 +72,7 @@ describe('formatting errors', () => {
 
   ["c'est ne pas une Error", 42, { an: 'object' }].forEach(obj => {
     it(`formats thrown non-error errors like: ${obj}(${typeof obj})`, () => {
-      const formatted = formatError(obj);
+      const formatted = formatError(obj) as Error;
       expect(formatted.message).toContain(`${obj}`);
       expect(formatted.name).toStrictEqual('');
       expect(formatted.stack).toStrictEqual('');
@@ -160,4 +161,18 @@ it('location info on execution', () => {
   // line no and column no will not match as we are using
   // ts-jest preset to transpile code.
   expect(checkLoc().file).toBe(__filename);
+});
+
+it('match tags and names', () => {
+  // match tags
+  expect(isMatch(['foo', 'bar'], 'test', ['foo*'])).toBe(true);
+  expect(isMatch(['bar', 'baz'], 'test', ['b*'])).toBe(true);
+  expect(isMatch(['bar', 'baz'], 'test', ['c*'])).toBe(false);
+  // prefer tags over names
+  expect(isMatch(['bar', 'baz'], 'foo', ['c*'], 'foo')).toBe(false);
+  // match names when no tags
+  expect(isMatch(['bar'], 'foo', undefined, 'fo*')).toBe(true);
+  // match both name and tags
+  expect(isMatch(['bar'], 'foo', undefined, 'ba*')).toBe(true);
+  expect(isMatch(['bar'], 'foo', undefined, 'test*')).toBe(false);
 });

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -207,7 +207,7 @@ heartbeat.monitors:
       );
     });
 
-    it('match file pattern', async () => {
+    it('prefer user provider pattern option', async () => {
       await writeHBFile(`
 heartbeat.monitors:
 - type: http

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -35,6 +35,7 @@ import {
 } from '../../src/push/monitor';
 import { Server } from '../utils/server';
 import { createTestMonitor } from '../utils/test-config';
+import { PushOptions } from '../../src/common_types';
 
 describe('Monitors', () => {
   let server: Server;
@@ -144,7 +145,7 @@ describe('Monitors', () => {
   describe('Lightweight monitors', () => {
     const PROJECT_DIR = generateTempPath();
     const HB_SOURCE = join(PROJECT_DIR, 'heartbeat.yml');
-    const opts = { auth: 'foo' };
+    const opts: PushOptions = { auth: 'foo' };
     beforeEach(async () => {
       await mkdir(PROJECT_DIR, { recursive: true });
     });
@@ -204,6 +205,19 @@ heartbeat.monitors:
       expect(createLightweightMonitors(PROJECT_DIR, opts)).rejects.toContain(
         `Aborted: Monitor name is required`
       );
+    });
+
+    it('match file pattern', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: http
+  schedule: "@every 1m"
+  id: "foo"
+  name: "foo"
+      `);
+      opts.pattern = '.yaml$';
+      const monitors = await createLightweightMonitors(PROJECT_DIR, opts);
+      expect(monitors.length).toBe(0);
     });
 
     it('skip browser monitors', async () => {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -245,6 +245,9 @@ export type PushOptions = Partial<ProjectSettings> & {
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
   yes?: boolean;
+  pattern?: string;
+  match?: string;
+  tags?: Array<string>;
 };
 
 export type ProjectSettings = {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -397,10 +397,9 @@ export default class Runner {
       playwrightOptions: options.playwrightOptions,
     });
 
-    const { match, tags } = options;
     const monitors: Monitor[] = [];
     for (const journey of this.journeys) {
-      if (!journey.isMatch(match, tags)) {
+      if (!journey.isMatch(options.match, options.tags)) {
         continue;
       }
       this.#currentJourney = journey;

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -30,10 +30,10 @@ import {
   CDPSession,
   APIRequestContext,
 } from 'playwright-chromium';
-import micromatch, { isMatch } from 'micromatch';
 import { Step } from './step';
 import { VoidCallback, HooksCallback, Params, Location } from '../common_types';
 import { Monitor, MonitorConfig } from './monitor';
+import { isMatch } from '../helpers';
 
 export type JourneyOptions = {
   name: string;
@@ -103,21 +103,8 @@ export class Journey {
 
   /**
    * Matches journeys based on the provided args. Proitize tags over match
-   * - tags pattern that matches only tags
-   * - match pattern that matches both name and tags
    */
   isMatch(matchPattern: string, tagsPattern: Array<string>) {
-    if (tagsPattern) {
-      return this.tagsMatch(tagsPattern);
-    }
-    if (matchPattern) {
-      return isMatch(this.name, matchPattern) || this.tagsMatch(matchPattern);
-    }
-    return true;
-  }
-
-  tagsMatch(pattern) {
-    const matchess = micromatch(this.tags || ['*'], pattern);
-    return matchess.length > 0;
+    return isMatch(this.tags, this.name, tagsPattern, matchPattern);
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,6 +37,7 @@ import {
   Location,
   ThrottlingOptions,
 } from './common_types';
+import micromatch from 'micromatch';
 
 const SEPARATOR = '\n';
 
@@ -394,4 +395,31 @@ export function removeTrailingSlash(url: string) {
 
 export function getMonitorManagementURL(url) {
   return removeTrailingSlash(url) + '/app/uptime/manage-monitors/all';
+}
+
+/**
+ * Matches tests based on the provided args. Proitize tags over match
+ * - tags pattern that matches only tags
+ * - match pattern that matches both name and tags
+ */
+export function isMatch(
+  tags: Array<string>,
+  name: string,
+  tagsPattern?: Array<string>,
+  matchPattern?: string
+) {
+  if (tagsPattern) {
+    return tagsMatch(tags, tagsPattern);
+  }
+  if (matchPattern) {
+    return (
+      micromatch.isMatch(name, matchPattern) || tagsMatch(tags, matchPattern)
+    );
+  }
+  return true;
+}
+
+export function tagsMatch(tags, pattern) {
+  const matchess = micromatch(tags || ['*'], pattern);
+  return matchess.length > 0;
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -24,7 +24,7 @@
  */
 
 import { stdin, cwd } from 'process';
-import { resolve } from 'path';
+import { extname, resolve } from 'path';
 import { CliArgs } from './common_types';
 import { step, journey } from './core';
 import { log } from './core/logger';
@@ -38,6 +38,7 @@ import {
 import { installTransform } from './core/transform';
 
 const resolvedCwd = cwd();
+const JOURNEY_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs'];
 
 /**
  * Perform global setup process required for running the test suites
@@ -131,6 +132,9 @@ function requireSuites(suites: Iterable<string>) {
 async function prepareSuites(inputs: string[], filePattern?: string) {
   const suites = new Set<string>();
   const addSuite = absPath => {
+    if (!JOURNEY_EXTENSIONS.includes(extname(absPath))) {
+      return;
+    }
     log(`Processing file: ${absPath}`);
     suites.add(require.resolve(absPath));
   };

--- a/src/options.ts
+++ b/src/options.ts
@@ -154,15 +154,15 @@ export function getCommonCommandOpts() {
 
   const pattern = createOption(
     '--pattern <pattern>',
-    'RegExp pattern to look for journey files that are different from the default (ex: /*.journey.(ts|js)$/)'
+    'RegExp pattern to match journey/monitor files that are different from the default (ex: /*.journey.(ts|js)$/)'
   );
   const tags = createOption(
     '--tags <name...>',
-    'run only journeys with a tag that matches the glob'
+    'run/push tests with a tag that matches the glob'
   );
   const match = createOption(
     '--match <name>',
-    'run only journeys with a name or tag that matches the glob'
+    'run/push tests with a name or tags that matches the glob'
   );
 
   return {


### PR DESCRIPTION
+ fix #754 
+ PR adds support for `--pattern, --tags, --match` which will be applied while pushing lighweight monitors as well. 
+ Added guards to catch errors that might arise when trying to apply transforms to Lightweight monitor files (.yml). 