### PR TITLE
fix: expose running journey as currentJourney

### DIFF
--- a/__tests__/core/index.test.ts
+++ b/__tests__/core/index.test.ts
@@ -54,7 +54,7 @@ it('add journeys to runner', () => {
 
   expect(j.name).toBe(name);
   expect(j.id).toBe(name);
-  expect(runner.journey).toEqual(j);
+  expect(runner.currentJourney).toEqual(j);
   expect(runner.journeys.length).toBe(1);
 });
 
@@ -63,10 +63,10 @@ it('add steps to journeys', () => {
   const s1 = step('step1', noop);
   const s2 = step('step2', noop);
 
-  expect(runner.journey).toEqual(j);
+  expect(runner.currentJourney).toEqual(j);
   expect(runner.journeys.length).toBe(1);
-  expect(runner.journey?.steps.length).toBe(2);
-  expect(runner.journey?.steps).toEqual([s1, s2]);
+  expect(runner.currentJourney?.steps.length).toBe(2);
+  expect(runner.currentJourney?.steps).toEqual([s1, s2]);
 });
 
 it('add hooks to journeys', () => {
@@ -74,11 +74,11 @@ it('add hooks to journeys', () => {
   before(noop);
   after(noop);
 
-  expect(runner.journey).toEqual(j);
+  expect(runner.currentJourney).toEqual(j);
   expect(runner.journeys.length).toBe(1);
-  expect(runner.journey?.steps.length).toBe(0);
-  expect(runner.journey?._getHook("before")).toEqual([noop]);
-  expect(runner.journey?._getHook("after")).toEqual([noop]);
+  expect(runner.currentJourney?.steps.length).toBe(0);
+  expect(runner.currentJourney?._getHook("before")).toEqual([noop]);
+  expect(runner.currentJourney?._getHook("after")).toEqual([noop]);
 });
 
 it('add hooks - error on before/after outside journey context', () => {

--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -181,12 +181,12 @@ describe('runner', () => {
     const error = new Error('Broken step');
     const j1 = journey('fail-journey-with-hooks', () => {
       before(({ info }) => {
-        expect(info.journey?.status).toBe('pending');
+        expect(info.currentJourney?.status).toBe('pending');
       });
       after(({ info }) => {
-        expect(info.journey?.status).toBe('failed');
-        expect(info.journey?.error).toBe(error);
-        expect(info.journey?.duration).toBeGreaterThan(0);
+        expect(info.currentJourney?.status).toBe('failed');
+        expect(info.currentJourney?.error).toBe(error);
+        expect(info.currentJourney?.duration).toBeGreaterThan(0);
       });
       step('step1', () => { throw error });
     });
@@ -201,11 +201,11 @@ describe('runner', () => {
   it('run journey - expose info in journey', async () => {
     const j1 = journey('with info', ({ info }) => {
       step('step1', () => {
-        expect(info.journey?.status).toBe('pending');
+        expect(info.currentJourney?.status).toBe('pending');
       });
       after(({ info }) => {
-        expect(info.journey?.status).toBe('succeeded');
-        expect(info.journey?.duration).toBeGreaterThan(0);
+        expect(info.currentJourney?.status).toBe('succeeded');
+        expect(info.currentJourney?.duration).toBeGreaterThan(0);
       })
     });
     const result = await runner._runJourney(j1, defaultRunOptions);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -64,7 +64,7 @@ const createStep = (type?: 'skip' | 'soft' | 'only') =>
   wrapFnWithLocation(
     (location: Location, name: string, callback: VoidCallback) => {
       log(`Step register: ${name}`);
-      const step = runner.journey?._addStep(name, callback, location);
+      const step = runner.currentJourney?._addStep(name, callback, location);
       if (type) {
         step[type] = true;
       }
@@ -83,8 +83,8 @@ export const monitor = {
      * If the context is inside journey, then set it to journey context
      * otherwise set to the global monitor which will be used for all journeys
      */
-    if (runner.journey) {
-      runner.journey._updateMonitor(config);
+    if (runner.currentJourney) {
+      runner.currentJourney._updateMonitor(config);
     } else {
       runner._updateMonitor(config);
     }
@@ -100,15 +100,15 @@ export const afterAll = (callback: HooksCallback) => {
 };
 
 export const before = (callback: HooksCallback) => {
-  if (!runner.journey) {
+  if (!runner.currentJourney) {
     throw new Error('before is called outside of the journey context');
   }
-  return runner.journey._addHook('before', callback);
+  return runner.currentJourney._addHook('before', callback);
 };
 
 export const after = (callback: HooksCallback) => {
-  if (!runner.journey) {
+  if (!runner.currentJourney) {
     throw new Error('after is called outside of the journey context');
   }
-  return runner.journey._addHook('after', callback);
+  return runner.currentJourney._addHook('after', callback);
 };

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -66,7 +66,7 @@ export interface RunnerInfo {
   /**
    * Currently active journey
    */
-  readonly journey: Journey | undefined;
+  readonly currentJourney: Journey | undefined;
   /**
    * All registerd journeys
    */
@@ -86,7 +86,7 @@ export default class Runner implements RunnerInfo {
   #monitor?: Monitor;
   config: RunOptions;
 
-  get journey() {
+  get currentJourney() {
     return this.#currentJourney;
   }
 


### PR DESCRIPTION
+ Some libraries depend on this private variables, so renaming it to the previous value to make things easier. 