### PR TITLE
fix: align push command timeout with kibana route

### DIFF
--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -48,7 +48,8 @@ export async function sendRequest(options: APIRequestOptions) {
       'user-agent': `Elastic/Synthetics ${version}`,
       'kbn-xsrf': 'true',
     },
-    headersTimeout: 60 * 1000,
+    // align with the default timeout of the kibana route
+    headersTimeout: 2 * 60 * 1000,
   });
 }
 


### PR DESCRIPTION
align push command timeout with kibana route, kibana default timeout is 120s. 

this addresses part of https://github.com/elastic/synthetics/issues/851