### PR TITLE
fix(push): coerce equivalent schedules to the same value (#1119)

### DIFF
--- a/__tests__/push/monitor.test.ts
+++ b/__tests__/push/monitor.test.ts
@@ -128,6 +128,9 @@ describe('Monitors', () => {
     expect(parseSchedule('@every 4s')).toBe('10s');
     expect(parseSchedule('@every 40s')).toBe('30s');
     expect(parseSchedule('@every 70s')).toBe(1);
+    // same total duration must coerce to the same schedule regardless of unit
+    expect(parseSchedule('@every 1m59s')).toBe(parseSchedule('@every 119s'));
+    expect(parseSchedule('@every 119s')).toBe(2);
     expect(parseSchedule('@every 121s')).toBe(2);
     expect(parseSchedule('@every 1m')).toBe(1);
     expect(parseSchedule('@every 2m30s')).toBe(2);

--- a/src/push/monitor.ts
+++ b/src/push/monitor.ts
@@ -425,8 +425,10 @@ export function parseSchedule(schedule: string) {
   const duration = schedule.substring(EVERY_SYNTAX.length + 1);
   // split between non-digit (\D) and a digit (\d)
   const durations = duration.split(/(?<=\D)(?=\d)/g);
-  let minutes = 0;
-  let seconds = 0;
+  // Accumulate everything as seconds so the same total duration maps to the
+  // same schedule regardless of the units it was expressed in
+  // (e.g. `1m59s` and `119s`).
+  let totalSeconds = 0;
   for (const dur of durations) {
     // split between a digit and non-digit
     const [value, format] = dur.split(/(?<=\d)(?=\D)/g);
@@ -434,33 +436,32 @@ export function parseSchedule(schedule: string) {
     const scheduleValue = parseInt(value, 10);
     switch (format) {
       case 's':
-        if (scheduleValue < 60) {
-          seconds += scheduleValue;
-        } else {
-          minutes += Math.round(scheduleValue / 60);
-        }
+        totalSeconds += scheduleValue;
         break;
       case 'm':
-        minutes += scheduleValue;
+        totalSeconds += scheduleValue * 60;
         break;
       case 'h':
-        minutes += scheduleValue * 60;
+        totalSeconds += scheduleValue * 60 * 60;
         break;
       case 'd':
-        minutes += scheduleValue * 24 * 60;
+        totalSeconds += scheduleValue * 24 * 60 * 60;
         break;
     }
   }
-  return nearestSchedule(minutes, seconds);
+  return nearestSchedule(totalSeconds);
 }
 
 // Find the nearest schedule that is supported by the platform
 // from the parsed schedule value
-function nearestSchedule(minutes: number, seconds: number) {
-  if (seconds > 0 && minutes === 0) {
+function nearestSchedule(totalSeconds: number) {
+  if (totalSeconds < 60) {
     // we allow only 10 and 30 seconds, return the nearest one
-    return seconds < 20 ? '10s' : '30s';
+    return totalSeconds < 20 ? '10s' : '30s';
   }
+  // Round to the nearest whole minute, breaking ties downward (e.g. `2m30s`
+  // stays at 2m) so the matched schedule never overshoots the requested cadence.
+  const minutes = Math.ceil((totalSeconds - 30) / 60);
   let nearest: typeof ALLOWED_SCHEDULES[number] = ALLOWED_SCHEDULES[0];
   let prev = Math.abs(nearest - minutes);
   for (let i = 1; i < ALLOWED_SCHEDULES.length; i++) {


### PR DESCRIPTION
## Summary

Fixes #1119.

`parseSchedule` accumulated the duration into separate `minutes` and `seconds` buckets with inconsistent conversion:

- a `s` value `< 60` was added to `seconds` and then **silently dropped** by `nearestSchedule` whenever minutes were present
- a `s` value `>= 60` was instead `Math.round`-ed into `minutes`

As a result, two equal durations could coerce to different schedules:

```ts
parseSchedule('@every 1m59s'); // 1
parseSchedule('@every 119s');  // 2
```

This PR accumulates the whole duration as total seconds, then rounds to the nearest whole minute (breaking ties downward, so `2m30s` stays at `2m` and never overshoots the requested cadence) before matching against `ALLOWED_SCHEDULES`. Equivalent durations now always resolve to the same schedule.

## Test plan

- [x] `npx jest __tests__/push/monitor.test.ts -t "parse @every schedule format"` passes
- Added an assertion that `@every 1m59s` and `@every 119s` resolve to the same value, plus an explicit `119s -> 2` case
- All pre-existing schedule assertions remain unchanged

Made with [Cursor](https://cursor.com)