### PR TITLE
ci(github-action): use hardcoded package name

### DIFF
--- a/.github/workflows/dist-tag.yml
+++ b/.github/workflows/dist-tag.yml
@@ -53,5 +53,4 @@ jobs:
 
       - name: NPM dist-tag
         run: |
-          NPM_PACKAGE=$(jq '.name' package.json)
-          npm dist-tag --otp=${TOTP_CODE} add "${NPM_PACKAGE}@${VERSION}" "${DIST_TAG}"
+          npm dist-tag --otp=${TOTP_CODE} add "@elastic/synthetics@${VERSION}" "${DIST_TAG}"


### PR DESCRIPTION
We have agreed to use this approach:

> Given the name of the package never changes and I dont expect it to change anytime in the future. We can replace the value of the .name with @elastic/synthetics since the release is specific to the synthetics package.

This will help with solving the issue defined in [here](https://securitylab.github.com/research/github-actions-untrusted-input/#remediation)