### PR TITLE
chore: print error when parsing synthetics.config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,7 @@ function readAndParseConfig(configPath) {
     const requiredModule = require(configPath);
     return interopRequireDefault(requiredModule).default;
   } catch (e) {
-    throw new Error('Unable to read synthetics config: ' + configPath);
+    throw new Error('Unable to read synthetics config: ' + configPath + '\n' + e);
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,9 @@ function readAndParseConfig(configPath) {
     const requiredModule = require(configPath);
     return interopRequireDefault(requiredModule).default;
   } catch (e) {
-    throw new Error('Unable to read synthetics config: ' + configPath + '\n' + e);
+    throw new Error(
+      'Unable to read synthetics config: ' + configPath + '\n' + e
+    );
   }
 }
 


### PR DESCRIPTION
When `synthetics.config.ts` throws an error, `config.ts` doesn't give any clue about the root cause, it's better if we can print the original thrown `Error`.