### PR TITLE
fix: omit playwright-core from bundles !!

### DIFF
--- a/src/push/bundler.ts
+++ b/src/push/bundler.ts
@@ -51,7 +51,7 @@ export class Bundler {
         write: false,
         minifyWhitespace: true,
         sourcemap: 'inline',
-        external: ['@elastic/synthetics'],
+        external: ['@elastic/synthetics', 'playwright-core'],
         plugins: [SyntheticsBundlePlugin()],
       },
     };


### PR DESCRIPTION
we have usage of playwright-core in internal monitors, which ends up bundling along. 