### PR TITLE
chore: keep pw version same as other pw deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "kleur": "^4.1.5",
         "micromatch": "^4.0.5",
         "pirates": "^4.0.5",
-        "playwright": "=1.38.0",
+        "playwright": "=1.38.1",
         "playwright-chromium": "=1.38.1",
         "playwright-core": "=1.38.1",
         "semver": "^7.5.2",
@@ -12812,11 +12812,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.0.tgz",
-      "integrity": "sha512-fJGw+HO0YY+fU/F1N57DMO+TmXHTrmr905J05zwAQE9xkuwP/QLDk63rVhmyxh03dYnEhnRbsdbH9B0UVVRB3A==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
+      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
       "dependencies": {
-        "playwright-core": "1.38.0"
+        "playwright-core": "1.38.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12847,17 +12847,6 @@
       "version": "1.38.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
       "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.0.tgz",
-      "integrity": "sha512-f8z1y8J9zvmHoEhKgspmCvOExF2XdcxMW8jNRuX4vkQFrzV4MlZ55iwb5QeyiFQgOFCUolXiRHgpjSEnqvO48g==",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "kleur": "^4.1.5",
     "micromatch": "^4.0.5",
     "pirates": "^4.0.5",
-    "playwright": "=1.38.0",
+    "playwright": "=1.38.1",
     "playwright-chromium": "=1.38.1",
     "playwright-core": "=1.38.1",
     "semver": "^7.5.2",


### PR DESCRIPTION
+ This was slipped when we did the change last time during the PW upgrade - https://github.com/elastic/synthetics/commit/f75c4705b30f30a2b33b2d20e82b18a65adfa0e6

+ Fixing it so we dont need to do anything separate in the Recorder - https://github.com/elastic/synthetics-recorder/pull/480