### PR TITLE
chore(ci): update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
+    cooldown:
+      days: 14
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
 Dependabot is configured per repo so we need your help to ensure that when “npm” is the package ecosystem that we set a cooldown to 14 days. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown- 

