### PR TITLE
ci: use pull-request event

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,7 +1,7 @@
 name: pr-title-lint
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types:


### PR DESCRIPTION
We enabled this to validate the PR listing in the title always.

However, I cannot think of what's the reason we cannot protect ourselves and use `Require approval for all outside collaborators` as we do in the other workflows.

Any genuine reasons, we need to run always regardless the code is not tested until the PR has been approved?