### PR TITLE
chore: fix provenance validation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "pre-commit": "lint-staged"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elastic/synthetics.git"
+  },
+  "keywords": ["elastic", "synthetics", "monitoring", "testing"],
   "author": "",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
+ We introduced provenance https://github.com/elastic/synthetics/pull/919 during the publishing phase which fails with validation error - https://github.com/elastic/synthetics/actions/runs/8942914195/job/24566505353
```
npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@elastic%2fsynthetics - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/elastic/synthetics" from provenance
```