### PR TITLE
fix: update hash logic to account for bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ __tests__/e2e/junit.xml
 seccomp/build
 
 test-projects/
+
+.DS_Store

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -105,7 +105,7 @@ describe('Monitors', () => {
     });
     monitor.setContent('foo');
     const schema1 = await buildMonitorSchema([monitor], true);
-    expect(schema1[0].hash).not.toEqual(schema[0].hash);
+    expect(schema1[0].hash).toEqual(schema[0].hash);
   });
 
   it('parse @every schedule format', async () => {

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -103,9 +103,9 @@ describe('Monitors', () => {
         match: 'test',
       },
     });
-    monitor.setContent('foo');
+    monitor.update({ locations: ['brazil'] });
     const schema1 = await buildMonitorSchema([monitor], true);
-    expect(schema1[0].hash).toEqual(schema[0].hash);
+    expect(schema1[0].hash).not.toEqual(schema[0].hash);
   });
 
   it('parse @every schedule format', async () => {

--- a/src/dsl/journey.ts
+++ b/src/dsl/journey.ts
@@ -97,7 +97,6 @@ export class Journey {
       ...config,
     });
     this.monitor.setSource(this.location);
-    this.monitor.setContent(this.callback.toString());
     this.monitor.setFilter({ match: this.name });
   }
 

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -109,6 +109,7 @@ export class Monitor {
 
   /**
    * The underlying journey code of the monitor
+   * along with its dependencies
    */
   setContent(content = '') {
     this.content = content;

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -110,12 +110,12 @@ export function diffMonitors(
   return result;
 }
 
-export function getLocalMonitors(monitorSchemas: MonitorSchema[]) {
+export function getLocalMonitors(schemas: MonitorSchema[]) {
   const data: MonitorHashID[] = [];
-  for (const monitor of monitorSchemas) {
+  for (const schema of schemas) {
     data.push({
-      journey_id: monitor.id,
-      hash: monitor.hash,
+      journey_id: schema.id,
+      hash: schema.hash,
     });
   }
   return data;
@@ -141,9 +141,13 @@ export async function buildMonitorSchema(monitors: Monitor[], isV2: boolean) {
     if (type === 'browser') {
       const outPath = join(bundlePath, config.name + '.zip');
       const content = await bundler.build(source.file, outPath);
-      monitor.content = content;
+      monitor.setContent(content);
       Object.assign(schema, { content, filter });
     }
+    /**
+     * Generate hash only after the bundled content is created
+     * to capture code changes in imported files
+     */
     if (isV2) {
       schema.hash = monitor.hash();
     }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -110,12 +110,12 @@ export function diffMonitors(
   return result;
 }
 
-export function getLocalMonitors(monitors: Monitor[]) {
+export function getLocalMonitors(monitorSchemas: MonitorSchema[]) {
   const data: MonitorHashID[] = [];
-  for (const monitor of monitors) {
+  for (const monitor of monitorSchemas) {
     data.push({
-      journey_id: monitor.config.id,
-      hash: monitor.hash(),
+      journey_id: monitor.id,
+      hash: monitor.hash,
     });
   }
   return data;
@@ -137,13 +137,16 @@ export async function buildMonitorSchema(monitors: Monitor[], isV2: boolean) {
       ...config,
       locations: translateLocation(config.locations),
     };
-    if (isV2) {
-      schema.hash = monitor.hash();
-    }
+
     if (type === 'browser') {
       const outPath = join(bundlePath, config.name + '.zip');
       const content = await bundler.build(source.file, outPath);
+      monitor.content = content;
       Object.assign(schema, { content, filter });
+    }
+    if (isV2) {
+      schema.hash = monitor.hash();
+      console.log(schema.hash);
     }
     schemas.push(schema);
   }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -146,7 +146,6 @@ export async function buildMonitorSchema(monitors: Monitor[], isV2: boolean) {
     }
     if (isV2) {
       schema.hash = monitor.hash();
-      console.log(schema.hash);
     }
     schemas.push(schema);
   }


### PR DESCRIPTION
fixes https://github.com/elastic/synthetics/issues/802

update hash logic to account for bundling.

Earlier it was doing difference based on hash calculated before bundling,  in updated logic diff will be done after hash calculated based on content of bundle.