### PR TITLE
feat: introduce kibana interal origin header for serverless requests

### DIFF
--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -47,6 +47,7 @@ export async function sendRequest(options: APIRequestOptions) {
       'content-type': 'application/json',
       'user-agent': `Elastic/Synthetics ${version}`,
       'kbn-xsrf': 'true',
+      'x-elastic-internal-origin': 'elastic-synthetics',
     },
     // align with the default timeout of the kibana route
     headersTimeout: 2 * 60 * 1000,


### PR DESCRIPTION
Kibana will reject external requests to `internal` routes by default in Serverless.

We flag our requests as `internal` by passing the `x-elastic-internal-origin` header with requests. This patch includes this header in the requests we send to Kibana, which will allow us to query the project monitor API without making it a documented public API.