### PR TITLE
feat: support configurable chunk size

### DIFF
--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -61,6 +61,11 @@ import {
 import { log } from '../core/logger';
 
 export async function push(monitors: Monitor[], options: PushOptions) {
+  if (parseInt(process.env.CHUNK_SIZE) > 250) {
+    throw error(
+      'Invalid CHUNK_SIZE. CHUNK_SIZE must be less than or equal to 250'
+    );
+  }
   const duplicates = trackDuplicates(monitors);
   if (duplicates.size > 0) {
     throw error(formatDuplicateError(duplicates));
@@ -218,8 +223,9 @@ export function validateSettings(opts: PushOptions) {
   - CLI '--schedule <mins>'
   - Config file 'monitors.schedule' field`;
   } else if (opts.schedule && !ALLOWED_SCHEDULES.includes(opts.schedule)) {
-    reason = `Set default schedule(${opts.schedule
-      }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
+    reason = `Set default schedule(${
+      opts.schedule
+    }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
   }
 
   if (!reason) return;

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -223,9 +223,8 @@ export function validateSettings(opts: PushOptions) {
   - CLI '--schedule <mins>'
   - Config file 'monitors.schedule' field`;
   } else if (opts.schedule && !ALLOWED_SCHEDULES.includes(opts.schedule)) {
-    reason = `Set default schedule(${
-      opts.schedule
-    }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
+    reason = `Set default schedule(${opts.schedule
+      }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
   }
 
   if (!reason) return;

--- a/src/push/kibana_api.ts
+++ b/src/push/kibana_api.ts
@@ -24,7 +24,7 @@
  */
 
 import { PushOptions } from '../common_types';
-import { safeNDJSONParse } from '../helpers';
+import { safeNDJSONParse, error } from '../helpers';
 import { MonitorHashID, MonitorSchema } from './monitor';
 import {
   formatFailedMonitors,
@@ -39,7 +39,7 @@ import { generateURL } from './utils';
 // Default chunk size for bulk put / delete
 export const CHUNK_SIZE = parseInt(process.env.CHUNK_SIZE) || 100;
 if (CHUNK_SIZE > 250) {
-  throw new Error(
+  throw error(
     'Invalid CHUNK_SIZE. CHUNK_SIZE must be less than or equal to 250'
   );
 }

--- a/src/push/kibana_api.ts
+++ b/src/push/kibana_api.ts
@@ -24,7 +24,7 @@
  */
 
 import { PushOptions } from '../common_types';
-import { safeNDJSONParse, error } from '../helpers';
+import { safeNDJSONParse } from '../helpers';
 import { MonitorHashID, MonitorSchema } from './monitor';
 import {
   formatFailedMonitors,
@@ -38,11 +38,6 @@ import { generateURL } from './utils';
 
 // Default chunk size for bulk put / delete
 export const CHUNK_SIZE = parseInt(process.env.CHUNK_SIZE) || 100;
-if (CHUNK_SIZE > 250) {
-  throw error(
-    'Invalid CHUNK_SIZE. CHUNK_SIZE must be less than or equal to 250'
-  );
-}
 
 export type PutResponse = {
   createdMonitors: string[];

--- a/src/push/kibana_api.ts
+++ b/src/push/kibana_api.ts
@@ -37,7 +37,12 @@ import {
 import { generateURL } from './utils';
 
 // Default chunk size for bulk put / delete
-export const CHUNK_SIZE = 100;
+export const CHUNK_SIZE = parseInt(process.env.CHUNK_SIZE) || 100;
+if (CHUNK_SIZE > 250) {
+  throw new Error(
+    'Invalid CHUNK_SIZE. CHUNK_SIZE must be less than or equal to 250'
+  );
+}
 
 export type PutResponse = {
   createdMonitors: string[];


### PR DESCRIPTION
Adds an environment variable to configure chunk size when pushing monitors to Kibana.

### Testing
1. Create a test project
2. Check out this PR. Run `npm install` then `npm run build`.
3. Run npm link
4. Check out the directory for the test project
5. run npm link @elastic/synthetics
6. Run `CHUNK_SIZE=1 SYNTHETICS_API_KEY=MXhmQURwRUI1UGtRakt5TW5zWk46VWtFTWJrbE9RMjZTdFBrRVpFd190Zw== npm run push`
7. Watch as only 1 monitor is pushed at a time

