### PR TITLE
fix: skip husky install in non-prod environments

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -2,6 +2,6 @@
 try {
   const husky = await import('husky');
   husky.default();
-} catch {
-  // husky not a dependency, skip
+} catch (e) {
+  if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e;
 }

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,7 @@
+// Skip if husky is not installed (CI, production, embedded installs with --omit=dev)
+try {
+  const husky = await import('husky');
+  husky.default();
+} catch {
+  // husky not a dependency, skip
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "jest",
     "test:browser-service": "WSENDPOINT=ws://localhost:9322 npm run test:unit",
     "coverage": "jest --coverage",
-    "prepare": "husky"
+    "prepare": "node .husky/install.mjs"
   },
   "bin": {
     "@elastic/synthetics": "dist/cli.js",


### PR DESCRIPTION
Currently, when installing only dependencies (not devDependencies), the "prepare": "husky" script fails because Husky isn't installed. This change was introduced [here](https://github.com/elastic/synthetics/pull/1133).

Replace `husky` prepare script with a wrapper script that exits when `husky` is not installed, preventing npm install failures in production and embedded installs.

More information: https://typicode.github.io/husky/how-to.html