### PR TITLE
chore: add Logs team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for this repository.
+* @elastic/obs-signals-logs-team


### PR DESCRIPTION
## Summary

- add `@elastic/obs-signals-logs-team` as the default code owner

## Testing

- not run (CODEOWNERS-only change)