### PR TITLE
feat: support tls alert key for project monitors

### DIFF
--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -39,6 +39,14 @@ module.exports = env => {
       schedule: 10,
       locations: ['us_east'],
       privateLocations: ['test-location'],
+      alert: {
+        status: {
+          enabled: true,
+        },
+        tls: {
+          enabled: false,
+        },
+      },
     },
   };
   if (env !== 'development' && config.params) {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -85,10 +85,10 @@ describe('options', () => {
       locations: ['us_east'],
       alert: {
         status: {
-          enabled: false,
+          enabled: true,
         },
         tls: {
-          enabled: true,
+          enabled: false,
         },
       },
     });
@@ -111,10 +111,10 @@ describe('options', () => {
       locations: ['australia_east'],
       alert: {
         status: {
-          enabled: false,
+          enabled: true,
         },
         tls: {
-          enabled: true,
+          enabled: false,
         },
       },
     });

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -83,6 +83,14 @@ describe('options', () => {
       schedule: 10,
       privateLocations: ['test-location'],
       locations: ['us_east'],
+      alert: {
+        status: {
+          enabled: false,
+        },
+        tls: {
+          enabled: true,
+        },
+      },
     });
 
     expect(
@@ -101,6 +109,14 @@ describe('options', () => {
       schedule: 3,
       privateLocations: ['test'],
       locations: ['australia_east'],
+      alert: {
+        status: {
+          enabled: false,
+        },
+        tls: {
+          enabled: true,
+        },
+      },
     });
   });
 });

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -140,6 +140,21 @@ describe('Monitors', () => {
     expect(parseAlertConfig({ alert: { status: { enabled: true } } })).toEqual({
       status: { enabled: true },
     });
+
+    expect(
+      parseAlertConfig(
+        { alert: { status: { enabled: true } } },
+        {
+          status: { enabled: false },
+          tls: { enabled: true },
+        }
+      )
+    ).toEqual({
+      status: { enabled: true },
+      tls: {
+        enabled: true,
+      },
+    });
   });
 
   it('parse tls alert config option', async () => {
@@ -156,8 +171,16 @@ describe('Monitors', () => {
     expect(parseAlertConfig({ 'alert.tls.enabled': true } as any)).toEqual({
       tls: { enabled: true },
     });
-    expect(parseAlertConfig({ alert: { tls: { enabled: true } } })).toEqual({
+    expect(
+      parseAlertConfig(
+        { alert: { tls: { enabled: true } } },
+        {
+          status: { enabled: false },
+        }
+      )
+    ).toEqual({
       tls: { enabled: true },
+      status: { enabled: false },
     });
   });
 

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -142,6 +142,25 @@ describe('Monitors', () => {
     });
   });
 
+  it('parse tls alert config option', async () => {
+    expect(parseAlertConfig({})).toBe(undefined);
+    expect(
+      parseAlertConfig({
+        'alert.status.enabled': true,
+        'alert.tls.enabled': true,
+      } as any)
+    ).toEqual({
+      status: { enabled: true },
+      tls: { enabled: true },
+    });
+    expect(parseAlertConfig({ 'alert.tls.enabled': true } as any)).toEqual({
+      tls: { enabled: true },
+    });
+    expect(parseAlertConfig({ alert: { tls: { enabled: true } } })).toEqual({
+      tls: { enabled: true },
+    });
+  });
+
   describe('Lightweight monitors', () => {
     const PROJECT_DIR = generateTempPath();
     const HB_SOURCE = join(PROJECT_DIR, 'heartbeat.yml');

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -34,7 +34,7 @@ import {
 } from 'playwright-chromium';
 import { Step } from './dsl';
 import { BuiltInReporterName, ReporterInstance } from './reporters';
-import { MonitorConfig } from './dsl/monitor';
+import { AlertConfig, MonitorConfig } from './dsl/monitor';
 
 export type VoidCallback = () => void;
 export type Location = {
@@ -212,6 +212,7 @@ type BaseArgs = {
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
+  alert?: AlertConfig;
 };
 
 export type CliArgs = BaseArgs & {
@@ -248,6 +249,7 @@ export type PushOptions = Partial<ProjectSettings> & {
   pattern?: string;
   match?: string;
   tags?: Array<string>;
+  alert?: AlertConfig;
 };
 
 export type ProjectSettings = {

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -63,7 +63,10 @@ export type MonitorConfig = {
   params?: Params;
   playwrightOptions?: PlaywrightOptions;
   alert?: {
-    status: {
+    status?: {
+      enabled: boolean;
+    };
+    tls?: {
       enabled: boolean;
     };
   };

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -44,6 +44,15 @@ export const ALLOWED_SCHEDULES = [
   1, 3, 5, 10, 15, 20, 30, 60, 120, 240,
 ] as const;
 
+export interface AlertConfig {
+  status?: {
+    enabled: boolean;
+  };
+  tls?: {
+    enabled: boolean;
+  };
+}
+
 export type MonitorConfig = {
   id?: string;
   name?: string;
@@ -62,14 +71,7 @@ export type MonitorConfig = {
   screenshot?: ScreenshotOptions;
   params?: Params;
   playwrightOptions?: PlaywrightOptions;
-  alert?: {
-    status?: {
-      enabled: boolean;
-    };
-    tls?: {
-      enabled: boolean;
-    };
-  };
+  alert?: AlertConfig;
 };
 
 type MonitorFilter = {

--- a/src/options.ts
+++ b/src/options.ts
@@ -130,9 +130,9 @@ export function normalizeOptions(
       options.locations = options.locations ?? monitor?.locations;
       options.privateLocations =
         options.privateLocations ?? monitor?.privateLocations;
+      options.alert = options.alert ?? monitor?.alert;
       break;
   }
-
   return options;
 }
 

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -255,14 +255,23 @@ export function buildMonitorFromYaml(
 }
 
 export const parseAlertConfig = (config: MonitorConfig) => {
+  const alertConfig = {};
   if (config['alert.status.enabled'] !== undefined) {
     const value = config['alert.status.enabled'];
     delete config['alert.status.enabled'];
-    return {
-      status: {
-        enabled: value,
-      },
+    alertConfig['status'] = {
+      enabled: value,
     };
+  }
+  if (config['alert.tls.enabled'] !== undefined) {
+    const value = config['alert.tls.enabled'];
+    delete config['alert.tls.enabled'];
+    alertConfig['tls'] = {
+      enabled: value,
+    };
+  }
+  if (Object.keys(alertConfig).length > 0) {
+    return alertConfig;
   }
   return config.alert;
 };

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -239,7 +239,6 @@ export function buildMonitorFromYaml(
   const privateLocations =
     config['private_locations'] || options.privateLocations;
   delete config['private_locations'];
-  console.log(options);
   const alertConfig = parseAlertConfig(config, options.alert);
   const mon = new Monitor({
     locations: options.locations,

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -262,7 +262,8 @@ export const parseAlertConfig = (
   config: MonitorConfig,
   globalAlertConfig?: AlertConfig
 ) => {
-  const alertConfig = {};
+  const alertConfig: AlertConfig = {};
+
   if (config['alert.status.enabled'] !== undefined) {
     const value = config['alert.status.enabled'];
     delete config['alert.status.enabled'];
@@ -277,12 +278,21 @@ export const parseAlertConfig = (
       enabled: value,
     };
   }
+  if (config?.alert?.status?.enabled !== undefined) {
+    alertConfig.status = {
+      enabled: config.alert.status.enabled,
+    };
+  }
+  if (config?.alert?.tls?.enabled !== undefined) {
+    alertConfig.tls = {
+      enabled: config.alert.tls.enabled,
+    };
+  }
 
   // If the user has provided a global alert config, merge it with the monitor alert config
   const result = {
     ...(globalAlertConfig ?? {}),
     ...alertConfig,
-    ...config.alert,
   };
   return Object.keys(result).length > 0 ? result : undefined;
 };

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -279,10 +279,12 @@ export const parseAlertConfig = (
   }
 
   // If the user has provided a global alert config, merge it with the monitor alert config
-  return {
+  const result = {
     ...(globalAlertConfig ?? {}),
     ...alertConfig,
+    ...config.alert,
   };
+  return Object.keys(result).length > 0 ? result : undefined;
 };
 
 export function parseSchedule(schedule: string) {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -277,17 +277,12 @@ export const parseAlertConfig = (
       enabled: value,
     };
   }
-  const monitorAlertConfig =
-    Object.keys(alertConfig).length > 0 ? alertConfig : config.alert;
 
   // If the user has provided a global alert config, merge it with the monitor alert config
-  if (globalAlertConfig) {
-    return {
-      ...globalAlertConfig,
-      ...monitorAlertConfig,
-    };
-  }
-  return monitorAlertConfig;
+  return {
+    ...(globalAlertConfig ?? {}),
+    ...alertConfig,
+  };
 };
 
 export function parseSchedule(schedule: string) {


### PR DESCRIPTION
Support tls alert key

```
heartbeat.monitors:
- type: http
  name: Todos Lightweight
  id: todos-lightweight
  enabled: true
  urls: "https://elastic.github.io/synthetics-demo/"
  schedule: '@every 3m'
  timeout: 16s
  alert.status.enabled: true
  alert.tls.enabled: true
```
