### PR TITLE
fix: add fields for browser monitors via config !!

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -787,6 +787,7 @@ describe('runner', () => {
         tags: ['g1', 'g2'],
         alert: { tls: { enabled: true } },
         playwrightOptions: { ignoreHTTPSErrors: true },
+        fields: { area: 'website' },
       });
 
       const j1 = new Journey({ name: 'j1', tags: ['foo*'] }, noop);
@@ -822,6 +823,7 @@ describe('runner', () => {
         throttling: { download: 100, latency: 20, upload: 50 },
         alert: { tls: { enabled: true } },
         retestOnFailure: true,
+        fields: { area: 'website' },
       });
       expect(monitors[1].config).toMatchObject({
         locations: ['us_east'],

--- a/__tests__/fixtures/synthetics.config.ts
+++ b/__tests__/fixtures/synthetics.config.ts
@@ -49,7 +49,7 @@ module.exports = env => {
         },
       },
       fields: {
-        area: 'website',
+        fromConfig: 'website',
       },
     },
   };

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -92,7 +92,7 @@ describe('options', () => {
         },
       },
       fields: {
-        area: 'website',
+        fromConfig: 'website',
       },
     });
 
@@ -126,7 +126,6 @@ describe('options', () => {
       },
       fields: {
         env: 'dev',
-        area: 'website',
       },
     });
   });

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -31,6 +31,7 @@ import {
   createLightweightMonitors,
   diffMonitors,
   parseAlertConfig,
+  parseFields,
   parseSchedule,
 } from '../../src/push/monitor';
 import { Server } from '../utils/server';
@@ -619,6 +620,61 @@ heartbeat.monitors:
         tls: { enabled: true },
       });
       expect(config).toEqual({});
+    });
+  });
+
+  describe('parseFields', () => {
+    it('extracts fields from config and removes them', () => {
+      const config = {
+        'fields.label1': 'value1',
+        'fields.label2': 'value2',
+        otherKey: 'otherValue',
+      };
+
+      const result = parseFields(config as any);
+
+      expect(result).toEqual({ label1: 'value1', label2: 'value2' });
+      expect(config).toEqual({ otherKey: 'otherValue' }); // Ensure fields were deleted
+    });
+
+    it('merges global fields into parsed fields', () => {
+      const config = {
+        'fields.label1': 'value1',
+      };
+      const gFields = {
+        label2: 'globalValue',
+        label3: 'anotherGlobalValue',
+      };
+
+      const result = parseFields(config as any, gFields);
+
+      expect(result).toEqual({
+        label1: 'value1',
+        label2: 'globalValue',
+        label3: 'anotherGlobalValue',
+      });
+    });
+
+    it('returns only global fields if no config fields exist', () => {
+      const config = {
+        otherKey: 'otherValue',
+      };
+      const gFields = {
+        label1: 'globalValue',
+      };
+
+      const result = parseFields(config as any, gFields);
+
+      expect(result).toEqual({ label1: 'globalValue' });
+    });
+
+    it('returns undefined if no fields exist', () => {
+      const config = {
+        otherKey: 'otherValue',
+      };
+      const result = parseFields(config as any);
+
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -442,6 +442,7 @@ export default class Runner implements RunnerInfo {
       alert: options.alert,
       retestOnFailure: options.retestOnFailure,
       enabled: options.enabled,
+      fields: options.fields,
     });
 
     const monitors: Monitor[] = [];


### PR DESCRIPTION
Fields were not being added via local config for browser monitors !!

reported via https://discuss.elastic.co/t/monitor-fields-ignored-for-browser-monitors-and-monitor-tags-are-not-merged/374559