### PR TITLE
feat: support service.name property for tests

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -82,6 +82,7 @@ describe('Monitors', () => {
       enabled: true,
       hash: expect.any(String),
       locations: ['europe-west2-a', 'australia-southeast1-a'],
+      'service.name': 'test-service',
       privateLocations: ['germany'],
       fields: { area: 'website' },
     });
@@ -99,6 +100,7 @@ describe('Monitors', () => {
       hash: expect.any(String), // hash is dynamic based on the file path
       locations: ['europe-west2-a', 'australia-southeast1-a'],
       privateLocations: ['germany'],
+      'service.name': 'test-service',
       content: expect.any(String),
       filter: {
         match: 'test',

--- a/__tests__/utils/test-config.ts
+++ b/__tests__/utils/test-config.ts
@@ -40,6 +40,7 @@ export function createTestMonitor(filename: string, type = 'browser') {
     type,
     schedule: 10,
     enabled: true,
+    serviceName: 'test-service',
     locations: ['united_kingdom', 'australia_east'],
     privateLocations: ['germany'],
     fields: { area: 'website' },
@@ -53,21 +54,31 @@ export function createTestMonitor(filename: string, type = 'browser') {
   return monitor;
 }
 
-export function tJourney(status: StatusValue = "succeeded", duration = 0, error?: Error) {
-  const jj = journey('j1', () => { });
+export function tJourney(
+  status: StatusValue = 'succeeded',
+  duration = 0,
+  error?: Error
+) {
+  const jj = journey('j1', () => {});
   jj.status = status;
   jj.duration = duration;
   jj.error = error;
-  return jj
+  return jj;
 }
 
-export function tStep(status: StatusValue = "succeeded", duration = 0, error?: Error, url?: string, name?: string) {
+export function tStep(
+  status: StatusValue = 'succeeded',
+  duration = 0,
+  error?: Error,
+  url?: string,
+  name?: string
+) {
   const ss = step(name ?? 's1', noop);
   ss.status = status;
   ss.duration = duration;
   ss.error = error;
   ss.url = url;
-  return ss
+  return ss;
 }
 
 export class CLIMock {
@@ -81,7 +92,7 @@ export class CLIMock {
   private stderrStr = '';
   exitCode: Promise<number>;
 
-  constructor(public debug: boolean = false) { }
+  constructor(public debug: boolean = false) {}
 
   args(a: string[]): CLIMock {
     this.cliArgs.push(...a);

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -263,6 +263,7 @@ export type PushOptions = Partial<ProjectSettings> &
     retestOnFailure?: MonitorConfig['retestOnFailure'];
     enabled?: boolean;
     grepOpts?: GrepOptions;
+    serviceName?: string;
   };
 
 export type ProjectSettings = {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -443,6 +443,7 @@ export default class Runner implements RunnerInfo {
       retestOnFailure: options.retestOnFailure,
       enabled: options.enabled,
       fields: options.fields,
+      serviceName: options.serviceName,
     });
 
     const monitors: Monitor[] = [];

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -63,6 +63,7 @@ export type MonitorConfig = {
   enabled?: boolean;
   locations?: SyntheticsLocationsType[];
   privateLocations?: string[];
+  serviceName?: string;
   /**
    * @deprecated This option is ignored.
    * Network throttling via chrome devtools is ignored at the moment.

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -134,7 +134,7 @@ export async function buildMonitorSchema(monitors: Monitor[], isV2: boolean) {
   const bundlePath = join(SYNTHETICS_PATH, 'bundles');
   await mkdir(bundlePath, { recursive: true });
   const bundler = new Bundler();
-  const schemas: MonitorSchema[] = [];
+  const schemas: MonitorAPISchema[] = [];
 
   for (const monitor of monitors) {
     const { source, config, filter, type } = monitor;


### PR DESCRIPTION
This PR allows the association of APM service names with monitors, as allowed by plain heartbeat. I think something isn't quite right though as trying this against a real cluster I didn't see that value set. Marking this as a draft for now. 