### PR TITLE
fix: Set default timezone to GMT 

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -106,6 +106,8 @@ export function normalizeOptions(
   );
   options.playwrightOptions = {
     ...playwrightOpts,
+    timezoneId: playwrightOpts?.timezoneId ?? 'GMT',
+    locale: playwrightOpts?.locale ?? 'en-GB',
     chromiumSandbox: cliArgs.sandbox ?? playwrightOpts?.chromiumSandbox,
     ignoreHTTPSErrors:
       cliArgs.ignoreHttpsErrors ?? playwrightOpts?.ignoreHTTPSErrors,


### PR DESCRIPTION

fixes https://github.com/elastic/synthetics/issues/777

Set default timezone to GMT 

if no options are specified !!
```

    timezoneId: playwrightOpts?.timezoneId ?? 'GMT',
    locale: playwrightOpts?.locale ?? 'en-GB',
```