### PR TITLE
chore: dependabot: add npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   # GitHub actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    reviewers:
-      - "elastic/observablt-ci"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -14,3 +12,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Add npm ecosystem.
Remove reviewers, it's not supported anymore. 

There are some examples of how other teams use it:
- https://github.com/elastic/apm-agent-nodejs/blob/main/.github/dependabot.yml
