### PR TITLE
chore(deps): upgrade undici to ^7.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "sonic-boom": "^3.3.0",
         "source-map-support": "^0.5.21",
         "stack-utils": "^2.0.6",
-        "undici": "^7.18.2",
+        "undici": "^7.24.0",
         "unzip-stream": "^0.3.4",
         "yaml": "^2.2.2"
       },
@@ -10157,9 +10157,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.0.tgz",
-      "integrity": "sha512-Heho1hJD81YChi+uS2RkSjcVO+EQLmLSyUlHyp7Y/wFbxQaGb4WXVKD073JytrjXJVkSZVzoE2MCSOKugFGtOQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "sonic-boom": "^3.3.0",
     "source-map-support": "^0.5.21",
     "stack-utils": "^2.0.6",
-    "undici": "^7.18.2",
+    "undici": "^7.24.0",
     "unzip-stream": "^0.3.4",
     "yaml": "^2.2.2"
   },


### PR DESCRIPTION
Upgrade the dependency to address multiple security related issues:

- CVE-2026-1525 (Medium): Request/response smuggling issues
- CVE-2026-1528 (High): WebSocket frame length handling crashes
- CVE-2026-1527 (Medium): CRLF injection via upgrade option
- CVE-2026-2229 (High): WebSocket permessage-deflate exceptions
- CVE-2026-1526 (High): Unbounded memory consumption in WebSocket decompression