### PR TITLE
ci(github-action): use wildcards for discovering all the workflows

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,21 +1,21 @@
 ---
+# Look up results at https://ela.st/oblt-ci-cd-stats.
+# There will be one service per GitHub repository, including the org name, and one Transaction per Workflow.
 name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows:
-      - ci
-      - dist-tag
-      - e2e
-      - pr-title-lint
-      - release
+    workflows: [ "*" ]
     types: [completed]
+
+permissions:
+  contents: read
 
 jobs:
   otel-export-trace:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@main
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
No need to maintain the static list of GitHub Workflows to be monitored with the CI/CD Observability using Opentelemetry

