### PR TITLE
feat: bundle expect from @playwright/test library

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -323,10 +323,25 @@ describe('CLI', () => {
     // flag turns on type checking
     process.env['TS_NODE_TYPE_CHECK'] = 'true';
     const cli = new CLIMock()
-      .args([join(FIXTURES_DIR, 'expect.journey.ts')])
+      .args([
+        join(FIXTURES_DIR, 'expect.journey.ts'),
+        '--match',
+        'expect extends',
+      ])
       .run();
     expect(await cli.exitCode).toBe(0);
     process.env['TS_NODE_TYPE_CHECK'] = 'false';
+  });
+
+  it('error on unsupported expect assertions', async () => {
+    const cli = new CLIMock()
+      .args([
+        join(FIXTURES_DIR, 'expect.journey.ts'),
+        '--match',
+        'expect unsupported',
+      ])
+      .run();
+    expect(await cli.exitCode).toBe(1);
   });
 
   describe('TLS site with self-signed cert', () => {

--- a/__tests__/fixtures/expect.journey.ts
+++ b/__tests__/fixtures/expect.journey.ts
@@ -62,7 +62,7 @@ expect.extend({
   },
 });
 
-journey('expect journey', ({ page }) => {
+journey('expect extends', ({ page }) => {
   step('exports work', () => {
     expect(100).toBe(100);
     expect([1, 2, 3]).toEqual(expect.arrayContaining([1, 2, 3]));
@@ -77,5 +77,11 @@ journey('expect journey', ({ page }) => {
   step('pw test methods work', async () => {
     await expect(page).toHaveURL('about:blank');
     await expect(page).toHaveTitle('', { timeout: 100 });
+  });
+});
+
+journey('expect unsupported', ({ page }) => {
+  step('throw unsupported', async () => {
+    await expect(page).toHaveScreenshot();
   });
 });

--- a/__tests__/fixtures/expect.journey.ts
+++ b/__tests__/fixtures/expect.journey.ts
@@ -33,6 +33,16 @@ declare global {
   }
 }
 
+// Declare the global matcher in the PW namesapce to be used in tests
+// to satisfy the type checker and IDE
+declare global {
+  namespace PlaywrightTest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+
 expect.extend({
   toBeWithinRange(received, floor, ceiling) {
     const pass = received >= floor && received <= ceiling;
@@ -52,7 +62,7 @@ expect.extend({
   },
 });
 
-journey('expect journey', ({}) => {
+journey('expect journey', ({ page }) => {
   step('exports work', () => {
     expect(100).toBe(100);
     expect([1, 2, 3]).toEqual(expect.arrayContaining([1, 2, 3]));
@@ -62,5 +72,10 @@ journey('expect journey', ({}) => {
   step('extends work', () => {
     expect(100).toBeWithinRange(90, 120);
     expect(101).not.toBeWithinRange(0, 100);
+  });
+
+  step('pw test methods work', async () => {
+    await expect(page).toHaveURL('about:blank');
+    await expect(page).toHaveTitle('', { timeout: 100 });
   });
 });

--- a/bundles/build.js
+++ b/bundles/build.js
@@ -25,32 +25,18 @@
 
 const path = require('path');
 const esbuild = require('esbuild');
+const { ENTRY_POINTS } = require('./src');
 
 const outdir = path.join(__dirname, '..', 'dist', 'bundles');
 
-function IgnorePlugin() {
-  return {
-    name: 'ignore-plugin',
-    setup(build) {
-      build.onResolve({ filter: /.(json|node)$/ }, async () => {
-        return {
-          external: true,
-        };
-      });
-    },
-  };
-}
-
 (async () => {
   const ctx = await esbuild.context({
-    entryPoints: [path.join(__dirname, 'src', 'index.ts')],
+    entryPoints: ENTRY_POINTS,
     bundle: true,
-    external: ['playwright-core'],
+    external: ['playwright-core', '@playwright/test/lib/transform/esmLoader'],
     outfile: path.join(outdir, 'lib', 'index.js'),
     format: 'cjs',
-    logLevel: 'silent',
     platform: 'node',
-    plugins: [IgnorePlugin()],
     target: `node${process.version.slice(1)}`,
     minify: process.argv.includes('--minify'),
     sourcemap: process.argv.includes('--sourcemap'),

--- a/bundles/build.js
+++ b/bundles/build.js
@@ -25,11 +25,8 @@
 
 const path = require('path');
 const esbuild = require('esbuild');
-const fs = require('fs');
 
-const outdir = path.join(__dirname, '../dist/bundles');
-
-if (!fs.existsSync(outdir)) fs.mkdirSync(outdir);
+const outdir = path.join(__dirname, '..', 'dist', 'bundles');
 
 function IgnorePlugin() {
   return {

--- a/bundles/build.js
+++ b/bundles/build.js
@@ -23,6 +23,7 @@
  *
  */
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const esbuild = require('esbuild');
 const { ENTRY_POINTS } = require('./src');

--- a/bundles/package-lock.json
+++ b/bundles/package-lock.json
@@ -7,18 +7,17 @@
     "": {
       "name": "pkg-bundles",
       "version": "0.0.0",
-      "license": "ISC",
       "dependencies": {
-        "@playwright/test": "^1.36.2"
+        "@playwright/test": "=1.37.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.2.tgz",
-      "integrity": "sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz",
+      "integrity": "sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==",
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.36.2"
+        "playwright-core": "1.37.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -49,9 +48,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
-      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/bundles/package-lock.json
+++ b/bundles/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "pkg-bundles",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pkg-bundles",
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@playwright/test": "^1.36.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.2.tgz",
+      "integrity": "sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==",
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.36.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
+      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/bundles/package.json
+++ b/bundles/package.json
@@ -8,6 +8,6 @@
     "build": "npm run bundle -- --minify"
   },
   "dependencies": {
-    "@playwright/test": "^1.36.2"
+    "@playwright/test": "=1.37.0"
   }
 }

--- a/bundles/package.json
+++ b/bundles/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pkg-bundles",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Package bundles that is required by Synthetics",
+  "scripts": {
+    "bundle": "node build.js",
+    "build": "npm run bundle -- --minify"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.36.2"
+  }
+}

--- a/bundles/src/index.js
+++ b/bundles/src/index.js
@@ -23,4 +23,8 @@
  *
  */
 
-export { expect } from '@playwright/test/lib/expect';
+const path = require('path');
+
+module.exports.ENTRY_POINTS = [
+  path.resolve('node_modules/@playwright/test/lib/matchers/expect.js'),
+];

--- a/bundles/src/index.js
+++ b/bundles/src/index.js
@@ -23,6 +23,7 @@
  *
  */
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
 module.exports.ENTRY_POINTS = [

--- a/bundles/src/index.ts
+++ b/bundles/src/index.ts
@@ -23,4 +23,4 @@
  *
  */
 
-export { expect } from '../../dist/bundles/lib/index';
+export { expect } from '@playwright/test/lib/expect';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "deepmerge": "^4.3.1",
         "enquirer": "^2.3.6",
         "esbuild": "^0.18.11",
-        "expect": "^28.1.3",
         "http-proxy": "^1.18.1",
         "kleur": "^4.1.5",
         "micromatch": "^4.0.5",
@@ -74,6 +73,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -286,6 +286,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -317,6 +318,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -330,6 +332,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -341,6 +344,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -354,6 +358,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -361,12 +366,14 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -375,6 +382,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -383,6 +391,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1431,6 +1440,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
       "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
+      "dev": true,
       "dependencies": {
         "jest-get-type": "^28.0.2"
       },
@@ -1882,6 +1892,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.24.1"
       },
@@ -2127,7 +2138,8 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.24.19",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.19.tgz",
-      "integrity": "sha512-gHJu8cdYTD5p4UqmQHrxaWrtb/jkH5imLXzuBypWhKzNkW0qfmgz+w1xaJccWVuJta1YYUdlDiPHXRTR4Ku0MQ=="
+      "integrity": "sha512-gHJu8cdYTD5p4UqmQHrxaWrtb/jkH5imLXzuBypWhKzNkW0qfmgz+w1xaJccWVuJta1YYUdlDiPHXRTR4Ku0MQ==",
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
@@ -2206,12 +2218,14 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -2220,6 +2234,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
       "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
@@ -2252,7 +2267,8 @@
     "node_modules/@types/node": {
       "version": "16.11.59",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
-      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw=="
+      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw==",
+      "dev": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -2284,12 +2300,14 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
       "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -2297,7 +2315,8 @@
     "node_modules/@types/yargs-parser": {
       "version": "20.2.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.38.0",
@@ -2572,6 +2591,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2580,6 +2600,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3051,6 +3072,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3439,6 +3461,7 @@
       "version": "28.1.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
       "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -3577,6 +3600,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3918,6 +3942,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
       "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "dev": true,
       "dependencies": {
         "@jest/expect-utils": "^28.1.3",
         "jest-get-type": "^28.0.2",
@@ -4300,6 +4325,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5142,6 +5168,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
       "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^28.1.1",
@@ -5318,6 +5345,7 @@
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
       "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
@@ -5476,6 +5504,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
       "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^28.1.3",
@@ -5490,6 +5519,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
       "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^28.1.3",
@@ -5509,6 +5539,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6134,6 +6165,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
       "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "dev": true,
       "dependencies": {
         "@jest/types": "^28.1.3",
         "@types/node": "*",
@@ -6150,6 +6182,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -6165,7 +6198,8 @@
     "node_modules/jest-util/node_modules/ci-info": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-      "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg=="
+      "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
+      "dev": true
     },
     "node_modules/jest-validate": {
       "version": "29.6.1",
@@ -6371,7 +6405,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -7173,6 +7208,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
       "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^28.1.3",
         "ansi-regex": "^5.0.1",
@@ -7187,6 +7223,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7311,7 +7348,8 @@
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "2.3.7",
@@ -7648,6 +7686,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7716,6 +7755,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -7835,6 +7875,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -8410,6 +8451,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.22.5"
       }
@@ -8576,7 +8618,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.22.5",
@@ -8599,6 +8642,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -8609,6 +8653,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -8617,6 +8662,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -8627,6 +8673,7 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -8634,22 +8681,26 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -9449,6 +9500,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
       "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
+      "dev": true,
       "requires": {
         "jest-get-type": "^28.0.2"
       }
@@ -9657,6 +9709,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.24.1"
       }
@@ -9854,7 +9907,8 @@
     "@sinclair/typebox": {
       "version": "0.24.19",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.19.tgz",
-      "integrity": "sha512-gHJu8cdYTD5p4UqmQHrxaWrtb/jkH5imLXzuBypWhKzNkW0qfmgz+w1xaJccWVuJta1YYUdlDiPHXRTR4Ku0MQ=="
+      "integrity": "sha512-gHJu8cdYTD5p4UqmQHrxaWrtb/jkH5imLXzuBypWhKzNkW0qfmgz+w1xaJccWVuJta1YYUdlDiPHXRTR4Ku0MQ==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "3.0.0",
@@ -9933,12 +9987,14 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -9947,6 +10003,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
       "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+      "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
@@ -9979,7 +10036,8 @@
     "@types/node": {
       "version": "16.11.59",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
-      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw=="
+      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -10011,12 +10069,14 @@
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw=="
+      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
       "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -10024,7 +10084,8 @@
     "@types/yargs-parser": {
       "version": "20.2.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.38.0",
@@ -10181,12 +10242,14 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -10516,6 +10579,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -10814,7 +10878,8 @@
     "diff-sequences": {
       "version": "28.1.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
-      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw=="
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -10924,7 +10989,8 @@
     "escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true
     },
     "eslint": {
       "version": "8.23.1",
@@ -11173,6 +11239,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
       "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
+      "dev": true,
       "requires": {
         "@jest/expect-utils": "^28.1.3",
         "jest-get-type": "^28.0.2",
@@ -11456,7 +11523,8 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -12048,6 +12116,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
       "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^28.1.1",
@@ -12176,7 +12245,8 @@
     "jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA=="
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true
     },
     "jest-haste-map": {
       "version": "29.6.1",
@@ -12294,6 +12364,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
       "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "jest-diff": "^28.1.3",
@@ -12305,6 +12376,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
       "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^28.1.3",
@@ -12321,6 +12393,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
           "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+          "dev": true,
           "requires": {
             "@jest/schemas": "^28.1.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -12801,6 +12874,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
       "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
+      "dev": true,
       "requires": {
         "@jest/types": "^28.1.3",
         "@types/node": "*",
@@ -12814,6 +12888,7 @@
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
           "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
+          "dev": true,
           "requires": {
             "@jest/schemas": "^28.1.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -12826,7 +12901,8 @@
         "ci-info": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-          "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg=="
+          "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
+          "dev": true
         }
       }
     },
@@ -12980,7 +13056,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -13571,6 +13648,7 @@
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
       "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
       "requires": {
         "@jest/schemas": "^28.1.3",
         "ansi-regex": "^5.0.1",
@@ -13581,7 +13659,8 @@
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
         }
       }
     },
@@ -13661,7 +13740,8 @@
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -13891,7 +13971,8 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -13945,6 +14026,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
@@ -14031,6 +14113,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepublish": "npm run clean && npm run build",
     "build": "tsc",
     "build:locations": "sh utils/update_locations.sh",
+    "build:bundles": "cd bundles && npm run build",
     "watch": "tsc -w",
     "lint": "eslint . --rulesdir utils/eslint-rules",
     "lint:fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist",
-    "prepublish": "npm run clean && npm run build:bundles && npm run build",
-    "build": "tsc",
+    "prepublish": "npm run clean && npm run build",
+    "build:lib": "tsc",
     "build:locations": "sh utils/update_locations.sh",
-    "build:bundles": "cd bundles && npm run build",
+    "build": "node utils/build.js",
     "watch": "tsc -w",
     "lint": "eslint . --rulesdir utils/eslint-rules",
     "lint:fix": "npm run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rimraf dist",
-    "prepublish": "npm run clean && npm run build",
+    "prepublish": "npm run clean && npm run build:bundles && npm run build",
     "build": "tsc",
     "build:locations": "sh utils/update_locations.sh",
     "build:bundles": "cd bundles && npm run build",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "deepmerge": "^4.3.1",
     "enquirer": "^2.3.6",
     "esbuild": "^0.18.11",
-    "expect": "^28.1.3",
     "http-proxy": "^1.18.1",
     "kleur": "^4.1.5",
     "micromatch": "^4.0.5",

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -36,7 +36,7 @@ expectLib.extend({
     throw new Error('toHaveScreenshot is not supported in elastic synthetics.');
   },
   toMatchSnapshot: () => {
-    throw new Error('toHaveScreenshot is not supported in elastic synthetics.');
+    throw new Error('toMatchSnapshot is not supported in elastic synthetics.');
   },
 });
 

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -23,7 +23,7 @@
  *
  */
 
-//eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
 const expectLib = require('../../dist/bundles/lib/index').expect;
 
 type ExpectLibrary =

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -23,4 +23,11 @@
  *
  */
 
-export { expect } from '../../dist/bundles/lib/index';
+const expectLib = require('../../dist/bundles/lib/index').expect;
+
+type ExpectLibrary =
+  typeof import('../../bundles/node_modules/@playwright/test/types/test').expect;
+
+type ModifiedExpect = Omit<ExpectLibrary, 'toMatchSnapshot'>;
+
+export const expect: ModifiedExpect = expectLib;

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -29,4 +29,15 @@ const expectLib = require('../../dist/bundles/lib/index').expect;
 type ExpectLibrary =
   typeof import('../../bundles/node_modules/@playwright/test/types/test').expect;
 
+// exclude toHaveScreenshot and toMatchSnapshot from expect
+// since they are not supported in synthetics
+expectLib.extend({
+  toHaveScreenshot: () => {
+    throw new Error('toHaveScreenshot is not supported in elastic synthetics.');
+  },
+  toMatchSnapshot: () => {
+    throw new Error('toHaveScreenshot is not supported in elastic synthetics.');
+  },
+});
+
 export const expect: ExpectLibrary = expectLib;

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -29,6 +29,4 @@ const expectLib = require('../../dist/bundles/lib/index').expect;
 type ExpectLibrary =
   typeof import('../../bundles/node_modules/@playwright/test/types/test').expect;
 
-type ModifiedExpect = Omit<ExpectLibrary, 'toMatchSnapshot'>;
-
-export const expect: ModifiedExpect = expectLib;
+export const expect: ExpectLibrary = expectLib;

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -23,6 +23,7 @@
  *
  */
 
+//eslint-disable-next-line @typescript-eslint/no-var-requires
 const expectLib = require('../../dist/bundles/lib/index').expect;
 
 type ExpectLibrary =

--- a/src/core/expect.ts
+++ b/src/core/expect.ts
@@ -26,18 +26,18 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const expectLib = require('../../dist/bundles/lib/index').expect;
 
-type ExpectLibrary =
-  typeof import('../../bundles/node_modules/@playwright/test/types/test').expect;
+function notSupported(name: string) {
+  throw new Error(`expect.${name} is not supported in @elastic/synthetics.`);
+}
 
-// exclude toHaveScreenshot and toMatchSnapshot from expect
-// since they are not supported in synthetics
+/**
+ * Exclude toHaveScreenshot and toMatchSnapshot from our custom expect
+ * since they are expected to be running inside PW test runner for it to work properly.
+ */
 expectLib.extend({
-  toHaveScreenshot: () => {
-    throw new Error('toHaveScreenshot is not supported in elastic synthetics.');
-  },
-  toMatchSnapshot: () => {
-    throw new Error('toMatchSnapshot is not supported in elastic synthetics.');
-  },
+  toHaveScreenshot: () => notSupported('toHaveScreenshot'),
+  toMatchSnapshot: () => notSupported('toMatchSnapshot'),
 });
 
-export const expect: ExpectLibrary = expectLib;
+export const expect: typeof import('../../bundles/node_modules/@playwright/test/types/test').expect =
+  expectLib;

--- a/utils/build.js
+++ b/utils/build.js
@@ -1,0 +1,87 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { spawnSync } = require('child_process');
+const { join } = require('path');
+const { cyan } = require('kleur/colors');
+
+const ROOT_DIR = join(__dirname, '..');
+/**
+ * @typedef {{
+ *   cmd: string,
+ *   args: string[],
+ *   env?: NodeJS.ProcessEnv,
+ *   cwd?: string,
+ * }} Script
+ */
+
+/** @type {Script[]} */
+const scripts = [];
+
+// bundles
+const BUNDLES_DIR = join(ROOT_DIR, 'bundles');
+
+scripts.push({
+  cmd: 'npm',
+  args: ['ci', '--no-fund', '--no-audit', '--no-save'],
+  cwd: BUNDLES_DIR,
+});
+
+scripts.push({
+  cmd: 'npm',
+  args: ['run', 'build'],
+  cwd: BUNDLES_DIR,
+});
+
+// test-runner
+scripts.push({
+  cmd: 'npm',
+  args: ['run', 'build:lib'],
+});
+
+function runBuild() {
+  for (const script of scripts) {
+    console.log(
+      cyan(
+        `Running '${script.cmd} ${script.args.join(' ')}' in ${
+          script.cwd || process.cwd()
+        }`
+      )
+    );
+    const out = spawnSync(script.cmd, script.args, {
+      stdio: 'inherit',
+      shell: true,
+      env: {
+        ...process.env,
+        ...script.env,
+      },
+      cwd: script.cwd,
+    });
+    if (out.status > 0) process.exit(out.status);
+  }
+}
+
+runBuild();


### PR DESCRIPTION
+ fix [#808 ](https://github.com/elastic/synthetics/issues/700)
+ Bundles the PW test library expect matcher with the synthetics and replaces the expect from jest in favor of the PW test matchers. 
+ The PR uses the `expect` library from the `@playwright/test` without bringing in the full runner which we do not require as we have our own Synthetics runner which is build with different syntax. This also replaces the `expect` from jest in favor of the PW test matchers which under the hood is built on top of expect.
+ With bundling approach, we get the benefit of only importing the necessary modules from the PW test and core and still utilize all the available matchers except for the matchers that does comparision on the files - `toMatchSnapshot` and `toHaveScreenshot`. 


### Folowup
+ [ ] Update the docs around expect library - https://www.elastic.co/guide/en/observability/8.9/synthetics-create-test.html#synthetics-assertions-methods
+ [x] Callout `toHaveScreenshot` and `toMatchSnapshot` wont work. 
+ [ ] Stacktrace fix to polish the errors from Expect - #824 