### PR TITLE
ci: add permissions block to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   actions: write
+  actions: write
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   actions: write
-  actions: write
 
 jobs:
 

--- a/.github/workflows/dist-tag.yml
+++ b/.github/workflows/dist-tag.yml
@@ -12,6 +12,9 @@ on:
         description: Dist tag to use.
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   dist-tag:
     env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   actions: write
-  actions: write
 
 jobs:
   test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   actions: write
+  actions: write
 
 jobs:
   test:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   test:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -9,6 +9,9 @@ on:
       - synchronize
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   pr-title-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   actions: read
+  checks: write
 
 jobs:
   report:

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -9,6 +9,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
