### PR TITLE
feat: camelcase retest config for lightweight monitors

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -245,10 +245,11 @@ heartbeat.monitors:
   tags:
     - ltag1
     - ltag2
-  retestOnFailure: true
+  retest_on_failure: true
       `);
 
       const [mon] = await createLightweightMonitors(PROJECT_DIR, {
+        auth: 'foo',
         params: { foo: 'bar' },
         kibanaVersion: '8.8.0',
         locations: ['australia_east'],
@@ -256,7 +257,7 @@ heartbeat.monitors:
         privateLocations: ['gbaz'],
         schedule: 10,
         retestOnFailure: false,
-      } as any);
+      });
 
       expect(mon.config).toEqual({
         id: 'test-icmp',
@@ -280,11 +281,12 @@ heartbeat.monitors:
       `);
 
       const [mon] = await createLightweightMonitors(PROJECT_DIR, {
+        auth: 'foo',
         tags: ['gtag1', 'gtag2'],
         privateLocations: ['gbaz'],
         schedule: 10,
         retestOnFailure: false,
-      } as PushOptions);
+      });
 
       expect(mon.config).toEqual({
         id: 'test-icmp',

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -217,8 +217,6 @@ type BaseArgs = {
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
-  alert?: AlertConfig;
-  retestOnFailure?: MonitorConfig['retestOnFailure'];
 };
 
 export type CliArgs = BaseArgs & {
@@ -249,6 +247,8 @@ export type PushOptions = Partial<ProjectSettings> &
     auth: string;
     kibanaVersion?: string;
     yes?: boolean;
+    alert?: AlertConfig;
+    retestOnFailure?: MonitorConfig['retestOnFailure'];
   };
 
 export type ProjectSettings = {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -242,13 +242,15 @@ export function buildMonitorFromYaml(
     config['private_locations'] ||
     config.privateLocations ||
     options.privateLocations;
-  delete config['private_locations'];
+  const retestOnFailure =
+    config['retest_on_failure'] ?? options.retestOnFailure;
   const alertConfig = parseAlertConfig(config, options.alert);
+
   const mon = new Monitor({
     locations: options.locations,
-    retestOnFailure: options.retestOnFailure,
     tags: options.tags,
-    ...config,
+    ...normalizeConfig(config),
+    retestOnFailure,
     privateLocations,
     schedule: schedule || options.schedule,
     alert: alertConfig,
@@ -262,6 +264,14 @@ export function buildMonitorFromYaml(
     mon.config.params = options.params;
   }
   return mon;
+}
+
+// Deletes unncessary fields from the lightweight monitor config
+//  that is not supported by the Kibana API
+function normalizeConfig(config: MonitorConfig) {
+  delete config['private_locations'];
+  delete config['retest_on_failure'];
+  return config;
 }
 
 export const parseAlertConfig = (


### PR DESCRIPTION
+ Addresses the concerns raised on the previous Retest PR - https://github.com/elastic/synthetics/pull/845#discussion_r1346088146
+ Also takes the local override in favor of the global one for lightweight monitors. 