### PR TITLE
chore: fix e2e test go version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
           node-version-file: .nvmrc
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
       - run: npm ci
       - run: npm run build
       - run: npm install


### PR DESCRIPTION
+ E2E tests are failing in main due to elastic-package version dependency - https://github.com/elastic/synthetics/actions/runs/6237678207/job/16931806039