### PR TITLE
fix(network): capture TLS cert details for invalid-cert navigations

### DIFF
--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -79,6 +79,27 @@ describe('network', () => {
     });
   });
 
+  it('capture tls details for invalid-cert navigation', async () => {
+    const tlsServer = await Server.create({ tls: true });
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
+    const network = new NetworkManager(driver);
+    await network.start();
+    // Self-signed cert fails validation (ERR_CERT_AUTHORITY_INVALID) so no CDP
+    // response carries securityDetails; we expect it from the Security domain.
+    await driver.page.goto(tlsServer.TEST_PAGE).catch(() => {});
+    await delay(100);
+    const netinfo = await network.stop();
+    await Gatherer.stop();
+    await tlsServer.close();
+
+    const navEntry = netinfo.find(ni => ni.isNavigationRequest);
+    expect(navEntry).toBeDefined();
+    expect(navEntry.response.securityDetails).toMatchObject({
+      validTo: expect.any(Number),
+      validFrom: expect.any(Number),
+    });
+  });
+
   it('not include data URL in network info', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     const network = new NetworkManager(driver);

--- a/__tests__/reporters/json.test.ts
+++ b/__tests__/reporters/json.test.ts
@@ -194,6 +194,32 @@ describe('json reporter', () => {
     }
   });
 
+  it('emits tls block for invalid-cert navigations without protocol', async () => {
+    const network = {
+      ...NETWORK_INFO[0],
+      response: {
+        ...NETWORK_INFO[0].response,
+        securityDetails: {
+          issuer: 'BadSSL',
+          subjectName: '*.badssl.com',
+          validFrom: 1428897600,
+          validTo: 1492056000,
+        },
+      },
+    };
+    const { ecs } = formatNetworkFields(network as any);
+    expect(ecs.tls).toEqual({
+      server: {
+        x509: {
+          issuer: { common_name: 'BadSSL' },
+          subject: { common_name: '*.badssl.com' },
+          not_after: new Date(1492056000 * 1000).toISOString(),
+          not_before: new Date(1428897600 * 1000).toISOString(),
+        },
+      },
+    });
+  });
+
   it('redact sensitive req/response headers', async () => {
     expect(
       redactKeys({

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -23,11 +23,58 @@
  *
  */
 
+import { connect as tlsConnect, PeerCertificate } from 'tls';
 import { Frame, Page, Request, Response } from 'playwright-core';
-import { NetworkInfo, BrowserInfo, Driver } from '../common_types';
+import {
+  NetworkInfo,
+  BrowserInfo,
+  Driver,
+  SecurityDetails,
+} from '../common_types';
 import { log } from '../core/logger';
 import { Step } from '../dsl';
 import { getTimestamp } from '../helpers';
+
+/**
+ * Chromium network errors that indicate the navigation failed during TLS
+ * certificate validation. For these, Chromium fires `Network.loadingFailed`
+ * instead of a response, so no `securityDetails` is captured and we recover the
+ * certificate via a direct TLS probe.
+ */
+const CERTIFICATE_ERROR = /ERR_CERT|ERR_SSL/;
+
+const CERT_PROBE_TIMEOUT = 5000;
+
+/**
+ * Node returns protocols as e.g. `TLSv1.3`, while the CDP `securityDetails`
+ * (and downstream `formatTLS`) expect the `TLS 1.3` form.
+ */
+function normalizeProtocol(protocol?: string): string | undefined {
+  if (!protocol) return undefined;
+  const match = protocol.match(/^TLSv([\d.]+)$/);
+  return match ? `TLS ${match[1]}` : protocol;
+}
+
+function toEpochSeconds(value?: string): number | undefined {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? undefined : Math.floor(ms / 1000);
+}
+
+function toSecurityDetails(
+  cert: PeerCertificate,
+  protocol: string | null
+): SecurityDetails | undefined {
+  // An empty object is returned when no peer certificate is available.
+  if (!cert || !cert.valid_to) return undefined;
+  return {
+    protocol: normalizeProtocol(protocol ?? undefined),
+    issuer: cert.issuer?.CN,
+    subjectName: cert.subject?.CN,
+    validFrom: toEpochSeconds(cert.valid_from),
+    validTo: toEpochSeconds(cert.valid_to),
+  };
+}
 
 /**
  * Kibana UI expects the requestStartTime and loadEndTime to be baseline
@@ -67,6 +114,20 @@ type RequestWithEntry = Request & {
 export class NetworkManager {
   private _browser: BrowserInfo;
   private _barrierPromises = new Set<Promise<void>>();
+  /**
+   * In-flight TLS probes used to recover certificate details for navigations
+   * that fail cert validation. Awaited (with per-probe timeouts) on stop so the
+   * details are present before the results are reported.
+   */
+  private _certProbes = new Set<Promise<void>>();
+  /**
+   * Memoizes the TLS probe per origin so multiple failed requests to the same
+   * host trigger only one outbound connection.
+   */
+  private _certProbeCache = new Map<
+    string,
+    Promise<SecurityDetails | undefined>
+  >();
   results: Array<NetworkInfo> = [];
   _currentStep: Partial<Step> = null;
 
@@ -285,6 +346,8 @@ export class NetworkManager {
     networkEntry.timings.receive = receive;
     this._calcTotalTime(networkEntry, timing);
 
+    this._maybeAttachCertDetails(request, networkEntry);
+
     // For aborted/failed requests sizes will not be present
     if (timing.startTime <= 0) {
       return;
@@ -308,6 +371,89 @@ export class NetworkManager {
         };
       })
     );
+  }
+
+  /**
+   * Navigations that fail TLS validation never produce a CDP response, so the
+   * usual `response.securityDetails` path captures nothing. Recover the cert
+   * from the Security domain so a `tls` block is still emitted (e.g. so the
+   * browser TLS-expiry alert can fire on already-expired certs).
+   */
+  private _maybeAttachCertDetails(request: Request, networkEntry: NetworkInfo) {
+    const failure = request.failure();
+    if (
+      !failure ||
+      networkEntry.response.securityDetails ||
+      !CERTIFICATE_ERROR.test(failure.errorText)
+    ) {
+      return;
+    }
+    const probe = this._probeCertificate(networkEntry.url).then(details => {
+      if (details) networkEntry.response.securityDetails = details;
+    });
+    this._certProbes.add(probe);
+    probe.finally(() => this._certProbes.delete(probe));
+  }
+
+  /**
+   * Opens a TLS connection (without verifying the cert) purely to read the peer
+   * certificate. This recovers cert details for hosts the browser refused to
+   * connect to due to an invalid cert.
+   */
+  private _probeCertificate(
+    urlString: string
+  ): Promise<SecurityDetails | undefined> {
+    let url: URL;
+    try {
+      url = new URL(urlString);
+    } catch (_) {
+      return Promise.resolve(undefined);
+    }
+    if (url.protocol !== 'https:') return Promise.resolve(undefined);
+
+    const origin = url.origin;
+    const cached = this._certProbeCache.get(origin);
+    if (cached) return cached;
+
+    const probe = new Promise<SecurityDetails | undefined>(resolve => {
+      let settled = false;
+      const done = (details?: SecurityDetails) => {
+        if (settled) return;
+        settled = true;
+        resolve(details);
+      };
+      try {
+        const socket = tlsConnect(
+          {
+            host: url.hostname,
+            port: url.port ? Number(url.port) : 443,
+            servername: url.hostname,
+            rejectUnauthorized: false,
+            timeout: CERT_PROBE_TIMEOUT,
+          },
+          () => {
+            const details = toSecurityDetails(
+              socket.getPeerCertificate(),
+              socket.getProtocol()
+            );
+            socket.end();
+            done(details);
+          }
+        );
+        socket.once('error', () => {
+          socket.destroy();
+          done();
+        });
+        socket.once('timeout', () => {
+          socket.destroy();
+          done();
+        });
+      } catch (_) {
+        done();
+      }
+    });
+    this._certProbeCache.set(origin, probe);
+    return probe;
   }
 
   /**
@@ -348,11 +494,18 @@ export class NetworkManager {
     if (this._barrierPromises.size > 0) {
       log(`Plugins: dropping ${this._barrierPromises.size} network events`);
     }
+    // Cert probes are bounded by their own timeout, so awaiting them here is
+    // safe and ensures recovered TLS details are present in the results.
+    if (this._certProbes.size > 0) {
+      await Promise.allSettled(this._certProbes);
+    }
     const context = this.driver.context;
     context.off('request', this._onRequest.bind(this));
     context.off('response', this._onResponse.bind(this));
     context.off('requestfinished', this._onRequestCompleted.bind(this));
     context.off('requestfailed', this._onRequestCompleted.bind(this));
+    this._certProbes.clear();
+    this._certProbeCache.clear();
     this._barrierPromises.clear();
     log(`Plugins: stopped collecting network events`);
     return this.results;

--- a/src/reporters/json.ts
+++ b/src/reporters/json.ts
@@ -138,11 +138,13 @@ function getMetadata() {
 }
 
 function formatTLS(tls: SecurityDetails) {
-  if (!tls || !tls.protocol) {
+  // For invalid-cert navigations (e.g. expired certs) the handshake may not
+  // expose a protocol, but the cert dates are still captured and are what the
+  // TLS-expiry alert needs, so we emit the x509 block whenever we have them.
+  if (!tls || (!tls.protocol && tls.validTo == null)) {
     return;
   }
-  const [name, version] = tls.protocol.toLowerCase().split(' ');
-  return {
+  const result: Record<string, unknown> = {
     server: {
       x509: {
         issuer: {
@@ -151,13 +153,23 @@ function formatTLS(tls: SecurityDetails) {
         subject: {
           common_name: tls.subjectName,
         },
-        not_after: new Date(tls.validTo * 1000).toISOString(),
-        not_before: new Date(tls.validFrom * 1000).toISOString(),
+        not_after:
+          tls.validTo != null
+            ? new Date(tls.validTo * 1000).toISOString()
+            : undefined,
+        not_before:
+          tls.validFrom != null
+            ? new Date(tls.validFrom * 1000).toISOString()
+            : undefined,
       },
     },
-    version_protocol: name,
-    version,
   };
+  if (tls.protocol) {
+    const [name, version] = tls.protocol.toLowerCase().split(' ');
+    result.version_protocol = name;
+    result.version = version;
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1156.

When a browser monitor navigates to a site with an **invalid TLS certificate** (e.g. expired or untrusted), Chromium fires `Network.loadingFailed` instead of a response. As a result, no `securityDetails` were captured, `formatTLS` emitted nothing, and Kibana's browser-monitor **TLS certificate expiry alert** had no `tls.server.x509.not_after` to evaluate — so an already-expired browser cert could never trigger the alert.

### Investigation

The issue proposed listening to the CDP `Security.visibleSecurityStateChanged` event. Probing the actual CDP traffic for a failed-cert navigation showed that event **does not fire** for blocked navigations — only `Security.certificateError` (URL + error type, no cert dates) and `Network.loadingFailed` do. `Network.getCertificate` **hangs** for failed-cert origins. So this uses the same technique as the lightweight TLS monitor: a direct TLS probe to read the peer certificate.

### Changes

- **`src/plugins/network.ts`** — On a request that fails with a certificate error (`ERR_CERT*` / `ERR_SSL*`), open a short, non-verifying TLS connection to the origin to read the peer certificate (`valid_from`, `valid_to`, issuer/subject CN, protocol) and attach it as `response.securityDetails`. Probes are memoized per origin, bounded by a 5s timeout, never reject, and are awaited in `stop()` so the data is present before reporting.
- **`src/reporters/json.ts`** — `formatTLS` now emits the `tls.server.x509` block whenever cert dates are present, even if the handshake exposes no protocol string (`version_protocol`/`version` are still added when available).

### Limitation

The TLS probe connects directly to the host and does not route through any configured proxy. For the cert-expiry use case the origin's certificate is exactly what we want, so this is acceptable.

## Test plan

- [x] New unit test: `formatTLS` emits the x509 block (with `not_after`/`not_before`) for a cert with no protocol.
- [x] New integration test: navigating to a self-signed HTTPS server (`ERR_CERT_AUTHORITY_INVALID`) recovers `securityDetails` on the navigation entry.
- [x] Existing network + reporter suites pass (incl. snapshots); type-check, lint, prettier clean.

Made with [Cursor](https://cursor.com)