### PR TITLE
ci: update test-reporter workflow

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -18,9 +18,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
+      - uses: elastic/oblt-actions/test-report@v1
         with:
-          artifact: test-results
-          name: ${{ github.event.workflow_run.name }}-test-report
+          artifact: /test-results(.*)/
+          name: '${{ github.event.workflow_run.name }} - Test Report $1'
           path: "**/junit*.xml"
           reporter: java-junit


### PR DESCRIPTION
This can be updated and re-enabled since https://github.com/elastic/synthetics/pull/950 and https://github.com/elastic/synthetics/pull/951