### PR TITLE
feat: add support for --config option in push command

### DIFF
--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -204,6 +204,7 @@ type BaseArgs = {
   params?: Params;
   screenshots?: ScreenshotOptions;
   dryRun?: boolean;
+  config?: string;
   pattern?: string;
   match?: string;
   tags?: Array<string>;
@@ -219,7 +220,6 @@ type BaseArgs = {
 };
 
 export type CliArgs = BaseArgs & {
-  config?: string;
   reporter?: BuiltInReporterName;
   inline?: boolean;
   require?: Array<string>;

--- a/src/options.ts
+++ b/src/options.ts
@@ -208,11 +208,17 @@ export function getCommonCommandOpts() {
     .env('SYNTHETICS_API_KEY')
     .makeOptionMandatory(true);
 
+  const configOpt = createOption(
+    '-c, --config <path>',
+    'configuration path (default: synthetics.config.js)'
+  );
+
   return {
     auth,
     authMandatory,
     params,
     playwrightOpts,
     pattern,
+    configOpt,
   };
 }


### PR DESCRIPTION
+ Add support for Push command that was not handling the `--config` option correctly. This PR fixed that and allows users to push the same journeys under different projects using different configuration file. 
```
> npx @elastic/synthetics push --config <synthetics.config.prod.ts>

> npx @elastic/synthetics push --config <synthetics.config.qa.ts>
```