### PR TITLE
chore(ci): remove set to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,6 @@ jobs:
           echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_ENV
           echo "NPM_PACKAGE=$(jq -r '.name' package.json) >> $GITHUB_ENV
 
-      - name: Create 'latest' dist-tag
-        if: ${{ !github.event.inputs.dry-run }}
-        run: npm dist-tag --otp=${TOTP_CODE} add "${NPM_PACKAGE}@${VERSION}" latest
-
       - name: Create 'stack_release' dist-tag
         if: ${{ !github.event.inputs.dry-run && github.event.inputs.is-stack-release }}
         run: npm dist-tag --otp=${TOTP_CODE} add "${NPM_PACKAGE}@${VERSION}" stack_release


### PR DESCRIPTION
### WHY

Latest dist tag is not necessary as `npm publish` would automatically mark the last published as latest.