### PR TITLE
chore: prepare for 1.0 stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - run: npm ci # runs npm prepublish
-      - name: Bump the beta version
+      - name: Bump the version
         run: |
-          echo "VERSION=$(npm version prerelease --preid=beta)" >> $GITHUB_ENV
+          echo "VERSION=$(npm version)" >> $GITHUB_ENV
           echo "NPM_PACKAGE=$(jq '.name' package.json) >> $GITHUB_ENV
       - run: git push --tags
       - uses: ./.github/actions/setup-totp
@@ -38,7 +38,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: NPM Publish
-        run: npm publish --otp=${TOTP_CODE} --tag beta
+        run: npm publish --otp=${TOTP_CODE}
       - name: Create 'latest' dist-tag
         run: npm dist-tag --otp=${TOTP_CODE} add "${NPM_PACKAGE}@${VERSION}" latest
       - name: Create 'stack_release' dist-tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,6 @@ We run end to end tests for the Synthetics agent itself, as well as the Elastic 
 
 ### Releasing
 
-**NOTE: This project is currently in Beta phase**
-
 #### CI based
 
 The release process is also automated in the way any specific commit from the main branch can be potentially released, for such it's required the below steps:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 [![ci](https://github.com/elastic/synthetics/actions/workflows/ci.yml/badge.svg)](https://github.com/elastic/synthetics/actions/workflows/ci.yml)
 [![e2e](https://github.com/elastic/synthetics/actions/workflows/e2e.yml/badge.svg)](https://github.com/elastic/synthetics/actions/workflows/e2e.yml)
 
-# Experimental Synthetics Agent
+# Synthetics Agent
 
 Synthetic Monitoring with Real Browsers.
-**Please note this is project is in beta status. Expect things to break and change!**
 
 ## Usage
 


### PR DESCRIPTION
+ Remove beta and other experimental labels from the repo. 
+ Release script is not correct still, have to use separate tool like `semantic-release` or similar to read it based on our PR commits. 