### PR TITLE
fix: log screenshot errors in debug mode

### DIFF
--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -102,19 +102,17 @@ export default class Runner {
   }
 
   async captureScreenshot(page: Driver['page'], step: Step) {
-    const buffer = await page
-      .screenshot({
+    try {
+      const buffer = await page.screenshot({
         type: 'jpeg',
         quality: 80,
         timeout: 5000,
       })
-      .catch(() => {});
-    /**
-     * Write the screenshot image buffer with additional details (step
-     * information) which could be extracted at the end of
-     * each journey without impacting the step timing information
-     */
-    if (buffer) {
+      /**
+       * Write the screenshot image buffer with additional details (step
+       * information) which could be extracted at the end of
+       * each journey without impacting the step timing information
+       */
       const fileName = `${generateUniqueId()}.json`;
       const screenshot: Screenshot = {
         step,
@@ -126,6 +124,9 @@ export default class Runner {
         JSON.stringify(screenshot)
       );
       log(`Runner: captured screenshot for (${step.name})`);
+    } catch (_) {
+      // Screenshot may fail sometimes, log and continue.
+      log(`Runner: failed to capture screenshot for (${step.name})`);
     }
   }
 

--- a/src/plugins/tracing.ts
+++ b/src/plugins/tracing.ts
@@ -38,7 +38,7 @@ export type TraceOptions = {
  * https://chromedevtools.github.io/devtools-protocol/tot/Tracing/
  */
 export class Tracing {
-  constructor(private driver: Driver, private options: TraceOptions) {}
+  constructor(private driver: Driver, private options: TraceOptions) { }
 
   async start() {
     log(`Plugins: started collecting trace events`);

--- a/src/sdk/trace-processor.ts
+++ b/src/sdk/trace-processor.ts
@@ -140,7 +140,7 @@ export class TraceProcessor extends LighthouseTraceProcessor {
         metrics: perfMetrics,
       };
     } catch (e) {
-      log(e);
+      log(`Plugins: error processing trace events: ${e}`);
       return {};
     }
   }


### PR DESCRIPTION
+ Sometimes the page gets crashed during the screenshot events, making it really hard to debug whats happening with the Journey/Steps. This is fixed already in the PW v1.45 - https://github.com/microsoft/playwright/issues/28995#issuecomment-2167261979. PR just adds a debug log event when screenshot fails to get captured for some reason and makes it easier to see whats happening during page crash events. 