### PR TITLE
[Chore] Export `FrameDescription` from JavaScript formatter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ export type { SyntheticsConfig } from './common_types';
 export type {
   Action,
   ActionInContext,
+  FrameDescription,
   Signal,
   Step,
   Steps,


### PR DESCRIPTION
Right now this type lives in both the Recorder and Synthetics. We want to delete it from the recorder, and to reference it here.

Doing a top-level export will simplify the import path, as right now the Recorder has to:

```typescript
import { FramDescription } from '@elastic/synthetics/src/formatter/javascript';
```