### PR TITLE
fix: surface client certificate startup errors and validate clientCertificates (#1123)

### DIFF
--- a/__tests__/core/runner.test.ts
+++ b/__tests__/core/runner.test.ts
@@ -138,6 +138,26 @@ describe('runner', () => {
     });
   });
 
+  it('run journey - surfaces startup error instead of masking it (#1123)', async () => {
+    // Simulate browser/context startup (e.g. bad clientCertificates) failing
+    // before recording starts, which leaves Gatherer.pluginManager uninitialized.
+    Gatherer.pluginManager = undefined as any;
+    const startupError = new Error('client certificate startup failure');
+    const setupSpy = jest
+      .spyOn(Gatherer, 'setupDriver')
+      .mockRejectedValue(startupError);
+    try {
+      const j1 = new Journey({ name: 'startup-fail' }, noop);
+      const result = await runner._runJourney(j1, defaultRunOptions);
+      expect(result).toMatchObject({
+        status: 'failed',
+        error: startupError,
+      });
+    } finally {
+      setupSpy.mockRestore();
+    }
+  });
+
   it('run journey - with hooks', async () => {
     const journey = new Journey({ name: 'with hooks' }, noop);
     journey._addHook('before', noop);

--- a/__tests__/options.test.ts
+++ b/__tests__/options.test.ts
@@ -193,6 +193,56 @@ describe('options', () => {
     });
   });
 
+  describe('clientCertificates validation (#1123)', () => {
+    const withCerts = (clientCertificates: any) =>
+      normalizeOptions(
+        { playwrightOptions: { clientCertificates } } as CliArgs,
+        'run'
+      );
+
+    it('rejects an empty clientCertificates entry', async () => {
+      await expect(withCerts([{}])).rejects.toThrow(/clientCertificates/);
+    });
+
+    it('rejects entries without an origin', async () => {
+      await expect(
+        withCerts([{ cert: Buffer.from('c'), key: Buffer.from('k') }])
+      ).rejects.toThrow(/origin/);
+    });
+
+    it('rejects entries without any certificate material', async () => {
+      await expect(
+        withCerts([{ origin: 'https://test.example.com' }])
+      ).rejects.toThrow(/cert|pfx/);
+    });
+
+    it('accepts a valid inline clientCertificates entry', async () => {
+      await expect(
+        withCerts([
+          {
+            origin: 'https://test.example.com',
+            cert: Buffer.from('c'),
+            key: Buffer.from('k'),
+          },
+        ])
+      ).resolves.toMatchObject({
+        playwrightOptions: { clientCertificates: expect.any(Array) },
+      });
+    });
+
+    it('accepts a structurally valid path-based entry (existence checked at runtime)', async () => {
+      await expect(
+        withCerts([
+          {
+            origin: 'https://test.example.com',
+            certPath: '/etc/mtls/cert.crt',
+            keyPath: '/etc/mtls/cert.key',
+          },
+        ])
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('parseFileOption', () => {
     it('parses file', () => {
       expect(

--- a/src/core/runner.ts
+++ b/src/core/runner.ts
@@ -333,25 +333,31 @@ export default class Runner implements RunnerInfo {
     result: JourneyResult,
     options: RunOptions
   ) {
-    // Enhance the journey results
-    const pOutput = await Gatherer.pluginManager.output();
-    const bConsole = filterBrowserMessages(
-      pOutput.browserconsole,
-      journey.status
-    );
+    // When browser/context startup fails before recording begins (e.g. invalid
+    // clientCertificates), the plugin manager and driver are never initialized.
+    // Guard against that so the original startup error surfaces instead of being
+    // masked by a cleanup crash. See https://github.com/elastic/synthetics/issues/1123
+    const pOutput = await Gatherer.pluginManager?.output();
+    const bConsole = pOutput
+      ? filterBrowserMessages(pOutput.browserconsole, journey.status)
+      : undefined;
     await this.#reporter?.onJourneyEnd?.(journey, {
       browserDelay: this.#browserDelay,
       timestamp: getTimestamp(),
       options,
-      networkinfo: pOutput.networkinfo,
+      networkinfo: pOutput?.networkinfo,
       browserconsole: bConsole,
     });
-    await Gatherer.endRecording();
-    await Gatherer.dispose(this.#driver);
+    if (Gatherer.pluginManager) {
+      await Gatherer.endRecording();
+    }
+    if (this.#driver) {
+      await Gatherer.dispose(this.#driver);
+    }
     // clear screenshots cache after each journey
     await rm(this.#screenshotPath, { recursive: true, force: true });
     return Object.assign(result, {
-      networkinfo: pOutput.networkinfo,
+      networkinfo: pOutput?.networkinfo,
       browserconsole: bConsole,
       ...journey,
     });

--- a/src/options.ts
+++ b/src/options.ts
@@ -98,6 +98,7 @@ export async function normalizeOptions(
     ignoreHTTPSErrors:
       cliArgs.ignoreHttpsErrors ?? playwrightOpts?.ignoreHTTPSErrors,
   };
+  validateClientCertificates(options.playwrightOptions.clientCertificates);
 
   options.proxy = Object.freeze(
     merge(config?.proxy ?? {}, cliArgs?.proxy || {})
@@ -277,6 +278,46 @@ export function getCommonCommandOpts() {
     fields,
     maintenanceWindows,
   };
+}
+
+/**
+ * Validate the structure of `clientCertificates` entries early so misconfigured
+ * monitors fail with a clear message instead of an opaque browser startup crash
+ * (or, for malformed shapes, an Elastic Agent panic during config transpilation).
+ * See https://github.com/elastic/synthetics/issues/1123
+ *
+ * Only the shape is validated here; file existence and PEM validity are surfaced
+ * at runtime by Playwright when the browser context is created.
+ */
+export function validateClientCertificates(
+  clientCertificates: unknown,
+  source = 'playwrightOptions.clientCertificates'
+) {
+  if (clientCertificates == null) {
+    return;
+  }
+  if (!Array.isArray(clientCertificates)) {
+    throw new Error(`${source} must be an array of certificate entries.`);
+  }
+  clientCertificates.forEach((entry, index) => {
+    const at = `${source}[${index}]`;
+    if (entry == null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`${at} must be an object.`);
+    }
+    if (!entry.origin || typeof entry.origin !== 'string') {
+      throw new Error(
+        `${at} must specify an "origin" (the exact request origin the client certificate applies to).`
+      );
+    }
+    const hasCertAndKey =
+      (entry.cert || entry.certPath) && (entry.key || entry.keyPath);
+    const hasPfx = Boolean(entry.pfx || entry.pfxPath);
+    if (!hasCertAndKey && !hasPfx) {
+      throw new Error(
+        `${at} must provide a certificate via "cert"/"certPath" together with "key"/"keyPath", or via "pfx"/"pfxPath".`
+      );
+    }
+  });
 }
 
 export function parsePlaywrightOptions(playwrightOpts: string) {


### PR DESCRIPTION
## Summary

Fixes parts of #1123. Browser monitors configured with `playwright_options.clientCertificates` could fail before any step ran, and the **real** startup error was masked by a secondary crash in `Runner.#endJourney`:

```
TypeError: Cannot read properties of undefined (reading 'output')
    at Runner.#endJourney (src/core/runner.ts)
    at Runner._runJourney (src/core/runner.ts)
```

This PR addresses two of the three in-scope root causes:

- **Masking crash (fix #1):** When browser/context startup fails before recording begins (e.g. an invalid `clientCertificates` path/PEM), `Gatherer.pluginManager` and the driver are never initialized. `#endJourney` now guards against this, so the original startup error is reported as the journey error instead of being swallowed by a cleanup crash.
- **Early validation (fix #3):** `normalizeOptions` now validates the **shape** of `clientCertificates` entries and throws a clear error for malformed input (e.g. `[{}]`, missing `origin`, or no certificate material). This prevents the confusing browser crash and the malformed-config Elastic Agent transpiler panic (Case 5 in the issue). Only structure is validated here — file existence / PEM validity still surface at runtime via the fix above.

### Not included (follow-up)
- Splitting launch-safe vs context/request-level Playwright options before `chromium.launch()` (the issue's suggestion #2). Verified empirically that `chromium.launch()` currently ignores `clientCertificates`, so it's not the trigger; tracking separately to keep this PR focused.
- The Elastic Agent SIGSEGV itself lives in `elastic-agent`'s transpiler and is out of scope for this repo; the new validation reduces the chance of feeding it malformed config.

## Test plan

- [x] `__tests__/core/runner.test.ts` — new test reproduces the masked `#endJourney` crash and asserts the original startup error is surfaced (red → green).
- [x] `__tests__/options.test.ts` — new tests reject empty entries, missing `origin`, and missing cert material, while accepting valid inline and path-based entries.
- [x] Full `runner` (42) and `options` (13) suites pass locally.
- [x] lint + format (pre-commit) pass.

Made with [Cursor](https://cursor.com)