### PR TITLE
Unset SYNTHETICS_API_KEY before tests to ensure clean test env

### DIFF
--- a/__tests__/utils/jest-global-setup.ts
+++ b/__tests__/utils/jest-global-setup.ts
@@ -27,6 +27,14 @@ import { spawn } from 'child_process';
 import { wsEndpoint } from './test-config';
 
 module.exports = async () => {
+  // Unset the SYNTHETICS_API_KEY to ensure it doesn't affect tests
+  if (process.env.SYNTHETICS_API_KEY) {
+    console.log(
+      '\nUnsetting SYNTHETICS_API_KEY environment variable for tests'
+    );
+    delete process.env.SYNTHETICS_API_KEY;
+  }
+
   if (wsEndpoint) {
     return new Promise((resolve, reject) => {
       console.log(`\nRunning BrowserService ${wsEndpoint}`);


### PR DESCRIPTION
After more hours than I'd care to admit debugging bizarre test failures I discovered the issue was that I often have SYNTHETICS_API_KEY set locally. That causes many functional tests to fail, where they assume the user has no auth specified etc.