### PR TITLE
fix: remove match/tags from push command

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -707,106 +707,90 @@ describe('runner', () => {
     expect(collectOrder).toEqual(realEventsOrder);
   });
 
-  it('runner - build monitors with local config', async () => {
-    const j1 = new Journey({ name: 'j1' }, noop);
-    const j2 = new Journey({ name: 'j2' }, noop);
-    j1.updateMonitor({
-      id: 'test-j1',
-      schedule: 3,
-      locations: ['united_kingdom'],
-    });
-    j2.updateMonitor({ throttling: { latency: 1000 }, schedule: 1 });
-    runner.addJourney(j1);
-    runner.addJourney(j2);
+  describe('build monitors', () => {
+    const options = { auth: 'foo', throttling: DEFAULT_THROTTLING_OPTIONS };
+    it('runner - build monitors with local config', async () => {
+      const j1 = new Journey({ name: 'j1', tags: ['j1', 'j2'] }, noop);
+      const j2 = new Journey({ name: 'j2' }, noop);
+      j1.updateMonitor({
+        id: 'test-j1',
+        schedule: 3,
+        tags: ['l1', 'l2'],
+        locations: ['united_kingdom'],
+      });
+      j2.updateMonitor({
+        throttling: { latency: 1000 },
+        schedule: 1,
+        alert: { status: { enabled: false } },
+      });
+      runner.addJourney(j1);
+      runner.addJourney(j2);
 
-    const monitors = runner.buildMonitors({
-      throttling: DEFAULT_THROTTLING_OPTIONS,
-    });
-    expect(monitors.length).toBe(2);
-    expect(monitors[0].config).toEqual({
-      id: 'test-j1',
-      name: 'j1',
-      type: 'browser',
-      tags: [],
-      locations: ['united_kingdom'],
-      privaateLocations: undefined,
-      schedule: 3,
-      params: undefined,
-      playwrightOptions: undefined,
-      throttling: { download: 5, latency: 20, upload: 3 },
-    });
-    expect(monitors[1].config).toMatchObject({
-      throttling: { latency: 1000 },
-    });
-  });
-
-  it('runner - build monitors with global config', async () => {
-    runner.updateMonitor({
-      schedule: 5,
-      locations: ['us_east'],
-      privateLocations: ['germany'],
-      throttling: { download: 100, upload: 50 },
-      params: { env: 'test' },
-      playwrightOptions: { ignoreHTTPSErrors: true },
+      const monitors = runner.buildMonitors(options);
+      expect(monitors.length).toBe(2);
+      expect(monitors[0].config).toEqual({
+        id: 'test-j1',
+        name: 'j1',
+        type: 'browser',
+        tags: ['l1', 'l2'],
+        locations: ['united_kingdom'],
+        schedule: 3,
+        throttling: { download: 5, latency: 20, upload: 3 },
+      });
+      expect(monitors[1].config).toMatchObject({
+        throttling: { latency: 1000 },
+        schedule: 1,
+        alert: { status: { enabled: false } },
+      });
     });
 
-    const j1 = new Journey({ name: 'j1', tags: ['foo*'] }, noop);
-    const j2 = new Journey({ name: 'j2' }, noop);
-    j1.updateMonitor({
-      id: 'test-j1',
-      schedule: 3,
-      locations: ['united_kingdom'],
-      privateLocations: ['spain'],
+    it('runner - build monitors with global config', async () => {
+      runner.updateMonitor({
+        schedule: 5,
+        locations: ['us_east'],
+        privateLocations: ['germany'],
+        throttling: { download: 100, upload: 50 },
+        params: { env: 'test' },
+        tags: ['g1', 'g2'],
+        alert: { tls: { enabled: true } },
+        playwrightOptions: { ignoreHTTPSErrors: true },
+      });
+
+      const j1 = new Journey({ name: 'j1', tags: ['foo*'] }, noop);
+      const j2 = new Journey({ name: 'j2' }, noop);
+      j1.updateMonitor({
+        id: 'test-j1',
+        schedule: 3,
+        locations: ['united_kingdom'],
+        privateLocations: ['spain'],
+      });
+      j2.updateMonitor({ throttling: { latency: 1000 } });
+      runner.addJourney(j1);
+      runner.addJourney(j2);
+
+      const monitors = runner.buildMonitors(options);
+      expect(monitors.length).toBe(2);
+      expect(monitors[0].config).toEqual({
+        id: 'test-j1',
+        name: 'j1',
+        type: 'browser',
+        tags: ['foo*'],
+        locations: ['united_kingdom'],
+        privateLocations: ['spain'],
+        schedule: 3,
+        params: { env: 'test' },
+        playwrightOptions: { ignoreHTTPSErrors: true },
+        throttling: { download: 100, latency: 20, upload: 50 },
+        alert: { tls: { enabled: true } },
+      });
+      expect(monitors[1].config).toMatchObject({
+        locations: ['us_east'],
+        privateLocations: ['germany'],
+        schedule: 5,
+        tags: ['g1', 'g2'],
+        throttling: { latency: 1000 },
+        alert: { tls: { enabled: true } },
+      });
     });
-    j2.updateMonitor({ throttling: { latency: 1000 } });
-    runner.addJourney(j1);
-    runner.addJourney(j2);
-
-    const monitors = runner.buildMonitors({
-      throttling: DEFAULT_THROTTLING_OPTIONS,
-    });
-    expect(monitors.length).toBe(2);
-    expect(monitors[0].config).toEqual({
-      id: 'test-j1',
-      name: 'j1',
-      type: 'browser',
-      tags: ['foo*'],
-      locations: ['united_kingdom'],
-      privateLocations: ['spain'],
-      schedule: 3,
-      params: { env: 'test' },
-      playwrightOptions: { ignoreHTTPSErrors: true },
-      throttling: { download: 100, latency: 20, upload: 50 },
-    });
-    expect(monitors[1].config).toMatchObject({
-      locations: ['us_east'],
-      privateLocations: ['germany'],
-      schedule: 5,
-      throttling: { latency: 1000 },
-    });
-  });
-
-  it('runner - build monitors filtered through "match"', async () => {
-    const j1 = new Journey({ name: 'j1' }, noop);
-    const j2 = new Journey({ name: 'j2' }, noop);
-    runner.addJourney(j1);
-    runner.addJourney(j2);
-
-    const monitors = runner.buildMonitors({ match: 'j1', schedule: 1 });
-    expect(monitors.length).toBe(1);
-    expect(monitors[0].config.name).toBe('j1');
-  });
-
-  it('runner - build monitors filtered through "tags"', async () => {
-    const j1 = new Journey({ name: 'j1', tags: ['first'] }, noop);
-    const j2 = new Journey({ name: 'j2', tags: ['second'] }, noop);
-    const j3 = new Journey({ name: 'j3' }, noop);
-    runner.addJourney(j1);
-    runner.addJourney(j2);
-    runner.addJourney(j3);
-
-    const monitors = runner.buildMonitors({ tags: ['first'], schedule: 1 });
-    expect(monitors.length).toBe(1);
-    expect(monitors[0].config.name).toBe('j1');
   });
 });

--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Push abort on tags and match 1`] = `
+"Aborted. Invalid CLI flags.
+
+Tags and Match are not supported in push command.
+"
+`;
+
 exports[`Push error on empty project id 1`] = `
 "Aborted. Invalid synthetics project settings.
 

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -119,6 +119,12 @@ describe('Push', () => {
     expect(output).toContain('Push command Aborted');
   });
 
+  it('abort on tags and match', async () => {
+    await fakeProjectSetup({}, {});
+    const output = await runPush([...DEFAULT_ARGS, '--tags', 'foo:*']);
+    expect(output).toMatchSnapshot();
+  });
+
   it('error on invalid schedule in monitor DSL', async () => {
     await fakeProjectSetup(
       { id: 'test-project', space: 'dummy', url: 'http://localhost:8080' },

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -328,13 +328,13 @@ heartbeat.monitors:
   name: "test-icmp"
       `);
 
-      const [monitor2] = await createLightweightMonitors(PROJECT_DIR, {
+      const [mon] = await createLightweightMonitors(PROJECT_DIR, {
         tags: ['gtag1', 'gtag2'],
         privateLocations: ['gbaz'],
         schedule: 10,
       } as PushOptions);
 
-      expect(monitor2.config).toEqual({
+      expect(mon.config).toEqual({
         id: 'test-icmp',
         name: 'test-icmp',
         privateLocations: ['gbaz'],

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -201,6 +201,7 @@ type BaseArgs = {
   params?: Params;
   screenshots?: ScreenshotOptions;
   dryRun?: boolean;
+  pattern?: string;
   match?: string;
   tags?: Array<string>;
   outfd?: number;
@@ -218,7 +219,6 @@ type BaseArgs = {
 export type CliArgs = BaseArgs & {
   config?: string;
   reporter?: BuiltInReporterName;
-  pattern?: string;
   inline?: boolean;
   require?: Array<string>;
   sandbox?: boolean;
@@ -238,18 +238,12 @@ export type RunOptions = BaseArgs & {
   reporter?: BuiltInReporterName | ReporterInstance;
 };
 
-export type PushOptions = Partial<ProjectSettings> & {
-  auth: string;
-  schedule?: MonitorConfig['schedule'];
-  locations?: MonitorConfig['locations'];
-  privateLocations?: MonitorConfig['privateLocations'];
-  params?: MonitorConfig['params'];
-  kibanaVersion?: number;
-  yes?: boolean;
-  pattern?: string;
-  tags?: Array<string>;
-  alert?: AlertConfig;
-};
+export type PushOptions = Partial<ProjectSettings> &
+  Partial<BaseArgs> & {
+    auth: string;
+    kibanaVersion?: number;
+    yes?: boolean;
+  };
 
 export type ProjectSettings = {
   id: string;
@@ -263,6 +257,7 @@ export type PlaywrightOptions = LaunchOptions &
     actionTimeout?: number;
     navigationTimeout?: number;
   };
+
 export type SyntheticsConfig = {
   params?: Params;
   playwrightOptions?: PlaywrightOptions;

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -247,7 +247,6 @@ export type PushOptions = Partial<ProjectSettings> & {
   kibanaVersion?: number;
   yes?: boolean;
   pattern?: string;
-  match?: string;
   tags?: Array<string>;
   alert?: AlertConfig;
 };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -44,6 +44,7 @@ import {
   RunOptions,
   JourneyResult,
   StepResult,
+  PushOptions,
 } from '../common_types';
 import { PluginManager } from '../plugins';
 import { PerformanceManager } from '../plugins';
@@ -383,7 +384,7 @@ export default class Runner {
     await mkdir(CACHE_PATH, { recursive: true });
   }
 
-  buildMonitors(options: RunOptions) {
+  buildMonitors(options: PushOptions) {
     /**
      * Update the global monitor configuration required for
      * setting defaults
@@ -396,13 +397,12 @@ export default class Runner {
       params: options.params,
       playwrightOptions: options.playwrightOptions,
       screenshot: options.screenshots,
+      tags: options.tags,
+      alert: options.alert,
     });
 
     const monitors: Monitor[] = [];
     for (const journey of this.journeys) {
-      if (!journey.isMatch(options.match, options.tags)) {
-        continue;
-      }
       this.#currentJourney = journey;
       /**
        * Execute dummy callback to get all monitor specific

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -91,7 +91,10 @@ export class Monitor {
   update(globalOpts: MonitorConfig = {}) {
     this.config = merge(globalOpts, this.config, {
       arrayMerge(target, source) {
-        return [...new Set(source)];
+        if (source && source.length > 0) {
+          return [...new Set(source)];
+        }
+        return target;
       },
     });
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -127,6 +127,11 @@ export function normalizeOptions(
        */
       const monitor = config.monitor;
       for (const key of Object.keys(monitor || {})) {
+        // TODO: screenshots require special handling as the flags are different
+        if (key === 'screenshot') {
+          options.screenshots = options.screenshots ?? monitor[key];
+          continue;
+        }
         options[key] = options[key] ?? monitor[key];
       }
       break;

--- a/src/options.ts
+++ b/src/options.ts
@@ -136,7 +136,9 @@ export function normalizeOptions(
 
 export function validatePushOptions(opts: PushOptions & { match?: string }) {
   if (opts.tags || opts.match) {
-    throw error('Aborted. Invalid flags: tags or match are not supported.');
+    throw error(`Aborted. Invalid CLI flags.
+
+Tags and Match are not supported in push command.`);
   }
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,8 +26,8 @@
 import merge from 'deepmerge';
 import { createOption } from 'commander';
 import { readConfig } from './config';
-import type { CliArgs, RunOptions } from './common_types';
-import { THROTTLING_WARNING_MSG, warn } from './helpers';
+import type { CliArgs, PushOptions, RunOptions } from './common_types';
+import { THROTTLING_WARNING_MSG, error, warn } from './helpers';
 
 type Mode = 'run' | 'push';
 
@@ -120,20 +120,24 @@ export function normalizeOptions(
       options.screenshots = cliArgs.screenshots ?? 'on';
       break;
     case 'push':
+      validatePushOptions(options as PushOptions);
       /**
        * Merge the default monitor config from synthetics.config.ts file
        * with the CLI options passed via push command
        */
       const monitor = config.monitor;
-      options.screenshots = options.screenshots ?? monitor?.screenshot;
-      options.schedule = options.schedule ?? monitor?.schedule;
-      options.locations = options.locations ?? monitor?.locations;
-      options.privateLocations =
-        options.privateLocations ?? monitor?.privateLocations;
-      options.alert = options.alert ?? monitor?.alert;
+      for (const key of Object.keys(monitor || {})) {
+        options[key] = options[key] ?? monitor[key];
+      }
       break;
   }
   return options;
+}
+
+export function validatePushOptions(opts: PushOptions & { match?: string }) {
+  if (opts.tags || opts.match) {
+    throw error('Aborted. Invalid flags: tags or match are not supported.');
+  }
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
@@ -173,20 +177,10 @@ export function getCommonCommandOpts() {
     '--pattern <pattern>',
     'RegExp pattern to match journey/monitor files that are different from the default (ex: /*.journey.(ts|js)$/)'
   );
-  const tags = createOption(
-    '--tags <name...>',
-    'run/push tests with a tag that matches the glob'
-  );
-  const match = createOption(
-    '--match <name>',
-    'run/push tests with a name or tags that matches the glob'
-  );
 
   return {
     params,
     playwrightOpts,
     pattern,
-    tags,
-    match,
   };
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -127,7 +127,7 @@ export function normalizeOptions(
        */
       const monitor = config.monitor;
       for (const key of Object.keys(monitor || {})) {
-        // TODO: screenshots require special handling as the flags are different
+        // screenshots require special handling as the flags are different
         if (key === 'screenshot') {
           options.screenshots = options.screenshots ?? monitor[key];
           continue;
@@ -139,7 +139,7 @@ export function normalizeOptions(
   return options;
 }
 
-export function validatePushOptions(opts: PushOptions & { match?: string }) {
+export function validatePushOptions(opts: PushOptions) {
   if (opts.tags || opts.match) {
     throw error(`Aborted. Invalid CLI flags.
 

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -174,6 +174,14 @@ ${INSTALLATION_HELP}`);
   }
 }
 
+export async function validatePush(
+  opts: PushOptions,
+  settings: ProjectSettings
+) {
+  validateSettings(opts);
+  await catchIncorrectSettings(settings, opts);
+}
+
 export function validateSettings(opts: PushOptions) {
   const INVALID = 'Aborted. Invalid synthetics project settings.';
 

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -203,10 +203,6 @@ export async function createLightweightMonitors(
         continue;
       }
       const config = monNode.toJSON();
-      // Filter based on matched tags and name
-      if (!isMatch(config.tags, config.name, options.tags, options.match)) {
-        continue;
-      }
       const { line, col } = lineCounter.linePos(monNode.srcToken.offset);
       try {
         const mon = buildMonitorFromYaml(config, options);
@@ -237,11 +233,14 @@ export function buildMonitorFromYaml(
   }
   const schedule = config.schedule && parseSchedule(String(config.schedule));
   const privateLocations =
-    config['private_locations'] || options.privateLocations;
+    config['private_locations'] ||
+    config.privateLocations ||
+    options.privateLocations;
   delete config['private_locations'];
   const alertConfig = parseAlertConfig(config, options.alert);
   const mon = new Monitor({
     locations: options.locations,
+    tags: options.tags,
     ...config,
     privateLocations,
     schedule: schedule || options.schedule,

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -28,7 +28,7 @@ import { extname, join } from 'path';
 import { LineCounter, parseDocument, YAMLSeq, YAMLMap } from 'yaml';
 import { bold, red } from 'kleur/colors';
 import { Bundler } from './bundler';
-import { SYNTHETICS_PATH, totalist, indent, warn, isMatch } from '../helpers';
+import { SYNTHETICS_PATH, totalist, indent, warn } from '../helpers';
 import { LocationsMap } from '../locations/public-locations';
 import {
   AlertConfig,


### PR DESCRIPTION
+ fix #780
+ fix #787 
+ PR removes the ability to add `--tags`and `--match` to the push command and aborts the command if the command is run with any of the CLI flags.
+ Adds the ability to configure tags for the project based browser and lightweight monitors. Will be overridden by the individual monitor.tags or journey.tags if present on the monitors themselves. 
+ `private_locations` and `privateLocations` are supported in the lightweight monitor config. 
+ `alert.status, alert.tls` was not captured from global config file for browser monitors. Fixed that as well. 


### Testing
- Build the project `npm run build`
- Run the Push command 
```sh
SYNTHETICS_API_KEY=<key> node dist/cli.js push --tags "foo*"
// aborts and logs the error
```
- Test with configuring `monitor.tags` in the synthetics.config file and check if its applied on all monitors in the UI. 
