### PR TITLE
fix: keep size limit at 1500kb for project monitors

### DIFF
--- a/src/push/bundler.ts
+++ b/src/push/bundler.ts
@@ -32,7 +32,7 @@ import { commonOptions } from '../core/transform';
 import { SyntheticsBundlePlugin } from './plugin';
 
 // 1500KB Max Gzipped limit for bundled code to be pushed as Kibana project monitors.
-const SIZE_LIMIT_KB = 200;
+const SIZE_LIMIT_KB = 1500;
 
 function relativeToCwd(entry: string) {
   return path.relative(process.cwd(), entry);


### PR DESCRIPTION
+ Fix that was Incorrectly pushed to set the size at 200kb. 