### PR TITLE
feat: Add minutes-only timeout parameter to monitor config and format for Kibana

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -121,6 +121,22 @@ describe('Monitors', () => {
     });
   });
 
+  it('formats timeout as string with minutes suffix', async () => {
+    const monitor = createTestMonitor('example.journey.ts');
+    // Add timeout to the monitor config
+    monitor.update({ timeout: 5 });
+    const { schemas } = await buildMonitorSchema([monitor], true);
+    // Timeout should be formatted as "5m" for 5 minutes
+    expect(schemas[0].timeout).toBe('5m');
+  });
+
+  it('omits timeout when not specified', async () => {
+    const monitor = createTestMonitor('example.journey.ts');
+    const { schemas } = await buildMonitorSchema([monitor], true);
+    // Timeout should be undefined when not specified
+    expect(schemas[0].timeout).toBeUndefined();
+  });
+
   it('parse @every schedule format', async () => {
     expect(() => parseSchedule('* * * *')).toThrowError(
       `Monitor schedule format(* * * *) not supported: use '@every' syntax instead`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ const {
   match,
   fields,
   maintenanceWindows,
+  timeout,
 } = getCommonCommandOpts();
 
 program
@@ -234,6 +235,7 @@ program
   .addOption(playwrightOpts)
   .addOption(configOpt)
   .addOption(maintenanceWindows)
+  .addOption(timeout)
   .action(async cmdOpts => {
     cmdOpts = { ...cmdOpts, ...program.opts() };
     const workDir = cwd();

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -228,6 +228,7 @@ type BaseArgs = {
   proxy?: ProxySettings;
   namespace?: MonitorConfig['namespace'];
   maintenanceWindows?: MonitorConfig['maintenanceWindows'];
+  timeout?: MonitorConfig['timeout'];
 };
 
 export type CliArgs = BaseArgs & {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -447,6 +447,7 @@ export default class Runner implements RunnerInfo {
       spaces: Array.from(new Set([...(options.spaces ?? []), options.space])),
       namespace: options.namespace,
       maintenanceWindows: options.maintenanceWindows,
+      timeout: options.timeout,
     });
 
     const monitors: Monitor[] = [];

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -83,6 +83,10 @@ export type MonitorConfig = {
   spaces?: string[];
   namespace?: string;
   maintenanceWindows?: string[];
+  /**
+   * Timeout in minutes for the monitor. Defaults to 15 minutes if not specified.
+   */
+  timeout?: number;
 };
 
 type MonitorFilter = {

--- a/src/options.ts
+++ b/src/options.ts
@@ -264,6 +264,10 @@ export function getCommonCommandOpts() {
     '--maintenance-windows <ids...>',
     "List of Kibana's Maintenance Windows IDs assigned by default. More information on https://www.elastic.co/docs/explore-analyze/alerts-cases/alerts/maintenance-windows."
   );
+  const timeout = createOption(
+    '--timeout <minutes>',
+    'Monitor timeout in minutes. Overrides default agent timeout.'
+  ).argParser(parseInt);
 
   return {
     auth,
@@ -276,6 +280,7 @@ export function getCommonCommandOpts() {
     match,
     fields,
     maintenanceWindows,
+    timeout,
   };
 }
 

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -45,12 +45,14 @@ const ALLOWED_LW_EXTENSIONS = ['.yml', '.yaml'];
 // 1500kB Max Gzipped limit for bundled monitor code to be pushed as Kibana project monitors.
 const SIZE_LIMIT_KB = 1500;
 
-export type MonitorSchema = Omit<MonitorConfig, 'locations'> & {
+export type MonitorSchema = Omit<MonitorConfig, 'locations' | 'timeout'> & {
   locations: string[];
   content?: string;
   filter?: Monitor['filter'];
   hash?: string;
   size?: number;
+  /** Timeout as a string with time unit suffix (e.g., "3m" for 3 minutes) */
+  timeout?: string;
 };
 
 // Abbreviated monitor info, as often returned by the API,
@@ -138,8 +140,13 @@ export async function buildMonitorSchema(monitors: Monitor[], isV2: boolean) {
 
   for (const monitor of monitors) {
     const { source, config, filter, type } = monitor;
+    // Format timeout as a string with time unit suffix (e.g., "3m" for 3 minutes)
+    // Kibana API expects timeout as a string like "3m", "60s", etc.
+    const timeout: string | undefined =
+      config.timeout != null ? `${config.timeout}m` : undefined;
     const schema: MonitorSchema = {
       ...config,
+      timeout,
       locations: translateLocation(config.locations),
     };
 
@@ -288,6 +295,7 @@ export function buildMonitorFromYaml(
   const maintenanceWindows =
     (config['maintenance_windows'] || config.maintenanceWindows) ??
     options.maintenanceWindows;
+  const timeout = config.timeout ?? options.timeout;
   const alertConfig = parseAlertConfig(config, options.alert);
 
   const mon = new Monitor({
@@ -304,6 +312,7 @@ export function buildMonitorFromYaml(
       (schedule as typeof ALLOWED_SCHEDULES[number]) || options.schedule,
     alert: alertConfig,
     maintenanceWindows,
+    timeout,
   });
 
   /**


### PR DESCRIPTION
Fixes #133

## Summary
- Add support for a minutes-only `timeout` parameter for monitors.
- Internally accept numeric minutes; when pushing to Kibana the timeout is formatted as a string with a time unit (`m`) suffix (e.g. `3m`) to match Kibana's expected normalization

## What changed
- **CLI**: expose `--timeout <minutes>` and wire it through push commands.
- **Types**: add `timeout?: number` to monitor config usage and include it in shared args.
- **Runner**: pass `timeout` through monitor defaults.
- **Push / Schema**: convert numeric minutes → string (e.g. `5m`) and update `MonitorSchema.timeout` to `string` for the outgoing payload.
- **Tests**: add unit tests ensuring `buildMonitorSchema` formats `timeout` as `'5m'` and omits it when unspecified.

## Verification
- Run unit tests:
All tests passed

- Manual push used for verification (example):
```bash
node ./dist/cli.js push --auth "<base64-apikey>" --timeout 3 --yes
# Expect: "✓ Pushed: ..."
```

## Notes for reviewers
- The change preserves an internal minutes-only numeric representation (simple UX for CLI/config) while ensuring the outgoing payload meets Kibana's string-with-units requirement - similar to `schedule` param
- Consider whether to accept other units (seconds/hours) or already-formatted timeout strings in future enhancements; current scope enforces minutes-only.

## Release note
- Added `timeout` parameter to monitor configuration (minutes-only).