### PR TITLE
feat: export types from playwright-core 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export type {
   BrowserContext,
 } from 'playwright-core';
 
-export type { devices, request } from 'playwright-core';
+export { devices, request } from 'playwright-core';
 
 export type { Serializable } from 'playwright-core/types/structs';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,13 +57,8 @@ export type {
   APIRequestContext,
   APIResponse,
   APIRequest,
-  Browser,
-  BrowserContext,
 } from 'playwright-core';
-
 export { devices, request } from 'playwright-core';
-
-export type { Serializable } from 'playwright-core/types/structs';
 
 /**
  * Export the types necessary to write custom reporters
@@ -79,7 +74,6 @@ export type {
   JourneyResult,
   StepResult,
   StartEvent,
-  Params,
 } from './common_types';
 
 export type {
@@ -99,5 +93,3 @@ export type {
   Steps,
   actionTitle,
 } from './formatter/javascript';
-
-export { log } from './core/logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export type {
   JourneyResult,
   StepResult,
   StartEvent,
+  Params,
 } from './common_types';
 
 export type {
@@ -98,3 +99,5 @@ export type {
   Steps,
   actionTitle,
 } from './formatter/javascript';
+
+export { log } from './core/logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,15 @@ export type {
   ChromiumBrowserContext,
   CDPSession,
   APIRequestContext,
-  devices,
+  APIResponse,
+  APIRequest,
+  Browser,
+  BrowserContext,
 } from 'playwright-core';
+
+export type { devices, request } from 'playwright-core';
+
+export type { Serializable } from 'playwright-core/types/structs';
 
 /**
  * Export the types necessary to write custom reporters


### PR DESCRIPTION
export types from playwright-core  !!

Tested a simple journey 
```

import { journey, step, monitor, request } from '@elastic/synthetics';

journey(`My Example Journey playwrgiht`, ({ page }) => {
  monitor.use({
    locations: ['us_central'],
    enabled: false,
  });
  step('launch application', async () => {
    const context = await request.newContext();
    await page.goto('http://google.com');
  });
});
```