### PR TITLE
feat: consider "chore" commits for patch releases

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,14 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "chore", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/npm",


### PR DESCRIPTION
"chore" commits are not considered by the release process. Instead, consider them for patch releases.
