### PR TITLE
ci: use obltmachine for tagging and creating the release in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+
+      - uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       - run: npm ci # runs npm prepublish
 
       - name: configure NPMJS token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ on:
         default: false
 
 permissions:
-  contents: write # needed to push the tag and create the release
   id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
@@ -40,7 +39,7 @@ jobs:
       - run: npx semantic-release --dry-run="${DRY_RUN}"
         env:
           DRY_RUN: ${{ github.event.inputs.dry-run }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Get version and package name
         run: |


### PR DESCRIPTION
Due to the introduction of tag rulesets, the github-actions[bot] cannot bypass the rule and thus cannot push a tag.
Hence, we use @obltmachine, who is on the bypasser list, to create the release.