### PR TITLE
feat: add types for maintenanceWindows

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -790,6 +790,7 @@ describe('runner', () => {
         playwrightOptions: { ignoreHTTPSErrors: true },
         fields: { area: 'website' },
         namespace: 'test',
+        maintenanceWindows: ['mw-1', 'mw-2'],
       });
 
       const j1 = new Journey({ name: 'j1', tags: ['foo*'] }, noop);
@@ -828,6 +829,7 @@ describe('runner', () => {
         fields: { area: 'website' },
         spaces: [],
         namespace: 'test',
+        maintenanceWindows: ['mw-1', 'mw-2'],
       });
       expect(monitors[1].config).toMatchObject({
         locations: ['us_east'],

--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -609,6 +609,61 @@ heartbeat.monitors:
         namespace: 'foo',
       });
     });
+
+    it('supports maintenanceWindows in config', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: icmp
+  schedule: @every 5m
+  id: "test-icmp"
+  name: "test-icmp"
+  maintenanceWindows: ["mw-1", "mw-2"]
+      `);
+
+      const [mon] = await createLightweightMonitors(PROJECT_DIR, {
+        auth: 'foo',
+        kibanaVersion: '8.8.0',
+        locations: ['australia_east'],
+        schedule: 10,
+        maintenanceWindows: ['global-mw'],
+      });
+
+      expect(mon.config).toEqual({
+        id: 'test-icmp',
+        name: 'test-icmp',
+        locations: ['australia_east'],
+        type: 'icmp',
+        schedule: 5,
+        maintenanceWindows: ['mw-1', 'mw-2'],
+      });
+    });
+
+    it('falls back to global maintenanceWindows when not set per monitor', async () => {
+      await writeHBFile(`
+heartbeat.monitors:
+- type: icmp
+  schedule: @every 5m
+  id: "test-icmp"
+  name: "test-icmp"
+      `);
+
+      const [mon] = await createLightweightMonitors(PROJECT_DIR, {
+        auth: 'foo',
+        kibanaVersion: '8.8.0',
+        locations: ['australia_east'],
+        schedule: 10,
+        maintenanceWindows: ['global-mw'],
+      });
+
+      expect(mon.config).toEqual({
+        id: 'test-icmp',
+        name: 'test-icmp',
+        locations: ['australia_east'],
+        type: 'icmp',
+        schedule: 5,
+        maintenanceWindows: ['global-mw'],
+      });
+    });
   });
 
   describe('parseAlertConfig', () => {

--- a/src/common_types.ts
+++ b/src/common_types.ts
@@ -227,6 +227,7 @@ type BaseArgs = {
   spaces?: MonitorConfig['spaces'];
   proxy?: ProxySettings;
   namespace?: MonitorConfig['namespace'];
+  maintenanceWindows?: MonitorConfig['maintenanceWindows'];
 };
 
 export type CliArgs = BaseArgs & {

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -446,6 +446,7 @@ export default class Runner implements RunnerInfo {
       fields: options.fields,
       spaces: Array.from(new Set([...(options.spaces ?? []), options.space])),
       namespace: options.namespace,
+      maintenanceWindows: options.maintenanceWindows,
     });
 
     const monitors: Monitor[] = [];

--- a/src/dsl/monitor.ts
+++ b/src/dsl/monitor.ts
@@ -82,6 +82,8 @@ export type MonitorConfig = {
    */
   spaces?: string[];
   namespace?: string;
+  /** Maintenance window IDs or titles from Kibana */
+  maintenanceWindows?: string[];
 };
 
 type MonitorFilter = {

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -289,6 +289,7 @@ export function buildMonitorFromYaml(
 
   const mon = new Monitor({
     namespace: config.namespace ?? options.namespace,
+    maintenanceWindows: config.maintenanceWindows ?? options.maintenanceWindows,
     enabled: config.enabled ?? options.enabled,
     locations: options.locations,
     tags: options.tags,


### PR DESCRIPTION
## Summary

- Adds a new optional `maintenanceWindows?: string[]` field on `MonitorConfig`, accepting Kibana maintenance window IDs/titles.
- Threads the value through the runner (`monitor.use()` / project-level global config) and through the lightweight monitor YAML path (`heartbeat.monitors[].maintenanceWindows`), falling back to the global `options.maintenanceWindows` when not set per monitor.
- Mirrors the existing `namespace` support (#1021) — same shape, same fallback semantics, same test coverage.

## Test plan

- [x] `npx jest __tests__/push/monitor.test.ts` passes (new: `supports maintenanceWindows in config`, `falls back to global maintenanceWindows when not set per monitor`).
- [x] `npx jest __tests__/core/runner.test.ts -t "build monitors"` passes (existing global-config test extended to assert `maintenanceWindows` propagation).
- [x] `npm run lint` clean.


Made with [Cursor](https://cursor.com)