### PR TITLE
feat: trusted publishers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           cache: npm
           node-version-file: .nvmrc
@@ -26,8 +26,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           cache: npm
           node-version-file: .nvmrc
@@ -42,8 +42,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           cache: npm
           node-version-file: .nvmrc
@@ -60,8 +60,8 @@ jobs:
       - build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           cache: npm
           node-version-file: .nvmrc

--- a/.github/workflows/dist-tag.yml
+++ b/.github/workflows/dist-tag.yml
@@ -21,6 +21,9 @@ jobs:
       VERSION: ${{ github.event.inputs.version }}
       DIST_TAG: ${{ github.event.inputs.dist-tag }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for OIDC and provenance (npm publish)
     steps:
       - uses: actions/checkout@v4
 
@@ -40,9 +43,6 @@ jobs:
             echo "Dist tag input '${DIST_TAG}' is not a valid dist-tag"
             exit 1 ;;
           esac
-
-      - name: configure NPMJS token
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
 
       - name: NPM dist-tag
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,14 @@ on:
         default: false
 
 permissions:
-  id-token: write # to enable use of OIDC for npm provenance
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_PROVENANCE: true
+    permissions:
+      contents: read
+      id-token: write # required for OIDC and provenance (npm publish)
     steps:
       - name: Get token
         id: get_token
@@ -34,7 +35,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.get_token.outputs.token }}
@@ -43,10 +44,12 @@ jobs:
         with:
           github-token: ${{ steps.get_token.outputs.token }}
 
-      - run: npm ci # runs npm prepublish
+      - uses: actions/setup-node@v5
+        with:
+          cache: npm
+          node-version-file: .nvmrc
 
-      - name: configure NPMJS token
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      - run: npm ci # runs npm prepublish
 
       - run: npx semantic-release --dry-run="${DRY_RUN}"
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -6,13 +6,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
-      }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        "publishCmd": "npm publish"
+        "npmPublish": true
       }
     ],
     "@semantic-release/github"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
       "devDependencies": {
         "@commitlint/cli": "^17.7.1",
         "@commitlint/config-conventional": "^17.7.0",
-        "@semantic-release/exec": "^6.0.3",
         "@types/babel__code-frame": "^7.0.3",
         "@types/jest": "^28.1.8",
         "@types/micromatch": "^4.0.9",
@@ -3328,35 +3327,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@semantic-release/exec": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
-      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
-      "dev": true,
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "parse-json": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@semantic-release/github": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
-    "@semantic-release/exec": "^6.0.3",
     "@types/babel__code-frame": "^7.0.3",
     "@types/jest": "^28.1.8",
     "@types/micromatch": "^4.0.9",
@@ -109,5 +108,9 @@
   },
   "engines": {
     "node": ">=18.20.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
### What

- Bump checkout and nodejs actions
- Use package.json with the provenance by default
- Remove exec plugin added https://github.com/elastic/synthetics/pull/829 no more TOTP is needed
- Remove adhoc configuration with `NPM_TOKEN`
- See https://docs.npmjs.com/trusted-publishers

### Why

Tidy up and use OIDC, improve our security posture by following the best practices

### Further details
That's already done in some other projects:
- https://github.com/elastic/elastic-otel-node/pull/1063
- https://github.com/elastic/apm-agent-nodejs/pull/4794

### Tasks

- [ ] Configure trusted publisher


### Question

- How to test this out?