### PR TITLE
fix: ignore missing location on cert check

### DIFF
--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -223,11 +223,10 @@ export function validateSettings(opts: PushOptions) {
   - CLI '--schedule <mins>'
   - Config file 'monitors.schedule' field`;
   } else if (opts.schedule && !ALLOWED_SCHEDULES.includes(opts.schedule)) {
-    reason = `Set default schedule(${
-      opts.schedule
-    }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
+    reason = `Set default schedule(${opts.schedule
+      }) to one of the allowed values - ${ALLOWED_SCHEDULES.join(',')}`;
   } else if (
-    opts.locations.length > 0 &&
+    (opts.locations ?? []).length > 0 &&
     (opts?.playwrightOptions?.clientCertificates ?? []).filter(cert => {
       return cert.certPath || cert.keyPath || cert.pfxPath;
     }).length > 0


### PR DESCRIPTION
+ fix #968
+ Location will be `empty` when setting just the privateLocations property. 