### PR TITLE
fix: redact sensitive req/response headers by default

### DIFF
--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -32,6 +32,7 @@ import JSONReporter, {
   formatNetworkFields,
   gatherScreenshots,
   getScreenshotBlocks,
+  redactKeys,
 } from '../../src/reporters/json';
 import * as helpers from '../../src/helpers';
 import { NETWORK_INFO } from '../fixtures/networkinfo';
@@ -191,6 +192,26 @@ describe('json reporter', () => {
       expect(duplicates).toBe(false);
       expect(snakeCaseKeys(event)).toMatchSnapshot();
     }
+  });
+
+  it('redact sensitive req/response headers', async () => {
+    expect(
+      redactKeys({
+        'content-type': 'application/json',
+        authorization: 'Bearer Blah',
+        'x-access-token': 'bbb',
+        'x-api-key': 'ccc',
+        cookie: 'foo=bar',
+        'set-cookie': 'foo=bar; Secure; HttpOnly; SameSite=None',
+      })
+    ).toEqual({
+      authorization: '[REDACTED]',
+      'content-type': 'application/json',
+      cookie: '[REDACTED]',
+      'set-cookie': '[REDACTED]',
+      'x-access-token': '[REDACTED]',
+      'x-api-key': '[REDACTED]',
+    });
   });
 
   it('writes step errors to the top level', async () => {

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -167,9 +167,10 @@ const SANITIZE_HEADER_KEYS = [
   /^.*token.*$/i,
   /^.*session.*$/i,
   /^.*auth.*$/i,
+  /^cookie$/i,
   /^set\x2dcookie$/i,
 ];
-export function redactKeys(obj: Record<string, string>) {
+export function redactKeys(obj: Record<string, string> = {}) {
   const result = {};
   for (const key of Object.keys(obj)) {
     const shouldRedact = SANITIZE_HEADER_KEYS.some(regex => regex.test(key));
@@ -181,8 +182,12 @@ export function redactKeys(obj: Record<string, string>) {
 export function formatNetworkFields(network: NetworkInfo) {
   const { request, response, url, browser } = network;
   // Perform redaction on the headers before writing results
-  request.headers = redactKeys(request.headers);
-  response.headers = redactKeys(response.headers);
+  if (request?.headers) {
+    request.headers = redactKeys(request.headers);
+  }
+  if (response?.headers) {
+    response.headers = redactKeys(response.headers);
+  }
 
   const ecs = {
     // URL would be parsed and mapped by heartbeat

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -154,8 +154,36 @@ function formatTLS(tls: SecurityDetails) {
   };
 }
 
+/**
+ * List of wildcard header keys that should be sanitized/redacted from the request/response headers
+ *
+ * Spec followed by APM agent is used as a reference.
+ * https://github.com/elastic/apm/blob/36a5abd49ff156c80cf0c9e2e1eac919873cb18b/specs/agents/sanitization.md?plain=1#L27
+ */
+const SANITIZE_HEADER_KEYS = [
+  /^password$/i,
+  /^secret$/i,
+  /^.*key$/i,
+  /^.*token.*$/i,
+  /^.*session.*$/i,
+  /^.*auth.*$/i,
+  /^set\x2dcookie$/i,
+];
+export function redactKeys(obj: Record<string, string>) {
+  const result = {};
+  for (const key of Object.keys(obj)) {
+    const shouldRedact = SANITIZE_HEADER_KEYS.some(regex => regex.test(key));
+    result[key] = shouldRedact ? '[REDACTED]' : obj[key];
+  }
+  return result;
+}
+
 export function formatNetworkFields(network: NetworkInfo) {
   const { request, response, url, browser } = network;
+  // Perform redaction on the headers before writing results
+  request.headers = redactKeys(request.headers);
+  response.headers = redactKeys(response.headers);
+
   const ecs = {
     // URL would be parsed and mapped by heartbeat
     url,


### PR DESCRIPTION
+ fix #468 
+ Redacts some of the well known sensitive headers and other Access token related keys that might be accidentally captured by the agent when capturing network information. 
+ Cookies are already filtered out by Playwright, But we still get rid of Cookie and Set cookie for the request/response cycle to be on safer side. 