### PR TITLE
feat: improve project scaffolding experience

### DIFF
--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -51,7 +51,6 @@ describe('Generator', () => {
         ...process.env,
         TEST_QUESTIONS: JSON.stringify({
           locations: ['us_east'],
-          auth: 'api_key',
           privateLocations: ['custom'],
           schedule: 30,
           id: 'test',
@@ -71,11 +70,6 @@ describe('Generator', () => {
     expect(existsSync(join(scaffoldDir, 'package.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, 'package-lock.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, '.gitignore'))).toBeTruthy();
-
-    // Verify push command
-    expect(
-      await readFile(join(scaffoldDir, 'package.json'), 'utf-8')
-    ).toContain('"push": "npx @elastic/synthetics push --auth api_key"');
 
     // Verify gitignore contents
     expect(await readFile(join(scaffoldDir, '.gitignore'), 'utf-8'))

--- a/__tests__/generator/index.test.ts
+++ b/__tests__/generator/index.test.ts
@@ -51,6 +51,7 @@ describe('Generator', () => {
         ...process.env,
         TEST_QUESTIONS: JSON.stringify({
           locations: ['us_east'],
+          auth: 'api_key',
           privateLocations: ['custom'],
           schedule: 30,
           id: 'test',
@@ -70,6 +71,11 @@ describe('Generator', () => {
     expect(existsSync(join(scaffoldDir, 'package.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, 'package-lock.json'))).toBeTruthy();
     expect(existsSync(join(scaffoldDir, '.gitignore'))).toBeTruthy();
+
+    // Verify push command
+    expect(
+      await readFile(join(scaffoldDir, 'package.json'), 'utf-8')
+    ).toContain('"push": "npx @elastic/synthetics push --auth api_key"');
 
     // Verify gitignore contents
     expect(await readFile(join(scaffoldDir, '.gitignore'), 'utf-8'))

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -287,12 +287,10 @@ All set, you can run below commands inside: ${this.projectDir}:
 
   Run synthetic tests: ${cyan(runCommand(this.pkgManager, 'test'))}
 
-  Push monitors to Kibana: ${cyan(
-    'SYNTHETICS_API_KEY=<value> ' + runCommand(this.pkgManager, 'push')
-  )}
+  Push monitors to Kibana: ${cyan(runCommand(this.pkgManager, 'push'))}
 
   ${yellow(
-    'Make sure to configure the SYNTHETICS_API_KEY before pushing monitors to Kibana.'
+    'Modify the API Key via `SYNTHETICS_API_KEY` env variable or --auth CLI flag.'
   )}
 
 Visit https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html to learn more.

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -45,7 +45,6 @@ import type { ProjectSettings } from '../common_types';
 const templateDir = join(__dirname, '..', '..', 'templates');
 
 type PromptOptions = ProjectSettings & {
-  auth: string;
   locations: Array<string>;
   privateLocations: Array<string>;
   schedule: number;
@@ -239,7 +238,7 @@ export class Generator {
     }
   }
 
-  async patchPkgJSON(answers: PromptOptions) {
+  async patchPkgJSON() {
     const filename = 'package.json';
     const pkgJSON = JSON.parse(
       await readFile(join(this.projectDir, filename), 'utf-8')
@@ -254,7 +253,7 @@ export class Generator {
     }
     // Add push command
     if (!pkgJSON.scripts.push) {
-      pkgJSON.scripts.push = `npx @elastic/synthetics push --auth ${answers.auth}`;
+      pkgJSON.scripts.push = `npx @elastic/synthetics push`;
     }
 
     await this.createFile(
@@ -287,10 +286,12 @@ All set, you can run below commands inside: ${this.projectDir}:
 
   Run synthetic tests: ${cyan(runCommand(this.pkgManager, 'test'))}
 
-  Push monitors to Kibana: ${cyan(runCommand(this.pkgManager, 'push'))}
+  Push monitors to Kibana: ${cyan(
+    'SYNTHETICS_API_KEY=<value> ' + runCommand(this.pkgManager, 'push')
+  )}
 
   ${yellow(
-    'Modify the API Key via `SYNTHETICS_API_KEY` env variable or --auth CLI flag.'
+    'Configure API Key via `SYNTHETICS_API_KEY` env variable or --auth CLI flag.'
   )}
 
 Visit https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html to learn more.
@@ -303,7 +304,7 @@ Visit https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.
     const answers = await this.questions();
     await this.package();
     await this.files(answers);
-    await this.patchPkgJSON(answers);
+    await this.patchPkgJSON();
     await this.patchGitIgnore();
     this.banner();
   }

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -61,7 +61,7 @@ export const REGULAR_FILES_PATH = [
 ];
 export const CONFIG_PATH = 'synthetics.config.ts';
 
-const IS_URL = new RegExp('^(https?:\\/\\/)?');
+const IS_URL = new RegExp('^(https?:\\/\\/)');
 
 export class Generator {
   pkgManager = 'npm';

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -88,10 +88,10 @@ export class Generator {
       message: 'Enter Elastic Kibana URL or Cloud ID',
       required: true,
       validate(value) {
-        if (!IS_URL.test(value)) {
-          value = cloudIDToKibanaURL(value);
-        }
         try {
+          if (!IS_URL.test(value)) {
+            value = cloudIDToKibanaURL(value);
+          }
           new URL(value);
           return true;
         } catch (e) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -184,14 +184,12 @@ export function getCommonCommandOpts() {
   const params = createOption(
     '-p, --params <jsonstring>',
     'JSON object that gets injected to all journeys'
-  );
-  params.argParser(JSON.parse);
+  ).argParser(JSON.parse);
 
   const playwrightOpts = createOption(
     '--playwright-options <jsonstring>',
     'JSON object to pass in custom Playwright options for the agent. Options passed will be merged with Playwright options defined in your synthetics.config.js file.'
-  );
-  playwrightOpts.argParser(JSON.parse);
+  ).argParser(JSON.parse);
 
   const pattern = createOption(
     '--pattern <pattern>',


### PR DESCRIPTION
+ fix https://github.com/elastic/synthetics/issues/906
+ Part of https://github.com/elastic/synthetics/issues/907
+ Adds support for validating both the Kibana URL or cloud.id and adds validation step if the given URL is invalid. 
+ Hides API key on the CLI prompt and adds the API Key to the push command