### PR TITLE
feat: introduce totp command for OTP token

### DIFF
--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -93,7 +93,7 @@ describe('CLI', () => {
     });
 
     it('generate mfa totp token', async () => {
-      const cli = new CLIMock(true)
+      const cli = new CLIMock()
         .stdin(
           `step('gen mfa totp', async () => {
           const token = mfa.totp('FLIIOLP3IR3W');

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -491,4 +491,24 @@ describe('CLI', () => {
       });
     });
   });
+
+  describe('TOTP token', () => {
+    async function runTotp(args) {
+      const cli = new CLIMock()
+        .args(['totp', ...args])
+        .run({});
+      await cli.exitCode;
+      return cli.stderr();
+    }
+
+    it('error when secret is not provided', async () => {
+      const output = await runTotp('');
+      expect(output).toContain(`error: missing required argument 'secret'`);
+    });
+
+    it('generates otp token', async () => {
+      const output = await runTotp('FLIIOLP3IR3W');
+      expect(output).toContain('OTP Token: ');
+    });
+  });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -286,7 +286,7 @@ program
       const token = totp(secret, cmdOpts)
       write(bold(`OTP Token: ${token}`));
     } catch (e) {
-      e && error(e);
+      error(e);
       process.exit(1);
     }
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -278,7 +278,7 @@ program
 // TOTP command
 program
   .command('totp <secret>')
-  .description('Generate a Time-based One-Time token using the secret key')
+  .description('Generate a Time-based One-Time token using the provided secret.')
   .option('--issuer <issuer>', 'Provider or Service the secret is associated with.')
   .option('--label <label>', 'Account Identifier (default: SyntheticsTOTP)')
   .action((secret, cmdOpts: TOTPCmdOptions) => {

--- a/src/core/mfa.ts
+++ b/src/core/mfa.ts
@@ -60,6 +60,11 @@ type TOTPOptions = {
   period?: number
 };
 
+export type TOTPCmdOptions = {
+  issuer?: string
+  label?: string
+};
+
 export function totp(secret?: string, options: TOTPOptions = {}) {
   return new TOTP({ label: "SyntheticsTOTP", secret, ...options }).generate();
 }


### PR DESCRIPTION
+ Part of https://github.com/elastic/synthetics-dev/issues/367
+ Goes together with https://github.com/elastic/synthetics/pull/957 and makes the onboarding to the MFA based auth easier. 
+ Introduces a `totp` command that lets users generate a OTP token based on the provided secret that can be used to onboard the Synthetics TOTP generator to other providers. 

```ts
npx @elastic/synthetics totp secret --issuer <issuer> --label <label>

// prints
OTP Token: 123456

```

Documentation will be covered as part of https://github.com/elastic/observability-docs/issues/4334