### PR TITLE
chore(deps): Bump undici version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "sonic-boom": "^3.3.0",
         "source-map-support": "^0.5.21",
         "stack-utils": "^2.0.6",
-        "undici": "^5.28.5",
+        "undici": "^5.29.0",
         "unzip-stream": "^0.3.4",
         "yaml": "^2.2.2"
       },
@@ -15648,9 +15648,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "sonic-boom": "^3.3.0",
     "source-map-support": "^0.5.21",
     "stack-utils": "^2.0.6",
-    "undici": "^5.28.5",
+    "undici": "^5.29.0",
     "unzip-stream": "^0.3.4",
     "yaml": "^2.2.2"
   },


### PR DESCRIPTION
### Summary

Bump `undici` to 5.29.0.