### PR TITLE
fix: allow overriding enabled/retestOnFailure via global config

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -754,6 +754,7 @@ describe('runner', () => {
     });
 
     it('runner - build monitors with global config', async () => {
+      // Faking monitor.use across file level
       runner.updateMonitor({
         schedule: 5,
         locations: ['us_east'],
@@ -772,16 +773,22 @@ describe('runner', () => {
         schedule: 3,
         locations: ['united_kingdom'],
         privateLocations: ['spain'],
+        retestOnFailure: true,
       });
-      j2.updateMonitor({ throttling: { latency: 1000 } });
+      j2.updateMonitor({ throttling: { latency: 1000 }, enabled: true });
       runner.addJourney(j1);
       runner.addJourney(j2);
 
-      const monitors = runner.buildMonitors(options);
+      const monitors = runner.buildMonitors({
+        ...options,
+        enabled: false,
+        retestOnFailure: false,
+      });
       expect(monitors.length).toBe(2);
       expect(monitors[0].config).toEqual({
         id: 'test-j1',
         name: 'j1',
+        enabled: false,
         type: 'browser',
         tags: ['foo*'],
         locations: ['united_kingdom'],
@@ -791,11 +798,13 @@ describe('runner', () => {
         playwrightOptions: { ignoreHTTPSErrors: true },
         throttling: { download: 100, latency: 20, upload: 50 },
         alert: { tls: { enabled: true } },
+        retestOnFailure: true,
       });
       expect(monitors[1].config).toMatchObject({
         locations: ['us_east'],
         privateLocations: ['germany'],
         schedule: 5,
+        enabled: true,
         tags: ['g1', 'g2'],
         throttling: { latency: 1000 },
         alert: { tls: { enabled: true } },

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -248,6 +248,7 @@ export type PushOptions = Partial<ProjectSettings> &
     yes?: boolean;
     alert?: AlertConfig;
     retestOnFailure?: MonitorConfig['retestOnFailure'];
+    enabled?: boolean;
   };
 
 export type ProjectSettings = {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -417,6 +417,8 @@ export default class Runner {
       screenshot: options.screenshots,
       tags: options.tags,
       alert: options.alert,
+      retestOnFailure: options.retestOnFailure,
+      enabled: options.enabled,
     });
 
     const monitors: Monitor[] = [];

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -250,6 +250,7 @@ export function buildMonitorFromYaml(
   const alertConfig = parseAlertConfig(config, options.alert);
 
   const mon = new Monitor({
+    enabled: config.enabled ?? options.enabled,
     locations: options.locations,
     tags: options.tags,
     ...normalizeConfig(config),


### PR DESCRIPTION
+ fix #894 
+ enabled: false and retestOnFailure: false on the synthetics global config did not get passed to Kibana which effectively meant the users can only enable/disable them via individual monitor config. This PR fixes the problem and allows all monitors to be overridden with correct value. 