### PR TITLE
fix: use screenshots from synthetics.config file

### DIFF
--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -34,6 +34,12 @@ module.exports = env => {
     playwrightOptions: {
       ...devices['Galaxy S9+'],
     },
+    monitor: {
+      screenshot: 'off',
+      schedule: 10,
+      locations: ['us_east'],
+      privateLocations: ['test-location'],
+    },
   };
   if (env !== 'development' && config.params) {
     config.params.url = 'non-dev';

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -43,9 +43,11 @@ describe('options', () => {
       pauseOnError: true,
       config: join(__dirname, 'fixtures', 'synthetics.config.ts'),
     };
+    console.log('normalizeOptions({})', normalizeOptions({}));
     expect(normalizeOptions({})).toMatchObject({
       environment: 'test',
       params: {},
+      screenshots: 'on',
     });
     expect(normalizeOptions(cliArgs)).toMatchObject({
       dryRun: true,
@@ -76,13 +78,27 @@ describe('options', () => {
   });
 
   it('normalize monitor configs', () => {
+    const config = join(__dirname, 'fixtures', 'synthetics.config.ts');
+    expect(normalizeOptions({ config }, 'push')).toMatchObject({
+      screenshots: 'off',
+      schedule: 10,
+      privateLocations: ['test-location'],
+      locations: ['us_east'],
+    });
+
     expect(
-      normalizeOptions({
-        schedule: 3,
-        privateLocations: ['test'],
-        locations: ['australia_east'],
-      })
+      normalizeOptions(
+        {
+          config,
+          schedule: 3,
+          screenshots: 'only-on-failure',
+          locations: ['australia_east'],
+          privateLocations: ['test'],
+        },
+        'push'
+      )
     ).toMatchObject({
+      screenshots: 'only-on-failure',
       schedule: 3,
       privateLocations: ['test'],
       locations: ['australia_east'],

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -43,7 +43,6 @@ describe('options', () => {
       pauseOnError: true,
       config: join(__dirname, 'fixtures', 'synthetics.config.ts'),
     };
-    console.log('normalizeOptions({})', normalizeOptions({}));
     expect(normalizeOptions({})).toMatchObject({
       environment: 'test',
       params: {},

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -88,9 +88,10 @@ program
     'Enable capabilities through feature flags'
   )
   .addOption(
-    new Option('--screenshots [flag]', 'take screenshots at end of each step')
-      .choices(['on', 'off', 'only-on-failure'])
-      .default('on')
+    new Option(
+      '--screenshots [flag]',
+      'take screenshots at end of each step'
+    ).choices(['on', 'off', 'only-on-failure'])
   )
   .option(
     '--dry-run',
@@ -133,7 +134,7 @@ program
   .action(async (cliArgs: CliArgs) => {
     const tearDown = await globalSetup(cliArgs, program.args);
     try {
-      const options = normalizeOptions(cliArgs);
+      const options = normalizeOptions(cliArgs, 'run');
       const results = await run(options);
       /**
        * Exit with error status if any journey fails
@@ -204,11 +205,14 @@ program
     ]);
     try {
       const settings = await loadSettings();
-      const options = normalizeOptions({
-        ...program.opts(),
-        ...settings,
-        ...cmdOpts,
-      }) as PushOptions;
+      const options = normalizeOptions(
+        {
+          ...program.opts(),
+          ...settings,
+          ...cmdOpts,
+        },
+        'push'
+      ) as PushOptions;
       validateSettings(options);
       await catchIncorrectSettings(settings, options);
       const monitors = runner.buildMonitors(options);

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -206,7 +206,6 @@ type BaseArgs = {
   outfd?: number;
   wsEndpoint?: string;
   pauseOnError?: boolean;
-  ignoreHttpsErrors?: boolean;
   playwrightOptions?: PlaywrightOptions;
   quietExitCode?: boolean;
   throttling?: MonitorConfig['throttling'];
@@ -234,7 +233,6 @@ export type RunOptions = BaseArgs & {
   trace?: boolean;
   filmstrips?: boolean;
   environment?: string;
-  playwrightOptions?: PlaywrightOptions;
   networkConditions?: NetworkConditions;
   reporter?: BuiltInReporterName | ReporterInstance;
 };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -395,6 +395,7 @@ export default class Runner {
       privateLocations: options.privateLocations,
       params: options.params,
       playwrightOptions: options.playwrightOptions,
+      screenshot: options.screenshots,
     });
 
     const monitors: Monitor[] = [];


### PR DESCRIPTION
+ Fixes the issue when applying the screenshot config from `monitor` field in the global `synthetics.config.ts` to all pushed monitors.
+ Added a new mode which merges all the relevant monitor config from the monitor key only during the push command instead of performing extra work during the local runner mode. 
+ `screenshot` is defaulted to `on` only when the tests are executed locally to keep the backwards compatibility as before. But during the push command, we prefer the `--screenshot` flag when its configured and use the `synthetics.config.ts`. Everything can be overriden by `monitor.use` API as before. 

Slack - https://elastic.slack.com/archives/CE4MRBU48/p1686321341637449