### PR TITLE
feat: add paramsFromEnv helper for environment-backed configuration

### DIFF
--- a/__tests__/helper.test.ts
+++ b/__tests__/helper.test.ts
@@ -24,6 +24,7 @@
  */
 
 import { cwd } from 'process';
+import { paramsFromEnv } from '../src/index';
 import {
   indent,
   monotonicTimeInSeconds,
@@ -145,4 +146,87 @@ it('match tags and names', () => {
   // match both name and tags
   expect(isMatch(['bar'], 'foo', undefined, 'ba*')).toBe(true);
   expect(isMatch(['bar'], 'foo', undefined, 'test*')).toBe(false);
+});
+describe('paramsFromEnv', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+
+    delete process.env.SYNTHETICS_REQUIRED_ONE;
+    delete process.env.SYNTHETICS_REQUIRED_TWO;
+    delete process.env.SYNTHETICS_OPTIONAL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns required environment variables from an array', () => {
+    process.env.SYNTHETICS_REQUIRED_ONE = 'first-value';
+    process.env.SYNTHETICS_REQUIRED_TWO = 'second-value';
+
+    expect(
+      paramsFromEnv(['SYNTHETICS_REQUIRED_ONE', 'SYNTHETICS_REQUIRED_TWO'])
+    ).toEqual({
+      SYNTHETICS_REQUIRED_ONE: 'first-value',
+      SYNTHETICS_REQUIRED_TWO: 'second-value',
+    });
+  });
+
+  it('reports all missing required environment variables', () => {
+    expect(() =>
+      paramsFromEnv(['SYNTHETICS_REQUIRED_ONE', 'SYNTHETICS_REQUIRED_TWO'])
+    ).toThrow(
+      'Missing required environment variables: SYNTHETICS_REQUIRED_ONE, SYNTHETICS_REQUIRED_TWO'
+    );
+  });
+
+  it('treats object entries as required by default', () => {
+    expect(() =>
+      paramsFromEnv({
+        SYNTHETICS_REQUIRED_ONE: {},
+      })
+    ).toThrow(
+      'Missing required environment variables: SYNTHETICS_REQUIRED_ONE'
+    );
+  });
+
+  it('omits missing optional environment variables', () => {
+    process.env.SYNTHETICS_REQUIRED_ONE = 'first-value';
+
+    expect(
+      paramsFromEnv({
+        SYNTHETICS_REQUIRED_ONE: {},
+        SYNTHETICS_OPTIONAL: { required: false },
+      })
+    ).toEqual({
+      SYNTHETICS_REQUIRED_ONE: 'first-value',
+    });
+  });
+
+  it('includes optional environment variables when present', () => {
+    process.env.SYNTHETICS_OPTIONAL = 'optional-value';
+
+    expect(
+      paramsFromEnv({
+        SYNTHETICS_OPTIONAL: { required: false },
+      })
+    ).toEqual({
+      SYNTHETICS_OPTIONAL: 'optional-value',
+    });
+  });
+
+  it('preserves defined empty environment variable values', () => {
+    process.env.SYNTHETICS_REQUIRED_ONE = '';
+
+    expect(paramsFromEnv(['SYNTHETICS_REQUIRED_ONE'])).toEqual({
+      SYNTHETICS_REQUIRED_ONE: '',
+    });
+  });
+
+  it('returns an empty object when no variables are requested', () => {
+    expect(paramsFromEnv([])).toEqual({});
+    expect(paramsFromEnv({})).toEqual({});
+  });
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -43,7 +43,46 @@ import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { EnvHttpProxyAgent } from 'undici';
 
 const SEPARATOR = '\n';
+/**
+ * Read environment variables into a parameters object.
+ *
+ * Array entries are required. Object entries are required unless
+ * explicitly marked as optional.
+ */
+export function paramsFromEnv(
+  variables: string[] | Record<string, { required?: boolean }>
+): Record<string, string> {
+  const params: Record<string, string> = {};
+  const missingVariables: string[] = [];
 
+  const entries: Array<[string, { required?: boolean }]> = Array.isArray(
+    variables
+  )
+    ? variables.map(name => [name, { required: true }])
+    : Object.entries(variables);
+
+  for (const [name, options] of entries) {
+    const value = process.env[name];
+
+    if (value === undefined) {
+      if (options.required !== false) {
+        missingVariables.push(name);
+      }
+
+      continue;
+    }
+
+    params[name] = value;
+  }
+
+  if (missingVariables.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missingVariables.join(', ')}`
+    );
+  }
+
+  return params;
+}
 export function noop() {}
 
 export function indent(lines: string, tab = '   ') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export {
   after,
 } from './core';
 export { expect } from './core/expect';
+export { paramsFromEnv } from './helpers';
 export * as mfa from './core/mfa';
 
 /**

--- a/templates/synthetics.config.ts
+++ b/templates/synthetics.config.ts
@@ -1,4 +1,4 @@
-import type { SyntheticsConfig } from '@elastic/synthetics';
+import { paramsFromEnv, type SyntheticsConfig } from '@elastic/synthetics';
 
 export default env => {
   const config: SyntheticsConfig = {
@@ -6,6 +6,10 @@ export default env => {
       url: 'https://elastic.github.io/synthetics-demo/',
       // Base URL for the API journey examples; replace with your service.
       apiUrl: 'https://jsonplaceholder.typicode.com',
+      // Load optional environment-backed parameters when available.
+      ...paramsFromEnv({
+        SYNTHETICS_API_URL: { required: false },
+      }),
     },
     playwrightOptions: {
       ignoreHTTPSErrors: false,
@@ -27,11 +31,13 @@ export default env => {
       space: '{{space}}',
     },
   };
+
   if (env !== 'development') {
     /**
      * Override configuration specific to environment
      * Ex: config.params.url = ""
      */
   }
+
   return config;
 };


### PR DESCRIPTION
## Summary

Adds a `paramsFromEnv` helper to simplify reading environment variables into synthetic monitoring configuration parameters.

Closes #1181.

## Changes

- Export `paramsFromEnv` from the package root.
- Support required environment variables through an array:

  ```ts
  paramsFromEnv(['USER_EMAIL', 'API_URL']);
  ```

- Support optional environment variables through object configuration:

  ```ts
  paramsFromEnv({
    API_URL: { required: false },
  });
  ```

- Report all missing required variables in one error.
- Preserve explicitly defined empty values.
- Update the generated configuration template with an optional environment-backed parameter.
- Add seven focused tests covering required variables, optional variables, missing values, empty values, and empty inputs.

## Verification

```bash
npm run test:unit -- __tests__/helper.test.ts --runInBand
```

Result: 15 tests passed.

```bash
npm run test:unit -- __tests__/generator/utils.test.ts --runInBand
```

Result: 1 test passed.

```bash
npm run build

npx eslint --rulesdir utils/eslint-rules src/helpers.ts src/index.ts __tests__/helper.test.ts
```

Both completed successfully.