### PR TITLE
fix: Throw better error message if version parsing fails

### DIFF
--- a/__tests__/utils/kibana-test-server.ts
+++ b/__tests__/utils/kibana-test-server.ts
@@ -34,6 +34,9 @@ export const createKibanaTestServer = async (kibanaVersion: string) => {
   server.route('/s/dummy/api/status', (req, res) =>
     res.end(JSON.stringify({ version: { number: kibanaVersion } }))
   );
+  server.route('/s/dummy/api/stats', (req, res) =>
+    res.end(JSON.stringify({ kibana: { version: kibanaVersion } }))
+  );
   // Legacy
   server.route(
     '/s/dummy/api/synthetics/service/project/monitors',

--- a/src/push/kibana_api.ts
+++ b/src/push/kibana_api.ts
@@ -124,8 +124,8 @@ export async function bulkDeleteMonitors(
 }
 
 type StatusResponse = {
-  version: {
-    number: string;
+  version?: {
+    number?: string;
   };
 };
 
@@ -135,6 +135,13 @@ export async function getVersion(options: PushOptions) {
     method: 'GET',
     auth: options.auth,
   });
+
+  if (!data.version || typeof data.version?.number === 'undefined') {
+    throw Error(
+      'Unable to retrieve version. Are your auth credentials correct?'
+    );
+  }
+
   return data.version.number;
 }
 

--- a/src/push/kibana_api.ts
+++ b/src/push/kibana_api.ts
@@ -124,8 +124,8 @@ export async function bulkDeleteMonitors(
 }
 
 type StatusResponse = {
-  version?: {
-    number?: string;
+  kibana: {
+    version: string;
   };
 };
 
@@ -136,13 +136,7 @@ export async function getVersion(options: PushOptions) {
     auth: options.auth,
   });
 
-  if (!data.version || typeof data.version?.number === 'undefined') {
-    throw Error(
-      'Unable to retrieve version. Are your auth credentials correct?'
-    );
-  }
-
-  return data.version.number;
+  return data.kibana.version;
 }
 
 export type LegacyAPISchema = {

--- a/src/push/utils.ts
+++ b/src/push/utils.ts
@@ -64,7 +64,7 @@ export function generateURL(options: PushOptions, operation: Operation) {
   const url = removeTrailingSlash(options.url);
   switch (operation) {
     case 'status':
-      return `${url}/s/${options.space}/api/status`;
+      return `${url}/s/${options.space}/api/stats`;
     case 'bulk_get':
     case 'bulk_update':
     case 'bulk_delete':


### PR DESCRIPTION
The Agent sends a request to Kibana during `push` operations to check its version number. Unfortunately, the API endpoint responsible for returning this data will always return a `2XX` error code, even if credentials are invalid, [for reasons](https://github.com/elastic/kibana/pull/94287#issuecomment-795643347), essentially because this endpoint acts as a heartbeat for Kibana in certain cases.

# Better solution

We can get around this issue [by calling](https://github.com/elastic/synthetics/pull/821/files#diff-a57766b2528b00ef17f58b293951b9da05293f17b8049cf03201bcddb0b7a7d7L67) `/api/stats` instead of `/api/status`. This endpoint returns the Kibana version and will throw a `401` in the event of a garbage API key, thus solving both problems.

---

**Note:** the rest of the info in the description is kept for context, but we will employ the solution explained above.

### Example

```
# API key
abc123

# Command with incorrect key
env SYNTHETICS_API_KEY=abc12 npm run push
```

### Explanation

Because we don't receive a `401`, the Agent's internal HTTP error handling will not display any error, per its design. Unfortunately, because this issue falls through to the calling code, when we do receive an error, it is very unhelpful from a UX perspective. At this point, the user is trying to `push` their monitors. While waiting with their fingers crossed, hoping to see a success message, receiving a log like the example output below is confusing, disheartening, and a bad experience.

```
➜ npm run push

> lugia@1.0.0 push
> npx @elastic/synthetics push

TypeError: Cannot read properties of undefined (reading 'number')
    at getVersion (~/lugia/node_modules/@elastic/synthetics/src/push/kibana_api.ts:138:23)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Command.<anonymous> (~/lugia/node_modules/@elastic/synthetics/src/cli.ts:212:31)
```

~My proposal is that the Agent should diagnose this novel error and throw a custom message in this case. The copy is by no means final and I am open to suggestions.~

~I'm aware that this is essentially fixing the problem by introducing tech debt. A longer term alternative fix to this approach would be to have Kibana provide a dedicated version API endpoint that could handle HTTP errors in the conventional way, but having spoken to the team, at this point it seems unlikely we will see this change in the short term. As the "fix" here has a really small footprint and is encapsulated to just this function, it seems acceptable to me, but I'm open to alternative solutions as well.~