### PR TITLE
ci: post e2e Slack results after the matrix finishes

### DIFF
--- a/.github/scripts/summarize_e2e_jobs.js
+++ b/.github/scripts/summarize_e2e_jobs.js
@@ -1,0 +1,71 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const TEST_JOB = /^test \((.+)\)$/;
+
+function compareVersions(a, b) {
+  return a.localeCompare(b, undefined, { numeric: true });
+}
+
+function summarizeTestJobs(jobs) {
+  const passed = [];
+  const failed = [];
+
+  for (const job of jobs) {
+    const match = TEST_JOB.exec(job.name);
+    if (!match) continue;
+    if (job.conclusion === 'success') {
+      passed.push(match[1]);
+    } else {
+      failed.push(match[1]);
+    }
+  }
+
+  passed.sort(compareVersions);
+  failed.sort(compareVersions);
+  return { passed, failed };
+}
+
+function formatVersionList(versions) {
+  return versions.map(version => `\`${version}\``).join(', ');
+}
+
+function formatSlackMessage({ passed, failed, ref, eventName, runNumber, runUrl }) {
+  const ok = failed.length === 0 && passed.length > 0;
+  const lines = [
+    `${ok ? ':white_check_mark:' : ':x:'} *e2e ${
+      ok ? 'passed' : 'failed'
+    }* on \`${ref}\` (\`${eventName}\`) — <${runUrl}|#${runNumber}>`,
+    '',
+  ];
+
+  if (passed.length) lines.push(`*Passed:* ${formatVersionList(passed)}`);
+  if (failed.length) lines.push(`*Failed:* ${formatVersionList(failed)}`);
+  if (!passed.length && !failed.length) lines.push('No version jobs ran.');
+
+  return lines.join('\n');
+}
+
+module.exports = { summarizeTestJobs, formatSlackMessage };

--- a/.github/scripts/summarize_e2e_jobs.test.js
+++ b/.github/scripts/summarize_e2e_jobs.test.js
@@ -1,0 +1,107 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020-present, Elastic NV
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  summarizeTestJobs,
+  formatSlackMessage,
+} = require('./summarize_e2e_jobs');
+
+const runMeta = {
+  ref: 'main',
+  eventName: 'schedule',
+  runNumber: 1299,
+  runUrl:
+    'https://github.com/elastic/synthetics/actions/runs/32009079908/attempts/1',
+};
+
+describe('summarizeTestJobs', () => {
+  it('splits matrix versions into passed and failed', () => {
+    const summary = summarizeTestJobs([
+      { name: 'prepare', conclusion: 'success' },
+      { name: 'test (9.5.0)', conclusion: 'failure' },
+      { name: 'test (8.19.19)', conclusion: 'success' },
+      { name: 'test (9.6.0-SNAPSHOT)', conclusion: 'cancelled' },
+      { name: 'notify', conclusion: 'success' },
+    ]);
+
+    assert.deepEqual(summary, {
+      passed: ['8.19.19'],
+      failed: ['9.5.0', '9.6.0-SNAPSHOT'],
+    });
+  });
+
+  it('returns empty lists when no version jobs ran', () => {
+    assert.deepEqual(summarizeTestJobs([{ name: 'prepare', conclusion: 'failure' }]), {
+      passed: [],
+      failed: [],
+    });
+  });
+});
+
+describe('formatSlackMessage', () => {
+  it('summarizes an all-green run', () => {
+    assert.equal(
+      formatSlackMessage({
+        passed: ['8.19.19', '9.4.4'],
+        failed: [],
+        ...runMeta,
+      }),
+      [
+        ':white_check_mark: *e2e passed* on `main` (`schedule`) — <https://github.com/elastic/synthetics/actions/runs/32009079908/attempts/1|#1299>',
+        '',
+        '*Passed:* `8.19.19`, `9.4.4`',
+      ].join('\n')
+    );
+  });
+
+  it('lists passed and failed versions', () => {
+    assert.equal(
+      formatSlackMessage({
+        passed: ['8.19.19', '9.4.4'],
+        failed: ['9.5.0'],
+        ...runMeta,
+      }),
+      [
+        ':x: *e2e failed* on `main` (`schedule`) — <https://github.com/elastic/synthetics/actions/runs/32009079908/attempts/1|#1299>',
+        '',
+        '*Passed:* `8.19.19`, `9.4.4`',
+        '*Failed:* `9.5.0`',
+      ].join('\n')
+    );
+  });
+
+  it('explains when no version jobs ran', () => {
+    assert.equal(
+      formatSlackMessage({ passed: [], failed: [], ...runMeta }),
+      [
+        ':x: *e2e failed* on `main` (`schedule`) — <https://github.com/elastic/synthetics/actions/runs/32009079908/attempts/1|#1299>',
+        '',
+        'No version jobs ran.',
+      ].join('\n')
+    );
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           cache: npm
           node-version-file: .nvmrc
       - run: npm ci
+      - run: node --test .github/scripts/summarize_e2e_jobs.test.js
       - run: npm run test:unit -- --ci --reporters=default --reporters=jest-junit
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,8 +65,42 @@ jobs:
     needs: test
     if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
-      - uses: elastic/oblt-actions/slack/notify-result@v1
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        id: summary
+        with:
+          script: |
+            const path = require('path');
+            const {
+              summarizeTestJobs,
+              formatSlackMessage,
+            } = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/summarize_e2e_jobs.js'
+            ));
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                filter: 'latest',
+              }
+            );
+            const message = formatSlackMessage({
+              ...summarizeTestJobs(jobs),
+              ref: process.env.GITHUB_REF_NAME,
+              eventName: context.eventName,
+              runNumber: context.runNumber,
+              runUrl: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}/attempts/${process.env.GITHUB_RUN_ATTEMPT}`,
+            });
+            core.setOutput('message', encodeURIComponent(message));
+      - uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#synthetics-notify"
+          message: ${{ steps.summary.outputs.message }}


### PR DESCRIPTION
## Summary
- `#synthetics-notify` currently gets `Workflow e2e triggered (...)` from `slack/notify-result`. That action always uses the **notify** job's own success status, so the channel never sees pass/fail.
- After the matrix completes, the notify job now lists jobs for this run and posts passed/failed stack versions via `slack/send`.

Example:

```
:white_check_mark: *e2e passed* on `main` (`push`) — <#1304>
*Passed:* `8.19.19`, `8.19.20`, …
```

PRs still skip Slack (`github.event_name != 'pull_request'`).

## Test plan
- [x] `node --test .github/scripts/summarize_e2e_jobs.test.js` (5 passing)
- [ ] After merge, next `main` push or scheduled e2e posts a pass/fail summary to `#synthetics-notify`
- [ ] Confirm PR e2e runs do not Slack-notify