### PR TITLE
feat: support tags/match filtering in push

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -338,7 +338,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        filter: { match: 'j2' },
+        grepOpts: { match: 'j2' },
       })
     ).toMatchObject({
       j2: { status: 'succeeded' },
@@ -351,7 +351,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        filter: { match: 'j*' },
+        grepOpts: { match: 'j*' },
       })
     ).toMatchObject({
       j1: { status: 'succeeded' },
@@ -368,7 +368,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        filter: { tags: ['foo*'], match: 'j*' },
+        grepOpts: { tags: ['foo*'], match: 'j*' },
       })
     ).toMatchObject({
       j1: { status: 'succeeded' },
@@ -384,7 +384,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        filter: { tags: ['hello:b*'] },
+        grepOpts: { tags: ['hello:b*'] },
       })
     ).toMatchObject({
       j2: { status: 'succeeded' },
@@ -399,7 +399,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        filter: { tags: ['!hello:b*'] },
+        grepOpts: { tags: ['!hello:b*'] },
       })
     ).toMatchObject({
       j1: { status: 'succeeded' },
@@ -749,6 +749,7 @@ describe('runner', () => {
         throttling: { latency: 1000 },
         schedule: 1,
         alert: { status: { enabled: false } },
+        tags: [],
       });
     });
 
@@ -810,7 +811,7 @@ describe('runner', () => {
       });
     });
 
-    it('runner - build monitors filtered through "match"', async () => {
+    it('runner - build monitors filtered via "match"', async () => {
       const j1 = new Journey({ name: 'j1' }, noop);
       const j2 = new Journey({ name: 'j2' }, noop);
       runner.addJourney(j1);
@@ -818,14 +819,14 @@ describe('runner', () => {
 
       const monitors = runner.buildMonitors({
         ...options,
-        filter: { match: 'j1' },
+        grepOpts: { match: 'j1' },
         schedule: 1,
       });
       expect(monitors.length).toBe(1);
       expect(monitors[0].config.name).toBe('j1');
     });
 
-    it('runner - build monitors filtered through "tags"', async () => {
+    it('runner - build monitors with  via "tags"', async () => {
       const j1 = new Journey({ name: 'j1', tags: ['first'] }, noop);
       const j2 = new Journey({ name: 'j2', tags: ['second'] }, noop);
       const j3 = new Journey({ name: 'j3' }, noop);
@@ -835,11 +836,31 @@ describe('runner', () => {
 
       const monitors = runner.buildMonitors({
         ...options,
-        filter: { tags: ['first'] },
+        grepOpts: { tags: ['first'] },
         schedule: 1,
       });
       expect(monitors.length).toBe(1);
       expect(monitors[0].config.name).toBe('j1');
+    });
+
+    it('runner - build monitors with config and filter  via "tags"', async () => {
+      const j1 = new Journey({ name: 'j1', tags: ['first'] }, noop);
+      const j2 = new Journey({ name: 'j2', tags: ['second'] }, noop);
+      const j3 = new Journey({ name: 'j3' }, noop);
+      runner.addJourney(j1);
+      runner.addJourney(j2);
+      runner.addJourney(j3);
+      // using monitor.use
+      j2.updateMonitor({ tags: ['newtag'] });
+
+      const monitors = runner.buildMonitors({
+        ...options,
+        tags: ['newtag'],
+        grepOpts: { tags: ['newtag'] },
+        schedule: 1,
+      });
+      expect(monitors.length).toBe(2);
+      expect(monitors.map(m => m.config.name)).toEqual(['j2', 'j3']);
     });
   });
 

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -338,7 +338,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        match: 'j2',
+        filter: { match: 'j2' },
       })
     ).toMatchObject({
       j2: { status: 'succeeded' },
@@ -351,7 +351,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        match: 'j*',
+        filter: { match: 'j*' },
       })
     ).toMatchObject({
       j1: { status: 'succeeded' },
@@ -368,8 +368,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        tags: ['foo*'],
-        match: 'j*',
+        filter: { tags: ['foo*'], match: 'j*' },
       })
     ).toMatchObject({
       j1: { status: 'succeeded' },
@@ -385,7 +384,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        tags: ['hello:b*'],
+        filter: { tags: ['hello:b*'] },
       })
     ).toMatchObject({
       j2: { status: 'succeeded' },
@@ -400,7 +399,7 @@ describe('runner', () => {
     expect(
       await runner.run({
         ...defaultRunOptions,
-        tags: ['!hello:b*'],
+        filter: { tags: ['!hello:b*'] },
       })
     ).toMatchObject({
       j1: { status: 'succeeded' },
@@ -809,6 +808,38 @@ describe('runner', () => {
         throttling: { latency: 1000 },
         alert: { tls: { enabled: true } },
       });
+    });
+
+    it('runner - build monitors filtered through "match"', async () => {
+      const j1 = new Journey({ name: 'j1' }, noop);
+      const j2 = new Journey({ name: 'j2' }, noop);
+      runner.addJourney(j1);
+      runner.addJourney(j2);
+
+      const monitors = runner.buildMonitors({
+        ...options,
+        filter: { match: 'j1' },
+        schedule: 1,
+      });
+      expect(monitors.length).toBe(1);
+      expect(monitors[0].config.name).toBe('j1');
+    });
+
+    it('runner - build monitors filtered through "tags"', async () => {
+      const j1 = new Journey({ name: 'j1', tags: ['first'] }, noop);
+      const j2 = new Journey({ name: 'j2', tags: ['second'] }, noop);
+      const j3 = new Journey({ name: 'j3' }, noop);
+      runner.addJourney(j1);
+      runner.addJourney(j2);
+      runner.addJourney(j3);
+
+      const monitors = runner.buildMonitors({
+        ...options,
+        filter: { tags: ['first'] },
+        schedule: 1,
+      });
+      expect(monitors.length).toBe(1);
+      expect(monitors[0].config.name).toBe('j1');
     });
   });
 

--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -38,6 +38,7 @@ module.exports = env => {
       screenshot: 'off',
       schedule: 10,
       locations: ['us_east'],
+      tags: ['foo', 'bar'],
       privateLocations: ['test-location'],
       alert: {
         status: {

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -51,7 +51,7 @@ describe('options', () => {
     expect(await normalizeOptions(cliArgs)).toMatchObject({
       dryRun: true,
       environment: 'test',
-      filter: { match: 'check*' },
+      grepOpts: { match: 'check*' },
       params: {
         foo: 'bar',
         url: 'non-dev',

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -51,7 +51,7 @@ describe('options', () => {
     expect(await normalizeOptions(cliArgs)).toMatchObject({
       dryRun: true,
       environment: 'test',
-      match: 'check*',
+      filter: { match: 'check*' },
       params: {
         foo: 'bar',
         url: 'non-dev',
@@ -108,6 +108,7 @@ describe('options', () => {
       screenshots: 'only-on-failure',
       schedule: 3,
       privateLocations: ['test'],
+      tags: ['foo', 'bar'],
       locations: ['australia_east'],
       alert: {
         status: {

--- a/__tests__/push/__snapshots__/index.test.ts.snap
+++ b/__tests__/push/__snapshots__/index.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Push abort on tags and match 1`] = `
-"Aborted. Invalid CLI flags.
-
-Tags and Match are not supported in push command.
-"
-`;
-
 exports[`Push error on empty project id 1`] = `
 "Aborted. Invalid synthetics project settings.
 

--- a/__tests__/push/index.test.ts
+++ b/__tests__/push/index.test.ts
@@ -123,12 +123,6 @@ describe('Push', () => {
     expect(output).toContain('Push command Aborted');
   });
 
-  it('abort on tags and match', async () => {
-    await fakeProjectSetup({}, {});
-    const output = await runPush([...DEFAULT_ARGS, '--tags', 'foo:*']);
-    expect(output).toMatchSnapshot();
-  });
-
   it('error on invalid schedule in monitor DSL', async () => {
     await fakeProjectSetup(
       { id: 'test-project', space: 'dummy', url: 'http://localhost:8080' },

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -207,7 +207,7 @@ heartbeat.monitors:
       `);
       const monitors = await createLightweightMonitors(PROJECT_DIR, {
         ...opts,
-        filter: { pattern: '.yaml$' },
+        grepOpts: { pattern: '.yaml$' },
       });
       expect(monitors.length).toBe(0);
     });
@@ -236,7 +236,7 @@ heartbeat.monitors:
       expect(monitors.length).toBe(1);
     });
 
-    it('push - match filering', async () => {
+    it('push - match filter', async () => {
       await writeHBFile(`
 heartbeat.monitors:
 - type: http
@@ -250,13 +250,13 @@ heartbeat.monitors:
       `);
       const monitors = await createLightweightMonitors(PROJECT_DIR, {
         ...opts,
-        filter: { match: 'm1' },
+        grepOpts: { match: 'm1' },
       });
       expect(monitors.length).toBe(1);
       expect(monitors[0].config.name).toEqual('m1');
     });
 
-    it('push - tags filering', async () => {
+    it('push - tags filter', async () => {
       await writeHBFile(`
 heartbeat.monitors:
 - type: http
@@ -274,10 +274,33 @@ heartbeat.monitors:
       `);
       const monitors = await createLightweightMonitors(PROJECT_DIR, {
         ...opts,
-        filter: { tags: ['bar'] },
+        grepOpts: { tags: ['bar'] },
       });
       expect(monitors.length).toBe(2);
       expect(monitors.map(m => m.config.name)).toEqual(['m1', 'm2']);
+    });
+
+    it('push - apply tags config and also filter', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: http
+  name: "m1"
+  id: "mon1"
+  tags: ["foo"]
+- type: http
+  name: "m2"
+  id: "mon2"
+- type: http
+  name: "m3"
+  id: "mon3"
+      `);
+      const monitors = await createLightweightMonitors(PROJECT_DIR, {
+        ...opts,
+        tags: ['ltag'],
+        grepOpts: { tags: ['ltag'] },
+      });
+      expect(monitors.length).toBe(2);
+      expect(monitors.map(m => m.config.name)).toEqual(['m2', 'm3']);
     });
 
     it('prefer local monitor config', async () => {

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -207,7 +207,7 @@ heartbeat.monitors:
       `);
       const monitors = await createLightweightMonitors(PROJECT_DIR, {
         ...opts,
-        pattern: '.yaml$',
+        filter: { pattern: '.yaml$' },
       });
       expect(monitors.length).toBe(0);
     });
@@ -234,6 +234,50 @@ heartbeat.monitors:
       `);
       const monitors = await createLightweightMonitors(PROJECT_DIR, opts);
       expect(monitors.length).toBe(1);
+    });
+
+    it('push - match filering', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: http
+  name: "m1"
+  id: "mon1"
+  tags: "tag1"
+- type: http
+  name: "m2"
+  id: "mon2"
+  tags: "tag2"
+      `);
+      const monitors = await createLightweightMonitors(PROJECT_DIR, {
+        ...opts,
+        filter: { match: 'm1' },
+      });
+      expect(monitors.length).toBe(1);
+      expect(monitors[0].config.name).toEqual('m1');
+    });
+
+    it('push - tags filering', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: http
+  name: "m1"
+  id: "mon1"
+  tags: ["foo", "bar"]
+- type: http
+  name: "m2"
+  id: "mon2"
+  tags: ["bar", "baz"]
+- type: http
+  name: "m3"
+  id: "mon3"
+  tags: ["baz", "boom"]
+      `);
+      const monitors = await createLightweightMonitors(PROJECT_DIR, {
+        ...opts,
+        filter: { tags: ['bar'] },
+      });
+      expect(monitors.length).toBe(2);
+      expect(monitors.map(m => m.config.name)).toEqual(['m1', 'm2']);
     });
 
     it('prefer local monitor config', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,20 +56,25 @@ import { installTransform } from './core/transform';
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const { name, version } = require('../package.json');
 
-const { params, pattern, playwrightOpts, auth, authMandatory, configOpt } =
-  getCommonCommandOpts();
+const {
+  params,
+  pattern,
+  playwrightOpts,
+  auth,
+  authMandatory,
+  configOpt,
+  tags,
+  match,
+} = getCommonCommandOpts();
 
 program
   .name(`npx ${name}`)
   .usage('[options] [dir] [files] file')
   .addOption(configOpt)
   .addOption(pattern)
+  .addOption(tags)
+  .addOption(match)
   .addOption(params)
-  .option('--tags <name...>', 'run tests with a tag that matches the glob')
-  .option(
-    '--match <name>',
-    'run tests with a name or tags that matches the glob'
-  )
   .addOption(
     new Option('--reporter <value>', `output reporter format`).choices(
       Object.keys(reporters)
@@ -157,6 +162,7 @@ program
   .description(
     'Push all journeys in the current directory to create monitors within the Kibana monitor management UI'
   )
+  .addOption(authMandatory)
   .option(
     '--schedule <time-in-minutes>',
     "schedule in minutes for the pushed monitors. Setting `10`, for example, configures monitors which don't have an interval defined to run every 10 minutes.",
@@ -172,7 +178,7 @@ program
     '--private-locations <locations...>',
     'default list of private locations from which your monitors will run.'
   )
-  .option('--url <url>', 'Kibana URL to upload the monitors')
+  .option('--url <url>', 'Kibana URL to upload the project monitors')
   .option(
     '--id <id>',
     'project id that will be used for logically grouping monitors'
@@ -182,8 +188,10 @@ program
     'the target Kibana spaces for the pushed monitors — spaces help you organise pushed monitors.'
   )
   .option('-y, --yes', 'skip all questions and run non-interactively')
-  .addOption(authMandatory)
+
   .addOption(pattern)
+  .addOption(tags)
+  .addOption(match)
   .addOption(params)
   .addOption(playwrightOpts)
   .addOption(configOpt)

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -200,7 +200,7 @@ export type ThrottlingOptions = {
   latency?: number;
 };
 
-type CmdFilter = {
+type GrepOptions = {
   pattern?: string;
   tags?: Array<string>;
   match?: string;
@@ -221,7 +221,6 @@ type BaseArgs = {
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
-  filter?: CmdFilter;
 };
 
 export type CliArgs = BaseArgs & {
@@ -247,6 +246,7 @@ export type RunOptions = BaseArgs & {
   environment?: string;
   networkConditions?: NetworkConditions;
   reporter?: BuiltInReporterName | ReporterInstance;
+  grepOpts?: GrepOptions;
 };
 
 export type PushOptions = Partial<ProjectSettings> &
@@ -258,6 +258,7 @@ export type PushOptions = Partial<ProjectSettings> &
     alert?: AlertConfig;
     retestOnFailure?: MonitorConfig['retestOnFailure'];
     enabled?: boolean;
+    grepOpts?: GrepOptions;
   };
 
 export type ProjectSettings = {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -200,14 +200,18 @@ export type ThrottlingOptions = {
   latency?: number;
 };
 
+type CmdFilter = {
+  pattern?: string;
+  tags?: Array<string>;
+  match?: string;
+};
+
 type BaseArgs = {
   params?: Params;
   screenshots?: ScreenshotOptions;
   dryRun?: boolean;
   config?: string;
-  pattern?: string;
-  match?: string;
-  tags?: Array<string>;
+  auth?: string;
   outfd?: number;
   wsEndpoint?: string;
   pauseOnError?: boolean;
@@ -217,9 +221,13 @@ type BaseArgs = {
   schedule?: MonitorConfig['schedule'];
   locations?: MonitorConfig['locations'];
   privateLocations?: MonitorConfig['privateLocations'];
+  filter?: CmdFilter;
 };
 
 export type CliArgs = BaseArgs & {
+  pattern?: string;
+  match?: string;
+  tags?: Array<string>;
   reporter?: BuiltInReporterName;
   inline?: boolean;
   require?: Array<string>;
@@ -246,6 +254,7 @@ export type PushOptions = Partial<ProjectSettings> &
     auth: string;
     kibanaVersion?: string;
     yes?: boolean;
+    tags?: Array<string>;
     alert?: AlertConfig;
     retestOnFailure?: MonitorConfig['retestOnFailure'];
     enabled?: boolean;

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -439,7 +439,10 @@ export default class Runner {
       journey.callback({ params: options.params } as any);
       journey.monitor.update(this.monitor?.config);
       if (
-        !journey.monitor.isMatch(options.filter?.match, options.filter?.tags)
+        !journey.monitor.isMatch(
+          options.grepOpts?.match,
+          options.grepOpts?.tags
+        )
       ) {
         continue;
       }
@@ -462,7 +465,7 @@ export default class Runner {
       params: options.params,
     }).catch(e => (this.hookError = e));
 
-    const { dryRun, filter } = options;
+    const { dryRun, grepOpts } = options;
     /**
      * Skip other journeys when using `.only`
      */
@@ -479,7 +482,7 @@ export default class Runner {
         this.#reporter.onJourneyRegister?.(journey);
         continue;
       }
-      if (!journey.isMatch(filter?.match, filter?.tags) || journey.skip) {
+      if (!journey.isMatch(grepOpts?.match, grepOpts?.tags) || journey.skip) {
         continue;
       }
       const journeyResult: JourneyResult = this.hookError

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -33,7 +33,7 @@ import {
   Params,
   PlaywrightOptions,
 } from '../common_types';
-import { indent } from '../helpers';
+import { indent, isMatch } from '../helpers';
 import { LocationsMap } from '../locations/public-locations';
 
 export type SyntheticsLocationsType = keyof typeof LocationsMap;
@@ -127,6 +127,18 @@ export class Monitor {
    */
   setFilter(filter: MonitorFilter) {
     this.filter = filter;
+  }
+
+  /**
+   * Matches monitors based on the provided args. Proitize tags over match
+   */
+  isMatch(matchPattern: string, tagsPattern: Array<string>) {
+    return isMatch(
+      this.config.tags,
+      this.config.name,
+      tagsPattern,
+      matchPattern
+    );
   }
 
   /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -47,7 +47,7 @@ export async function normalizeOptions(
    * Move filtering flags from the top level to filter object
    * and delete the old keys
    */
-  const filter = {
+  const grepOpts = {
     pattern: cliArgs.pattern,
     tags: cliArgs.tags,
     match: cliArgs.match,
@@ -58,7 +58,7 @@ export async function normalizeOptions(
 
   const options: RunOptions = {
     ...cliArgs,
-    filter,
+    grepOpts,
     environment: process.env['NODE_ENV'] || 'development',
   };
   /**

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -167,8 +167,8 @@ export async function createLightweightMonitors(
 ) {
   const lwFiles = new Set<string>();
   // Filter monitor files based on the provided pattern
-  const pattern = options.filter?.pattern
-    ? new RegExp(options.filter?.pattern, 'i')
+  const pattern = options.grepOpts?.pattern
+    ? new RegExp(options.grepOpts?.pattern, 'i')
     : /.(yml|yaml)$/;
   const ignore = /(node_modules|.github)/;
   await totalist(workDir, (rel, abs) => {
@@ -227,7 +227,7 @@ export async function createLightweightMonitors(
          * and perform the match based on the provided filters
          */
         const mon = buildMonitorFromYaml(monitor, options);
-        if (!mon.isMatch(options.filter?.match, options.filter?.tags)) {
+        if (!mon.isMatch(options.grepOpts?.match, options.grepOpts?.tags)) {
           continue;
         }
         mon.setSource({ file, line, column: col });


### PR DESCRIPTION
+ Part of https://github.com/elastic/synthetics/issues/910
+ Filtering in push via tags/match has been asked a lot both externally and internally as it makes it easier for the users to control the monitors getting pushed to Kibana. We have [intentionally made the decision](https://github.com/elastic/synthetics/issues/780) to not support it, mainly because monitors were deleted behind the scenes when users pushed monitors with different tags. We [improved deletion flow](https://github.com/elastic/synthetics/pull/912) and requires explicit approval from the user before all the monitors gets deleted, Also the monitors deleted are shown to the user if `DEBUG=synthetics` flag is enabled. 
+ PR adds support for filtering monitors via `--tags and --match` CLI flags in addition to the undocumented `--pattern` field. It behaves similar to the journey test runner which is used for filtering the journeys when running locally. 

```sh
// filter monitor names 
npx @elastic/synthetics --match "foo*"

// filter monitor with tags

npx @elastic/synthetics --tags "env:qa, env:staging"
```

+ Users can tag the monitors/journeys in different ways and its still supported and backwards compatible. 
```ts
// tag on the journey level
journey({name: "using journey param", tags: ["env:qa"], async(){})

// tag using monitor.use API
journey("using monitor API", async(){
  monitor.use({ tags: ["env:qa"]})
  step("blah", () => {})
})

// global tags via Synthetics.config.ts
export default () => {
  return {
    monitor: {
      tags: ["env:dev"]
    }
  }
};
```

Lightweight monitors
```yaml
heartbeat.monitors:
  - type: http
    enabled: true
    name: google.com
    id: google-1
    urls: ["google.com."]
    tags: ["env:qa"]
```