### PR TITLE
chore: add missing openat2 to seccomp profiles

### DIFF
--- a/.ci/seccomp_profile.json
+++ b/.ci/seccomp_profile.json
@@ -241,6 +241,7 @@
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",

--- a/examples/docker/seccomp_profile.json
+++ b/examples/docker/seccomp_profile.json
@@ -241,6 +241,7 @@
 				"_newselect",
 				"open",
 				"openat",
+				"openat2",
 				"pause",
 				"pipe",
 				"pipe2",


### PR DESCRIPTION
### Summary

Fixes e2e jobs by adding the missing `openat2` call to seccomp profiles.