### PR TITLE
chore(ci): use string evaluation rather than boolean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,20 +43,20 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Get version and package name
-        if: ${{ !github.event.inputs.dry-run }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         run: |
           echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
           echo "NPM_PACKAGE=$(jq -r '.name' package.json) >> $GITHUB_ENV
 
       - name: Create 'latest' dist-tag
-        if: ${{ !github.event.inputs.dry-run }}
+        if: ${{ github.event.inputs.dry-run == 'false' }}
         run: npm dist-tag --otp=${TOTP_CODE} add "${NPM_PACKAGE}@${VERSION}" latest
 
       - name: Create 'stack_release' dist-tag
-        if: ${{ !github.event.inputs.dry-run && github.event.inputs.is-stack-release }}
+        if: ${{ github.event.inputs.dry-run == 'false' && github.event.inputs.is-stack-release == 'true' }}
         run: npm dist-tag --otp=${TOTP_CODE} add "${NPM_PACKAGE}@${VERSION}" stack_release
 
-      - if: ${{ always() && !github.event.inputs.dry-run }}
+      - if: ${{ always() && github.event.inputs.dry-run == 'false' }}
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
Apparently, workflow_dispatch inputs are not actually booleans but are strings. When running the release.yml manually with default inputs the GitHub Action will not run as expected and skip some steps:

<img width="805" alt="image" src="https://github.com/elastic/synthetics/assets/2871786/2c04d906-953e-45d5-b3f8-b71f3dc523c3">

See https://github.com/actions/runner/issues/1483