### PR TITLE
fix: handle network metadata promise failures

### DIFF
--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -39,6 +39,22 @@ describe('network', () => {
 
   const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+  it('handles failures from optional network metadata collection', async () => {
+    const network = new NetworkManager({} as any);
+    const page = { on: jest.fn() };
+
+    (network as any)._addBarrier(
+      page,
+      Promise.reject(
+        new Error('Target page, context or browser has been closed')
+      )
+    );
+
+    await delay(0);
+
+    expect((network as any)._barrierPromises.size).toBe(0);
+  });
+
   it('should capture network info', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     const network = new NetworkManager(driver);

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -50,6 +50,7 @@ describe('network', () => {
       )
     );
 
+    // allow the event loop time to process the promise callbacks
     await delay(0);
 
     expect((network as any)._barrierPromises.size).toBe(0);

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -56,6 +56,21 @@ describe('network', () => {
     expect((network as any)._barrierPromises.size).toBe(0);
   });
 
+  it('stops recording network events on stop', async () => {
+    const driver = await Gatherer.setupDriver({ wsEndpoint });
+    const network = new NetworkManager(driver);
+    await network.start();
+    await driver.page.goto(server.TEST_PAGE, { waitUntil: 'networkidle' });
+    const netinfo = await network.stop();
+    const recorded = netinfo.length;
+    expect(recorded).toBeGreaterThan(0);
+
+    // Ensure no more network data was collected after calling `network.stop()`
+    await driver.page.goto(server.TEST_PAGE, { waitUntil: 'networkidle' });
+    expect(network.results.length).toBe(recorded);
+    await Gatherer.stop();
+  });
+
   it('should capture network info', async () => {
     const driver = await Gatherer.setupDriver({ wsEndpoint });
     const network = new NetworkManager(driver);

--- a/__tests__/plugins/network.test.ts
+++ b/__tests__/plugins/network.test.ts
@@ -41,7 +41,7 @@ describe('network', () => {
 
   it('handles failures from optional network metadata collection', async () => {
     const network = new NetworkManager({} as any);
-    const page = { on: jest.fn() };
+    const page = { once: jest.fn() };
 
     (network as any)._addBarrier(
       page,

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -71,12 +71,7 @@ export class NetworkManager {
       return;
     }
     const race = Promise.race([
-      new Promise<void>(resolve =>
-        page.on('close', () => {
-          this._barrierPromises.delete(race);
-          resolve();
-        })
-      ),
+      new Promise<void>(resolve => page.once('close', () => resolve())),
       promise,
     ]);
     this._barrierPromises.add(race);
@@ -84,7 +79,7 @@ export class NetworkManager {
       .catch(error => {
         log(`Plugins: failed to collect network metadata: ${error}`);
       })
-      .then(() => this._barrierPromises.delete(race));
+      .finally(() => this._barrierPromises.delete(race));
   }
 
   private _nullableFrameBarrier(req: Request): Frame | null {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -64,7 +64,10 @@ export class NetworkManager {
    * to not result in exception
    */
   private _addBarrier(page: Page, promise: Promise<void>) {
-    if (!page) return;
+    if (!page) {
+      promise.catch(() => {}); // Ignore failures from optional network metadata collection
+      return;
+    }
     const race = Promise.race([
       new Promise<void>(resolve =>
         page.on('close', () => {
@@ -75,7 +78,11 @@ export class NetworkManager {
       promise,
     ]);
     this._barrierPromises.add(race);
-    race.then(() => this._barrierPromises.delete(race));
+    race
+      .catch(() => {
+        // Ignore failures from optional network metadta collection
+      })
+      .then(() => this._barrierPromises.delete(race));
   }
 
   private _nullableFrameBarrier(req: Request): Frame | null {

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -107,10 +107,10 @@ export class NetworkManager {
     /**
      * Listen for all network events from PW context
      */
-    context.on('request', this._onRequest.bind(this));
-    context.on('response', this._onResponse.bind(this));
-    context.on('requestfinished', this._onRequestCompleted.bind(this));
-    context.on('requestfailed', this._onRequestCompleted.bind(this));
+    context.on('request', this._onRequest);
+    context.on('response', this._onResponse);
+    context.on('requestfinished', this._onRequestCompleted);
+    context.on('requestfailed', this._onRequestCompleted);
   }
 
   private _findNetworkEntry(
@@ -119,7 +119,7 @@ export class NetworkManager {
     return request[NETWORK_ENTRY_SUMBOL];
   }
 
-  private _onRequest(request: Request) {
+  private _onRequest = (request: Request) => {
     const url = request.url();
     /**
      * Data URI should not show up as network requests
@@ -174,9 +174,9 @@ export class NetworkManager {
 
     request[NETWORK_ENTRY_SUMBOL] = networkEntry;
     this.results.push(networkEntry);
-  }
+  };
 
-  private async _onResponse(response: Response) {
+  private _onResponse = async (response: Response) => {
     const request = response.request();
     const networkEntry = this._findNetworkEntry(request);
     if (!networkEntry) return;
@@ -229,9 +229,9 @@ export class NetworkManager {
         if (details) networkEntry.response.securityDetails = details;
       })
     );
-  }
+  };
 
-  private async _onRequestCompleted(request: Request) {
+  private _onRequestCompleted = async (request: Request) => {
     const networkEntry = this._findNetworkEntry(request);
     if (!networkEntry) return;
 
@@ -264,9 +264,18 @@ export class NetworkManager {
         };
       })
     );
-  }
+  };
 
   async stop() {
+    /**
+     * First detach the listeners so that no new network events are recorded
+     */
+    const context = this.driver.context;
+    context.off('request', this._onRequest);
+    context.off('response', this._onResponse);
+    context.off('requestfinished', this._onRequestCompleted);
+    context.off('requestfailed', this._onRequestCompleted);
+
     /**
      * Waiting for all network events is error prone and might hang the tests
      * from getting closed forever when there are upstream bugs in browsers or
@@ -275,11 +284,6 @@ export class NetworkManager {
     if (this._barrierPromises.size > 0) {
       log(`Plugins: dropping ${this._barrierPromises.size} network events`);
     }
-    const context = this.driver.context;
-    context.off('request', this._onRequest.bind(this));
-    context.off('response', this._onResponse.bind(this));
-    context.off('requestfinished', this._onRequestCompleted.bind(this));
-    context.off('requestfailed', this._onRequestCompleted.bind(this));
     this._barrierPromises.clear();
     log(`Plugins: stopped collecting network events`);
     return this.results;

--- a/src/plugins/network.ts
+++ b/src/plugins/network.ts
@@ -65,7 +65,9 @@ export class NetworkManager {
    */
   private _addBarrier(page: Page, promise: Promise<void>) {
     if (!page) {
-      promise.catch(() => {}); // Ignore failures from optional network metadata collection
+      promise.catch(error => {
+        log(`Plugins: failed to collect network metadata: ${error}`);
+      });
       return;
     }
     const race = Promise.race([
@@ -79,8 +81,8 @@ export class NetworkManager {
     ]);
     this._barrierPromises.add(race);
     race
-      .catch(() => {
-        // Ignore failures from optional network metadta collection
+      .catch(error => {
+        log(`Plugins: failed to collect network metadata: ${error}`);
       })
       .then(() => this._barrierPromises.delete(race));
   }


### PR DESCRIPTION
## Summary

Network metadata requests can fail when the page closes. These failures can cause an unhandled promise rejection that stops the process. Also, listeners were not properly detached, so new network data could be captured.

Ensure the promise failures are handled, and use a stable reference for the listeners.
