### PR TITLE
fix: handle nested alert keys

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -132,58 +132,6 @@ describe('Monitors', () => {
     expect(parseSchedule('@every 1d')).toBe(240);
   });
 
-  it('parse alert config option', async () => {
-    expect(parseAlertConfig({})).toBe(undefined);
-    expect(parseAlertConfig({ 'alert.status.enabled': true } as any)).toEqual({
-      status: { enabled: true },
-    });
-    expect(parseAlertConfig({ alert: { status: { enabled: true } } })).toEqual({
-      status: { enabled: true },
-    });
-
-    expect(
-      parseAlertConfig(
-        { alert: { status: { enabled: true } } },
-        {
-          status: { enabled: false },
-          tls: { enabled: true },
-        }
-      )
-    ).toEqual({
-      status: { enabled: true },
-      tls: {
-        enabled: true,
-      },
-    });
-  });
-
-  it('parse tls alert config option', async () => {
-    expect(parseAlertConfig({})).toBe(undefined);
-    expect(
-      parseAlertConfig({
-        'alert.status.enabled': true,
-        'alert.tls.enabled': true,
-      } as any)
-    ).toEqual({
-      status: { enabled: true },
-      tls: { enabled: true },
-    });
-    expect(parseAlertConfig({ 'alert.tls.enabled': true } as any)).toEqual({
-      tls: { enabled: true },
-    });
-    expect(
-      parseAlertConfig(
-        { alert: { tls: { enabled: true } } },
-        {
-          status: { enabled: false },
-        }
-      )
-    ).toEqual({
-      tls: { enabled: true },
-      status: { enabled: false },
-    });
-  });
-
   describe('Lightweight monitors', () => {
     const PROJECT_DIR = generateTempPath();
     const HB_SOURCE = join(PROJECT_DIR, 'heartbeat.yml');
@@ -403,6 +351,80 @@ heartbeat.monitors:
         ssl: {
           certificate_authorities: ['/etc/ca.crt'],
         },
+      });
+    });
+  });
+
+  describe('parseAlertConfig', () => {
+    it('parse alert config option', async () => {
+      expect(parseAlertConfig({})).toBe(undefined);
+      expect(parseAlertConfig({ 'alert.status.enabled': true } as any)).toEqual(
+        {
+          status: { enabled: true },
+        }
+      );
+      expect(
+        parseAlertConfig({ alert: { status: { enabled: true } } })
+      ).toEqual({
+        status: { enabled: true },
+      });
+    });
+
+    it('parse alert config option when global config is also provided', async () => {
+      expect(
+        parseAlertConfig(
+          { alert: { 'status.enabled': false, 'tls.enabled': true } } as any,
+          {
+            status: { enabled: false },
+            tls: { enabled: false },
+          }
+        )
+      ).toEqual({
+        status: { enabled: false },
+        tls: {
+          enabled: true,
+        },
+      });
+      expect(
+        parseAlertConfig(
+          { alert: { status: { enabled: true } } },
+          {
+            status: { enabled: false },
+            tls: { enabled: true },
+          }
+        )
+      ).toEqual({
+        status: { enabled: true },
+        tls: {
+          enabled: true,
+        },
+      });
+    });
+
+    it('parse tls alert config option', async () => {
+      expect(parseAlertConfig({})).toBe(undefined);
+      expect(
+        parseAlertConfig({
+          'alert.status.enabled': true,
+          'alert.tls.enabled': true,
+        } as any)
+      ).toEqual({
+        status: { enabled: true },
+        tls: { enabled: true },
+      });
+      expect(parseAlertConfig({ 'alert.tls.enabled': true } as any)).toEqual({
+        tls: { enabled: true },
+      });
+      expect(
+        parseAlertConfig(
+          { alert: { tls: { enabled: true } } },
+          {
+            status: { enabled: false },
+          }
+        )
+      ).toEqual({
+        tls: { enabled: true },
+        status: { enabled: false },
       });
     });
   });

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -427,5 +427,29 @@ heartbeat.monitors:
         status: { enabled: false },
       });
     });
+
+    it('deletes parsed keys from config', async () => {
+      let config: any = {
+        'alert.status.enabled': true,
+        'alert.tls.enabled': true,
+      };
+      expect(parseAlertConfig(config)).toEqual({
+        status: { enabled: true },
+        tls: { enabled: true },
+      });
+      expect(config).toEqual({});
+
+      config = {
+        alert: {
+          'status.enabled': true,
+          'tls.enabled': true,
+        },
+      };
+      expect(parseAlertConfig(config)).toEqual({
+        status: { enabled: true },
+        tls: { enabled: true },
+      });
+      expect(config).toEqual({});
+    });
   });
 });

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -180,7 +180,6 @@ export async function createLightweightMonitors(
     const parsedDoc = parseDocument(content, {
       lineCounter,
       keepSourceTokens: true,
-      merge: true,
     });
     // Skip other yml files that are not relevant
     const monitorSeq = parsedDoc.get('heartbeat.monitors') as YAMLSeq<YAMLMap>;

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -288,8 +288,13 @@ export function getAlertKeyValue(
   }
 
   if (value?.[`${key}.enabled`] !== undefined) {
+    const val = value?.[`${key}.enabled`];
+    delete value?.[`${key}.enabled`];
+    if (Object.keys(value).length === 0) {
+      delete config.alert;
+    }
     return {
-      enabled: value[`${key}.enabled`],
+      enabled: val,
     };
   }
   const rootKey = `alert.${key}.enabled`;


### PR DESCRIPTION
Handle alert config in following format as well

```
heartbeat.monitors:
- type: http
  name: Todos Lightweight
  id: todos-lightweight
  enabled: true
  urls: "${devUrl}"
  schedule: '@every 3m'
  timeout: 16s
  alert:
    status.enabled: false
    tls.enabled: false
```

Edit: 

Continuation of https://github.com/elastic/synthetics/pull/785 which is related to [elastic/kibana#159697](https://github.com/elastic/kibana/pull/159697)