### PR TITLE
fix: include .husky/install.mjs in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:unit": "jest",
     "test:browser-service": "WSENDPOINT=ws://localhost:9322 npm run test:unit",
     "coverage": "jest --coverage",
-    "prepare": "node .husky/install.mjs"
+    "prepare": "node .husky/install.mjs || true"
   },
   "bin": {
     "@elastic/synthetics": "dist/cli.js",
@@ -28,7 +28,8 @@
   "files": [
     "dist",
     "src",
-    "templates"
+    "templates",
+    ".husky/install.mjs"
   ],
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
The prepare script referenced .husky/install.mjs but the file was not
included in the tarball, causing npm to throw the following error:

npm error command sh -c node .husky/install.mjs
npm error node:internal/modules/cjs/loader:1386
npm error   throw err;
npm error   ^
npm error
npm error Error: Cannot find module '/.node/lib/node_modules/@elastic/synthetics/.husky/install.mjs'
npm error     at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)
npm error     at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)
npm error     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)
npm error     at Function._load (node:internal/modules/cjs/loader:1192:37)
npm error     at TracingChannel.traceSync (node:diagnostics_channel:328:14)
npm error     at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
npm error     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
npm error     at node:internal/main/run_main_module:36:49 {
npm error   code: 'MODULE_NOT_FOUND',
npm error   requireStack: []
npm error }

Add .husky/install.mjs to the files field and make the prepare script
non-fatal (|| true) as a safeguard against the same regression.
