### PR TITLE
fix: adding warning when pushing monitors from yaml files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/babel__code-frame": "^7.0.3",
         "@types/jest": "^28.1.8",
         "@types/micromatch": "^4.0.9",
-        "@types/node": "~18.19.63",
+        "@types/node": "^18.19.63",
         "@types/semver": "^7",
         "@types/stack-utils": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.38.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "source-map-support": "^0.5.21",
         "stack-utils": "^2.0.6",
         "undici": "^5.28.3",
+        "utf-8-validate": "^6.0.4",
         "yaml": "^2.2.2"
       },
       "bin": {
@@ -10233,6 +10234,16 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -16121,6 +16132,18 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.4.tgz",
+      "integrity": "sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "source-map-support": "^0.5.21",
         "stack-utils": "^2.0.6",
         "undici": "^5.28.3",
-        "utf-8-validate": "^6.0.4",
         "yaml": "^2.2.2"
       },
       "bin": {
@@ -44,7 +43,7 @@
         "@types/babel__code-frame": "^7.0.3",
         "@types/jest": "^28.1.8",
         "@types/micromatch": "^4.0.9",
-        "@types/node": "^16.11.59",
+        "@types/node": "~18.19.63",
         "@types/semver": "^7",
         "@types/stack-utils": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
@@ -4321,10 +4320,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.59.tgz",
-      "integrity": "sha512-6u+36Dj3aDzhfBVUf/mfmc92OEdzQ2kx2jcXGdigfl70E/neV21ZHE6UCz4MDzTRcVqGAM27fk+DLXvyDsn3Jw==",
-      "dev": true
+      "version": "18.19.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.63.tgz",
+      "integrity": "sha512-hcUB7THvrGmaEcPcvUZCZtQ2Z3C+UR/aOcraBLCvTsFMh916Gc1kCCYcfcMuB76HM2pSerxl1PoP3KnmHzd9Lw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -10234,16 +10236,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -16038,6 +16030,12 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/unique-string": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -16132,18 +16130,6 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.4.tgz",
-      "integrity": "sha512-xu9GQDeFp+eZ6LnCywXN/zBancWvOpUMzgjLPSjy4BRHSmTelvn2E0DG0o1sTiw5hkCKBHo8rwSKncfRfv2EEQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/babel__code-frame": "^7.0.3",
     "@types/jest": "^28.1.8",
     "@types/micromatch": "^4.0.9",
-    "@types/node": "~18.19.63",
+    "@types/node": "^18.19.63",
     "@types/semver": "^7",
     "@types/stack-utils": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.38.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "source-map-support": "^0.5.21",
     "stack-utils": "^2.0.6",
     "undici": "^5.28.3",
+    "utf-8-validate": "^6.0.4",
     "yaml": "^2.2.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "source-map-support": "^0.5.21",
     "stack-utils": "^2.0.6",
     "undici": "^5.28.3",
-    "utf-8-validate": "^6.0.4",
     "yaml": "^2.2.2"
   },
   "devDependencies": {
@@ -82,7 +81,7 @@
     "@types/babel__code-frame": "^7.0.3",
     "@types/jest": "^28.1.8",
     "@types/micromatch": "^4.0.9",
-    "@types/node": "^16.11.59",
+    "@types/node": "~18.19.63",
     "@types/semver": "^7",
     "@types/stack-utils": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.38.0",

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -28,7 +28,7 @@ import { extname, join } from 'path';
 import { LineCounter, parseDocument, Document, YAMLSeq, YAMLMap } from 'yaml';
 import { bold, red } from 'kleur/colors';
 import { Bundler } from './bundler';
-import utf8Validate from 'utf-8-validate';
+import NodeBuffer from 'node:buffer';
 import { SYNTHETICS_PATH, totalist, indent, warn } from '../helpers';
 import { LocationsMap } from '../locations/public-locations';
 import {
@@ -187,10 +187,10 @@ export async function createLightweightMonitors(
   for (const file of lwFiles.values()) {
     // First check encoding and warn if any files are not the correct encoding.
     const bufferContent = await readFile(file);
-    const isUtf8 = utf8Validate(bufferContent);
+    const isUtf8 = NodeBuffer.isUtf8(bufferContent);
     if (!isUtf8) {
       warn(
-        `${file} is not UTF-8 encoded. Monitor configurations in this file might be ignored.`
+        `file ${file} is not encoded in utf-8.  utf-8 encoding is expected.  Monitor configurations in this file may be ignored.`
       );
     }
     const content = bufferContent.toString('utf-8');

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -189,9 +189,7 @@ export async function createLightweightMonitors(
     const bufferContent = await readFile(file);
     const isUtf8 = NodeBuffer.isUtf8(bufferContent);
     if (!isUtf8) {
-      warn(
-        `file ${file} is not encoded in utf-8.  utf-8 encoding is expected.  Monitor configurations in this file may be ignored.`
-      );
+      warn(`${file} is not UTF-8 encoded. Monitors might be skipped.`);
     }
     const content = bufferContent.toString('utf-8');
     const lineCounter = new LineCounter();

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -228,7 +228,7 @@ export async function createLightweightMonitors(
       // Skip browser monitors from the YML files
       if (monitor['type'] === 'browser') {
         warn(
-          `a monitor with type 'browser' was detected in file ${file}.  'browser type monitors are not supported.  Monitor will be skipped.`
+          `Browser monitors from ${file} are skipped.`
         );
         continue;
       }

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -190,7 +190,7 @@ export async function createLightweightMonitors(
     const isUtf8 = utf8Validate(bufferContent);
     if (!isUtf8) {
       warn(
-        `file ${file} is not encoded in utf-8.  utf-8 encoding is expected.  Monitor configurations in this file may be ignored.`
+        `${file} is not UTF-8 encoded. Monitor configurations in this file might be ignored.`
       );
     }
     const content = bufferContent.toString('utf-8');


### PR DESCRIPTION
+ fixes #976 
Added warnings to npx push for scenarios where monitors are silently ignored.  See #976 
