### PR TITLE
feat: run pushed monitors locally in dry-run mode

### DIFF
--- a/__tests__/push/bundler.test.ts
+++ b/__tests__/push/bundler.test.ts
@@ -25,7 +25,7 @@
 
 import { createReadStream } from 'fs';
 import { writeFile, unlink, mkdir, rm } from 'fs/promises';
-import unzipper from 'unzipper';
+import unzip from 'unzip-stream';
 import { join } from 'path';
 import { generateTempPath } from '../../src/helpers';
 import { Bundler } from '../../src/push/bundler';
@@ -74,11 +74,10 @@ async function validateZip(content) {
   await writeFile(pathToZip, decoded);
 
   const files: Array<string> = [];
-
   let contents = '';
   await new Promise(r => {
     createReadStream(pathToZip)
-      .pipe(unzipper.Parse())
+      .pipe(unzip.Parse())
       .on('entry', function (entry) {
         files.push(entry.path);
         contents += '\n' + entry.path + '\n';

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -70,11 +70,11 @@ describe('Monitors', () => {
   });
 
   it('build lightweight monitor schema', async () => {
-    const schema = await buildMonitorSchema(
+    const { schemas } = await buildMonitorSchema(
       [createTestMonitor('heartbeat.yml', 'http')],
       true
     );
-    expect(schema[0]).toEqual({
+    expect(schemas[0]).toEqual({
       id: 'test-monitor',
       name: 'test',
       schedule: 10,
@@ -89,8 +89,8 @@ describe('Monitors', () => {
 
   it('build browser monitor schema', async () => {
     const monitor = createTestMonitor('example.journey.ts');
-    const schema = await buildMonitorSchema([monitor], true);
-    expect(schema[0]).toEqual({
+    const { schemas } = await buildMonitorSchema([monitor], true);
+    expect(schemas[0]).toEqual({
       id: 'test-monitor',
       name: 'test',
       schedule: 10,
@@ -106,9 +106,9 @@ describe('Monitors', () => {
       fields: { area: 'website' },
     });
     monitor.update({ locations: ['brazil'], fields: { env: 'dev' } });
-    const schema1 = await buildMonitorSchema([monitor], true);
-    expect(schema1[0].hash).not.toEqual(schema[0].hash);
-    expect(schema1[0].fields).toEqual({
+    const { schemas: schemas1 } = await buildMonitorSchema([monitor], true);
+    expect(schemas1[0].hash).not.toEqual(schemas[0].hash);
+    expect(schemas1[0].fields).toEqual({
       area: 'website',
       env: 'dev',
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "source-map-support": "^0.5.21",
         "stack-utils": "^2.0.6",
         "undici": "^5.28.3",
+        "unzip-stream": "^0.3.4",
         "yaml": "^2.2.2"
       },
       "bin": {
@@ -58,8 +59,7 @@
         "rimraf": "^3.0.2",
         "semantic-release": "^21.1.1",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.1.6",
-        "unzipper": "^0.10.11"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">=18.20.3"
@@ -5123,20 +5123,10 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dev": true,
       "dependencies": {
         "buffers": "~0.1.1",
         "chainsaw": "~0.1.0"
@@ -5144,12 +5134,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -5244,20 +5228,10 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/buffers": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.2.0"
       }
@@ -5334,7 +5308,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dev": true,
       "dependencies": {
         "traverse": ">=0.3.0 <0.4"
       },
@@ -5343,10 +5316,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -5401,10 +5375,11 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -6939,33 +6914,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -9668,12 +9616,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
-      "dev": true
-    },
     "node_modules/listr2": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.8.2.tgz",
@@ -10157,8 +10099,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -10186,7 +10127,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -15106,12 +15046,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
-    },
     "node_modules/sharp": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -15807,7 +15741,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -16066,22 +15999,14 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unzipper": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
-      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
-      "dev": true,
+    "node_modules/unzip-stream": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.4.tgz",
+      "integrity": "sha512-PyofABPVv+d7fL7GOpusx7eRT9YETY2X04PhwbSipdj6bMxVCFJrr+nm0Mxqbf9hUiTin/UsnuFWBXlDZFy0Cw==",
+      "license": "MIT",
       "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "source-map-support": "^0.5.21",
     "stack-utils": "^2.0.6",
     "undici": "^5.28.3",
+    "unzip-stream": "^0.3.4",
     "yaml": "^2.2.2"
   },
   "devDependencies": {
@@ -96,8 +97,7 @@
     "rimraf": "^3.0.2",
     "semantic-release": "^21.1.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.1.6",
-    "unzipper": "^0.10.11"
+    "typescript": "^5.1.6"
   },
   "overrides": {
     "follow-redirects": "^1.15.6",

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -34,4 +34,16 @@ if (!global[SYNTHETICS_RUNNER]) {
   global[SYNTHETICS_RUNNER] = new Runner();
 }
 
+/**
+ * Set debug based on DEBUG ENV and namespace - synthetics
+ */
+if (process.env.DEBUG && process.env.DEBUG.includes('synthetics')) {
+  process.env['__SYNTHETICS__DEBUG__'] = '1';
+}
+
 export const runner: Runner = global[SYNTHETICS_RUNNER];
+
+// is Debug mode enabled
+export function inDebugMode() {
+  return !!process.env['__SYNTHETICS__DEBUG__'];
+}

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -25,16 +25,10 @@
 
 import { grey, cyan, dim, italic } from 'kleur/colors';
 import { now } from '../helpers';
-
-/**
- * Set debug based on DEBUG ENV and namespace - synthetics
- */
-if (process.env.DEBUG && process.env.DEBUG.includes('synthetics')) {
-  process.env['__SYNTHETICS__DEBUG__'] = '1';
-}
+import { inDebugMode } from './globals';
 
 export function log(msg) {
-  if (!process.env['__SYNTHETICS__DEBUG__'] || !msg) {
+  if (!inDebugMode() || !msg) {
     return;
   }
   if (typeof msg === 'object') {

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -88,7 +88,7 @@ export class Monitor {
   content?: string;
   source?: Location;
   filter: MonitorFilter;
-  constructor(public config: MonitorConfig = {}) {}
+  constructor(public config: MonitorConfig = {}) { }
   /**
    * Treat the creation time config with `monitor.use` as source of truth by
    * merging the values coming from CLI and Synthetics config file
@@ -156,6 +156,13 @@ export class Monitor {
       .update(this.content || '')
       .update(this.source?.file || '')
       .digest('base64');
+  }
+
+  /**
+   * Returns the size of the monitor in bytes which is sent as payload to Kibana
+   */
+  size() {
+    return JSON.stringify(this).length
   }
 
   validate() {

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -88,7 +88,7 @@ export class Monitor {
   content?: string;
   source?: Location;
   filter: MonitorFilter;
-  constructor(public config: MonitorConfig = {}) { }
+  constructor(public config: MonitorConfig = {}) {}
   /**
    * Treat the creation time config with `monitor.use` as source of truth by
    * merging the values coming from CLI and Synthetics config file
@@ -162,7 +162,7 @@ export class Monitor {
    * Returns the size of the monitor in bytes which is sent as payload to Kibana
    */
   size() {
-    return JSON.stringify(this).length
+    return JSON.stringify(this).length;
   }
 
   validate() {

--- a/src/push/bundler.ts
+++ b/src/push/bundler.ts
@@ -53,7 +53,7 @@ export class Bundler {
     if (result.errors.length > 0) {
       throw result.errors;
     }
-    return result.outputFiles[0].text
+    return result.outputFiles[0].text;
   }
 
   async zip(source: string, code: string, dest: string) {

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -188,7 +188,7 @@ export function formatDuplicateError(monitors: Set<Monitor>) {
   let inner = '';
   for (const monitor of monitors) {
     const { config, source } = monitor;
-    inner += `* ${config.id} - ${source.file}:${source.line}:${source.column} \n`;
+    inner += `* ${config.id} - ${source.file}:${source.line}:${source.column}\n`;
   }
   outer += indent(inner);
   return outer;

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -60,7 +60,8 @@ import {
   logGroups,
   printBytes,
 } from './utils';
-import { run } from "./run-local"
+import { runLocal } from "./run-local"
+import { inDebugMode } from '../core/globals';
 
 
 export async function push(monitors: Monitor[], options: PushOptions) {
@@ -95,7 +96,7 @@ export async function push(monitors: Monitor[], options: PushOptions) {
     remote
   );
   logDiff(newIDs, changedIDs, removedIDs, unchangedIDs);
-  if (options.dryRun) {
+  if (inDebugMode()) {
     logGroups(sizes, newIDs, changedIDs, removedIDs, unchangedIDs);
     // show bundle size for the whole project
     let totalSize = 0;
@@ -103,7 +104,11 @@ export async function push(monitors: Monitor[], options: PushOptions) {
       totalSize += value;
     }
     progress("total size of the monitors payload is " + printBytes(totalSize));
-    await run(schemas);
+  }
+
+  if (options.dryRun) {
+    progress('Running browser monitors in dry run mode');
+    await runLocal(schemas);
     progress('Dry run completed');
     return;
   }

--- a/src/push/index.ts
+++ b/src/push/index.ts
@@ -60,9 +60,8 @@ import {
   logGroups,
   printBytes,
 } from './utils';
-import { runLocal } from "./run-local"
+import { runLocal } from './run-local';
 import { inDebugMode } from '../core/globals';
-
 
 export async function push(monitors: Monitor[], options: PushOptions) {
   if (parseInt(process.env.CHUNK_SIZE) > 250) {
@@ -103,7 +102,7 @@ export async function push(monitors: Monitor[], options: PushOptions) {
     for (const value of sizes.values()) {
       totalSize += value;
     }
-    progress("total size of the monitors payload is " + printBytes(totalSize));
+    progress('total size of the monitors payload is ' + printBytes(totalSize));
   }
 
   if (options.dryRun) {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -154,7 +154,9 @@ export async function buildMonitorSchema(monitors: Monitor[], isV2: boolean) {
     const size = monitor.size();
     const sizeKB = Math.round(size / 1000);
     if (sizeKB > SIZE_LIMIT_KB) {
-      let outer = bold(`Aborted: Bundled code ${sizeKB}kB exceeds the recommended ${SIZE_LIMIT_KB}kB limit. Please check the dependencies imported.\n`);
+      let outer = bold(
+        `Aborted: Bundled code ${sizeKB}kB exceeds the recommended ${SIZE_LIMIT_KB}kB limit. Please check the dependencies imported.\n`
+      );
       const inner = `* ${config.id} - ${source.file}:${source.line}:${source.column}\n`;
       outer += indent(inner);
       throw red(outer);

--- a/src/push/run-local.ts
+++ b/src/push/run-local.ts
@@ -1,0 +1,139 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import { execFileSync, spawn } from "child_process";
+import { MonitorSchema } from "./monitor";
+import { rm, writeFile } from "fs/promises";
+import { createReadStream } from "fs";
+import { Extract } from "unzip-stream"
+
+async function unzipFile(zipPath, destination) {
+  return new Promise<void>((resolve, reject) => {
+    createReadStream(zipPath)
+      .pipe(Extract({ path: destination }))
+      .on('close', resolve)
+      .on('error', (err) => {
+        reject(new Error(`failed to extract zip ${zipPath} : ${err.message}`));
+      });
+  });
+}
+
+async function runNpmInstall(directory) {
+  return new Promise<void>((resolve, reject) => {
+    const flags = [
+      "--no-audit",           // Prevent audit checks
+      "--no-update-notifier", // Prevent update checks
+      "--no-fund",            // No need for package funding messages here
+      "--package-lock=false", // no need to write package lock here
+      "--progress=false",     // no need to display progress
+    ]
+
+    const npmInstall = spawn('npm', ['install', ...flags],
+      { cwd: directory, stdio: 'ignore' });
+    npmInstall.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`npm install failed with exit code ${code}`));
+      }
+    });
+    npmInstall.on('error', (err) => {
+      reject(new Error(`Failed to start npm install: ${err.message}`));
+    });
+  });
+}
+
+async function runTest(directory, schema: MonitorSchema) {
+  return new Promise<void>((resolve, reject) => {
+    const runTest = spawn('npx', [
+      '@elastic/synthetics',
+      '.',
+      '--playwright-options',
+      JSON.stringify(schema.playwrightOptions),
+      '--params',
+      JSON.stringify(schema.params),
+    ], {
+      cwd: directory, stdio: 'inherit'
+    });
+
+    runTest.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      }
+      else {
+        reject(new Error(`Exited with code ${code}`));
+      }
+    });
+
+    runTest.on('error', (err) => {
+      reject(new Error(`Failed to execute @elastic/synthetics : ${err.message}`));
+    });
+  })
+}
+
+async function writePkgJSON(dir: string) {
+  // lookup installed bin path of a node module
+  const resolvedPath = execFileSync('which', ['elastic-synthetics'], { encoding: 'utf8' }).trim();
+  const installedPath = resolvedPath.replace("bin/elastic-synthetics", "lib/node_modules/@elastic/synthetics")
+
+  const packageJsonContent = {
+    name: "project-journey",
+    private: "true",
+    dependencies: {
+      "@elastic/synthetics": `file:${installedPath}`,
+    },
+  };
+  await writeFile(`${dir}/package.json`, JSON.stringify(packageJsonContent, null, 2), "utf-8");
+}
+
+
+async function extractAndRun(schema: MonitorSchema) {
+  if (schema.type !== "browser") {
+    return;
+  }
+  const content = schema.content;
+  const fileName = Date.now();
+  const zipPath = `/tmp/synthetics-zip-${fileName}.zip`;
+  const unzipPath = `/tmp/synthetics-unzip-${fileName}`;
+  try {
+    await writeFile(zipPath, content, "base64");
+    await unzipFile(zipPath, unzipPath);
+    await writePkgJSON(unzipPath);
+    await runNpmInstall(unzipPath);
+    await runTest(unzipPath, schema);
+  } catch (err) {
+    // console.error(err);
+  } finally {
+    await rm(zipPath, { recursive: true, force: true });
+    await rm(unzipPath, { recursive: true, force: true });
+  }
+}
+
+export async function run(schemas: MonitorSchema[]) {
+  for (const schema of schemas) {
+    await extractAndRun(schema);
+  }
+}
+

--- a/src/push/run-local.ts
+++ b/src/push/run-local.ts
@@ -111,15 +111,16 @@ export async function runLocal(schemas: MonitorSchema[]) {
   // lookup installed bin path of a node module
   const resolvedPath = execFileSync('which', ['elastic-synthetics'], { encoding: 'utf8' }).trim();
   const synthPath = resolvedPath.replace("bin/elastic-synthetics", "lib/node_modules/@elastic/synthetics")
-  const filename = Date.now();
-  const zipPath = `/tmp/synthetics-zip-${filename}.zip`;
-  const unzipPath = `/tmp/synthetics-unzip-${filename}`;
+  const rand = Date.now();
+  const zipPath = `/tmp/synthetics-zip-${rand}.zip`;
+  const unzipPath = `/tmp/synthetics-unzip-${rand}`;
   try {
     for (const schema of schemas) {
       await extract(schema, zipPath, unzipPath);
     }
     await writePkgJSON(unzipPath, synthPath);
     await runNpmInstall(unzipPath);
+    // TODO: figure out a way to collect all params and Playwright options
     await runTest(unzipPath, schemas[0]);
   } catch (e) {
     throw red(`Aborted: ${e.message}`);

--- a/src/push/utils.ts
+++ b/src/push/utils.ts
@@ -56,10 +56,15 @@ export function logGroups<T extends Set<string>>(
   logGroup(sizes, 'Updated', changedIDs, yellow);
   logGroup(sizes, 'Removed', removedIDs, red);
   logGroup(sizes, 'Unchanged', unchangedIDs, grey);
-  console.groupEnd()
+  console.groupEnd();
 }
 
-function logGroup(sizes: Map<string, number>, name: string, ids: Set<string>, color: Colorize) {
+function logGroup(
+  sizes: Map<string, number>,
+  name: string,
+  ids: Set<string>,
+  color: Colorize
+) {
   if (ids.size === 0) return;
   // under collapsed group, so giving 2 space for padding
   printLine(process.stdout.columns - 2);
@@ -71,22 +76,18 @@ function logGroup(sizes: Map<string, number>, name: string, ids: Set<string>, co
 }
 
 function printLine(length: number = process.stdout.columns) {
-  console.log(grey("-").repeat(length));
+  console.log(grey('-').repeat(length));
 }
 
-const BYTE_UNITS = [
-  'B',
-  'kB',
-  'MB',
-  'GB',
-  'TB',
-  'PB',
-];
+const BYTE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB', 'PB'];
 export function printBytes(bytes: number) {
   if (bytes <= 0) return '0 B';
-  const exponent = Math.min(Math.floor(Math.log10(bytes) / 3), BYTE_UNITS.length - 1);
+  const exponent = Math.min(
+    Math.floor(Math.log10(bytes) / 3),
+    BYTE_UNITS.length - 1
+  );
   bytes /= 1000 ** exponent;
-  return `${(bytes.toFixed(1))} ${BYTE_UNITS[exponent]}`;
+  return `${bytes.toFixed(1)} ${BYTE_UNITS[exponent]}`;
 }
 
 export function getChunks<T>(arr: Array<T>, size: number): Array<T[]> {

--- a/src/push/utils.ts
+++ b/src/push/utils.ts
@@ -61,6 +61,7 @@ export function logGroups<T extends Set<string>>(
 
 function logGroup(sizes: Map<string, number>, name: string, ids: Set<string>, color: Colorize) {
   if (ids.size === 0) return;
+  // under collapsed group, so giving 2 space for padding
   printLine(process.stdout.columns - 2);
   console.groupCollapsed(color(bold(name)));
   [...ids].forEach(id => {


### PR DESCRIPTION
+ fix https://github.com/elastic/synthetics/issues/973 and https://github.com/elastic/synthetics/issues/929
+ Setting `DEBUG=synthetics` will provides detailed information like Monitor size, overall project size and monitors that were added/deleted/updated etc. 
+ With `--dry-run`, we have the ability to now run these monitors similar to how it would be run inside the Synthetics Public/Private managed locations. 

<img width="841" alt="Screenshot 2024-12-19 at 4 17 52 PM" src="https://github.com/user-attachments/assets/49174ab1-b58b-466b-ab1e-fc41814798f4" />

