### PR TITLE
feat: capture unhandled rejections across all pages

### DIFF
--- a/__tests__/plugins/browser-console.test.ts
+++ b/__tests__/plugins/browser-console.test.ts
@@ -105,23 +105,37 @@ describe('BrowserConsole', () => {
     expect(referenceError?.step).toEqual(currentStep);
   });
 
-  it('should capture unhandled rejections', async () => {
+  it('capture unhandled rejections on all pages', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     const browserConsole = new BrowserConsole(driver);
     browserConsole.start();
     browserConsole._currentStep = currentStep;
     await driver.page.goto(server.TEST_PAGE);
-    await driver.page.setContent(
-      `<script>Promise.reject(new Error("Boom"))</script>`
-    );
-    await driver.page.waitForLoadState('networkidle');
+    await Promise.all([
+      driver.context.waitForEvent('weberror'),
+      driver.page.setContent(
+        `<script>Promise.reject(new Error("Boom"))</script>`
+      ),
+    ]);
+    // throw rejection inside new window
+    await Promise.all([
+      driver.page.evaluate(async () => {
+        const win = window.open();
+        Promise.reject('popup error');
+        (win as any).close();
+      }),
+      driver.context.waitForEvent('weberror'),
+      driver.page.waitForEvent('popup'),
+    ]);
     const messages = browserConsole.stop();
     await Gatherer.stop();
 
-    const unhandledError = messages.find(m => m.text.indexOf('Boom') >= 0);
-    expect(unhandledError?.type).toEqual('error');
-    expect(unhandledError?.step).toEqual(currentStep);
-    expect(unhandledError?.error?.stack).toContain('Error: Boom');
+    expect(messages.length).toEqual(2);
+    const [page1Err, page2Err] = messages;
+    expect(page1Err?.type).toEqual('error');
+    expect(page1Err?.step).toEqual(currentStep);
+    expect(page1Err?.error?.stack).toContain('Error: Boom');
+    expect(page2Err?.text).toEqual('popup error');
   });
 
   describe('Filtering', () => {

--- a/src/plugins/browser-console.ts
+++ b/src/plugins/browser-console.ts
@@ -23,7 +23,7 @@
  *
  */
 
-import type { ConsoleMessage } from 'playwright-core';
+import type { ConsoleMessage, WebError } from 'playwright-core';
 import { BrowserMessage, Driver, StatusValue } from '../common_types';
 import { log } from '../core/logger';
 import { Step } from '../dsl';
@@ -58,11 +58,12 @@ export class BrowserConsole {
     }
   };
 
-  private pageErrorEventListener = (error: Error) => {
+  private webErrorListener = (webErr: WebError) => {
     if (!this._currentStep) {
       return;
     }
     const { name, index } = this._currentStep;
+    const error = webErr.error();
     this.messages.push({
       timestamp: getTimestamp(),
       text: error.message,
@@ -83,12 +84,12 @@ export class BrowserConsole {
   start() {
     log(`Plugins: started collecting console events`);
     this.driver.context.on('console', this.consoleEventListener);
-    this.driver.page.on('pageerror', this.pageErrorEventListener);
+    this.driver.context.on('weberror', this.webErrorListener);
   }
 
   stop() {
     this.driver.context.off('console', this.consoleEventListener);
-    this.driver.page.off('pageerror', this.pageErrorEventListener);
+    this.driver.context.off('weberror', this.webErrorListener);
     log(`Plugins: stopped collecting console events`);
     return this.messages;
   }


### PR DESCRIPTION
+ fix https://github.com/elastic/synthetics/issues/815
+ Available from Playwright 1.38.0 - PR updates the PW to the latest version and captures the unhandled rejections via the new `weberror` event from browser contest instead of relying on the page level `pageerror` event which does not provide the rejections across multiple pages.
+ Docs - https://playwright.dev/docs/api/class-weberror
