### PR TITLE
ci: fix setup-totp action

### DIFF
--- a/.github/actions/setup-totp/action.yml
+++ b/.github/actions/setup-totp/action.yml
@@ -26,9 +26,9 @@ runs:
     - name: Set up TOTP_CODE
       uses: hashicorp/vault-action@v2.5.0
       with:
-        url: ${{ secrets.VAULT_ADDR }}
-        roleId: ${{ secrets.VAULT_ROLE_ID }}
-        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        url: ${{ inputs.vault-url }}
+        roleId: ${{ secrets.vault-role-id }}
+        secretId: ${{ secrets.vault-secret-id }}
         method: approle
         secrets: |
           ${{ inputs.secret }} ${{ inputs.secret-key }} | ${{ inputs.env-name }};


### PR DESCRIPTION
## Details

The action does not have access to the `secrets` context.

This change fixes the error and uses the inputs instead, which it was supposed to do in the first place.