### PR TITLE
fix: avoid consuming kibana response twice

### DIFF
--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -80,11 +80,11 @@ export async function handleError(
     throw formatNotFoundError(url, await body.text());
   } else if (!ok(statusCode)) {
     let parsed: APIError;
-    const resp = await body.text();
     try {
+      const resp = await body.text();
       parsed = JSON.parse(resp) as APIError;
     } catch (e) {
-      throw formatAPIError(statusCode, 'unexpected non-JSON error', resp);
+      throw formatAPIError(statusCode, 'unexpected error', e.message);
     }
     throw formatAPIError(statusCode, parsed.error, parsed.message);
   }

--- a/src/push/request.ts
+++ b/src/push/request.ts
@@ -80,14 +80,11 @@ export async function handleError(
     throw formatNotFoundError(url, await body.text());
   } else if (!ok(statusCode)) {
     let parsed: APIError;
+    const resp = await body.text();
     try {
-      parsed = (await body.json()) as APIError;
+      parsed = JSON.parse(resp) as APIError;
     } catch (e) {
-      throw formatAPIError(
-        statusCode,
-        'unexpected non-JSON error',
-        await body.text()
-      );
+      throw formatAPIError(statusCode, 'unexpected non-JSON error', resp);
     }
     throw formatAPIError(statusCode, parsed.error, parsed.message);
   }


### PR DESCRIPTION
+ fix #920 
+ Underlying error was triggered from Undici HTTP client when we consume the Response body twice during the error scenario, This hides the error message and throws the default TypeError instead. Copying docs from undici
```
Note: Once a mixin has been called then the body cannot be reused, thus calling additional mixins on .body, e.g. .body.json(); .body.text() will result in an error TypeError: unusable being thrown and returned through the Promise rejection.


```