### PR TITLE
chore: bump follow-redirects to 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5402,15 +5402,16 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "typescript": "^5.1.6"
   },
   "overrides": {
-    "follow-redirects": "^1.15.6",
+    "follow-redirects": "^1.16.0",
     "cross-spawn": "^7.0.5",
     "brace-expansion@1": "^1.1.13",
     "brace-expansion@2": "^2.0.3",


### PR DESCRIPTION
Bump follow-redirects dependency to 1.16.0
