### PR TITLE
fix: replace uptime urls with the ones from synthetics app

### DIFF
--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -29,11 +29,7 @@ import { bold, cyan, yellow } from 'kleur/colors';
 import { join, relative, dirname, basename } from 'path';
 // @ts-ignore-next-line: has no exported member 'Input'
 import { prompt, Input } from 'enquirer';
-import {
-  getMonitorManagementURL,
-  progress,
-  write as stdWrite,
-} from '../helpers';
+import { getProjectApiKeyURL, progress, write as stdWrite } from '../helpers';
 import {
   getPackageManager,
   replaceTemplates,
@@ -109,7 +105,7 @@ export class Generator {
     const auth = await new Input({
       name: 'auth',
       header: yellow(
-        `Generate API key from Kibana ${getMonitorManagementURL(url)}`
+        `Generate API key from Kibana ${getProjectApiKeyURL(url)}`
       ),
       required: true,
       message: 'What is your API key',

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -393,8 +393,12 @@ export function removeTrailingSlash(url = '') {
   return url.replace(/\/+$/, '');
 }
 
-export function getMonitorManagementURL(url) {
-  return removeTrailingSlash(url) + '/app/uptime/manage-monitors/all';
+export function getMonitorManagementURL(url: string) {
+  return removeTrailingSlash(url) + '/app/synthetics/monitors';
+}
+
+export function getProjectApiKeyURL(url: string) {
+  return removeTrailingSlash(url) + '/app/synthetics/settings/api-keys';
 }
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/elastic/synthetics/issues/769

# Summary

We replace uptime URLs with the ones from the synthetics app since the ones from uptime will not be available in 8.8.0


**Screenshot with new URL for generating an API key:**

<img width="631" alt="Screenshot 2023-05-16 at 19 43 41" src="https://github.com/elastic/synthetics/assets/15065076/433df41d-3eaf-4893-9039-92ac118d6b44">

**Screenshot with new URL to see pushed monitors in Kibana:**

<img width="516" alt="Screenshot 2023-05-16 at 19 45 41" src="https://github.com/elastic/synthetics/assets/15065076/ed1742a8-0cce-417a-9337-f2c84ba7c819">
