### PR TITLE
docs(examples): add fake microphone getUserMedia mock

### DIFF
--- a/examples/fake-microphone/.npmrc
+++ b/examples/fake-microphone/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/fake-microphone/README.md
+++ b/examples/fake-microphone/README.md
@@ -1,0 +1,66 @@
+# Fake microphone example
+
+Browser monitors on Elastic-hosted locations have no real microphone.
+Chromium's `--use-file-for-fake-audio-capture` flag also does not work
+after `push`: sidecar `.wav` files are not bundled, and the flag needs a
+launch-time filesystem path the managed host does not have.
+
+This example feeds a synthetic `MediaStream` through `getUserMedia`
+before the page loads. That works on public locations, without a
+Private Location, and without host files.
+
+Playwright 1.49+ launches **chrome-headless-shell** by default (Elastic
+Synthetics uses that). Headless shell rejects real `getUserMedia` with
+`NotSupportedError`, so `--use-fake-device-for-media-stream` is not
+enough on the default runner. The in-page mock does not depend on it.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `synthetics.config.ts` | Mic permission + optional Chromium fake-device flags |
+| `microphone.journey.ts` | Journey that installs the mock, then asserts audio energy |
+| `helpers.ts` | Demo page (via `page.route`), mock, assertions |
+
+The demo page is fulfilled in-process so the example is self-contained.
+Point `page.goto` at your own LiveKit / WebRTC app when adapting this.
+
+Install the mock **before** `page.goto` so the page's SDK never sees an
+empty `getUserMedia`. Resume `AudioContext` inside the mock — a
+suspended context is the usual reason a mock "kinda works".
+
+## Running
+
+```sh
+npm install
+npx @elastic/synthetics .
+```
+
+From the synthetics repo root, after `npm run build`:
+
+```sh
+node dist/cli.js examples/fake-microphone
+```
+
+## Adapting for a real voice app
+
+1. Keep `installMockMicrophone(page)` before navigation.
+2. Replace `openMicDemo()` with `page.goto` to your app.
+3. Drive the UI until the client publishes/listens, then assert
+   whatever yes/no signal you have (connection state, "audio
+   detected", etc.).
+
+Need a **specific** wav rather than a tone? Inline it as base64 in the
+journey, write it to `/tmp/fake.wav` in `beforeAll` (that hook runs
+before Chromium launches), and add
+`--use-file-for-fake-audio-capture=/tmp/fake.wav` to
+`playwrightOptions.args`. Do not `import './file.wav'` — `push` will
+not ship it. This still requires full Chromium, not headless shell.
+
+## Limitations
+
+- The mock proves the **capture pipeline**, not playback quality or a
+  physical mic.
+- `--use-file-for-fake-audio-capture` with a repo-relative path only
+  works locally, where the file exists on disk.
+- Lightweight HTTP monitors cannot exercise WebRTC.

--- a/examples/fake-microphone/helpers.ts
+++ b/examples/fake-microphone/helpers.ts
@@ -1,0 +1,155 @@
+import { expect, type Page } from '@elastic/synthetics';
+
+/**
+ * Served through `page.route` so the demo is a secure context (required by
+ * getUserMedia) without a local static server. Swap this URL for a real
+ * LiveKit / WebRTC app when adapting the journey.
+ */
+export const MIC_DEMO_URL =
+  'https://example.com/elastic-synthetics-mic-demo';
+
+const MIC_DEMO_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Synthetics microphone demo</title>
+  </head>
+  <body>
+    <button id="start">Start microphone</button>
+    <p data-testid="mic-status">idle</p>
+    <p data-testid="mic-level">0</p>
+    <script>
+      const status = document.querySelector('[data-testid="mic-status"]');
+      const level = document.querySelector('[data-testid="mic-level"]');
+
+      async function start() {
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({
+            audio: true,
+          });
+          status.textContent = 'live';
+          const ctx = new AudioContext();
+          await ctx.resume();
+          const source = ctx.createMediaStreamSource(stream);
+          const analyser = ctx.createAnalyser();
+          analyser.fftSize = 256;
+          source.connect(analyser);
+          const data = new Uint8Array(analyser.frequencyBinCount);
+          function tick() {
+            analyser.getByteTimeDomainData(data);
+            let sum = 0;
+            for (let i = 0; i < data.length; i++) {
+              const v = (data[i] - 128) / 128;
+              sum += v * v;
+            }
+            level.textContent = Math.sqrt(sum / data.length).toFixed(4);
+            requestAnimationFrame(tick);
+          }
+          tick();
+        } catch (err) {
+          status.textContent = 'error';
+          status.setAttribute(
+            'data-error',
+            (err && err.name ? err.name : 'Error') + ': ' + (err && err.message)
+          );
+        }
+      }
+      document.getElementById('start').onclick = start;
+    </script>
+  </body>
+</html>`;
+
+export async function openMicDemo(page: Page) {
+  await page.route('**/elastic-synthetics-mic-demo**', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: MIC_DEMO_HTML,
+    })
+  );
+  await page.goto(MIC_DEMO_URL, { waitUntil: 'domcontentloaded' });
+}
+
+/**
+ * Replace getUserMedia with a Web Audio oscillator *before* the page's JS
+ * runs. This is the Checkly-style path that works on Elastic-hosted
+ * locations: no wav on disk, no Chromium file-capture flag.
+ *
+ * For LiveKit, keep this as `addInitScript` before `page.goto` so the SDK
+ * never sees the real (empty) device list. Resume AudioContext — a
+ * suspended context is the usual reason a mock "kinda works".
+ */
+export async function installMockMicrophone(page: Page) {
+  await page.addInitScript(() => {
+    const devices = navigator.mediaDevices;
+    if (!devices) {
+      return;
+    }
+
+    const originalGetUserMedia = devices.getUserMedia.bind(devices);
+
+    devices.enumerateDevices = async () => [
+      {
+        deviceId: 'synthetics-fake-mic',
+        groupId: 'synthetics-fake-group',
+        kind: 'audioinput',
+        label: 'Synthetics Fake Microphone',
+        toJSON() {
+          return this;
+        },
+      },
+    ];
+
+    devices.getUserMedia = async constraints => {
+      if (!constraints || !constraints.audio) {
+        return originalGetUserMedia(constraints);
+      }
+
+      const context = new AudioContext();
+      await context.resume();
+      const destination = context.createMediaStreamDestination();
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+      oscillator.frequency.value = 440;
+      gain.gain.value = 0.35;
+      oscillator.connect(gain).connect(destination);
+      oscillator.start();
+
+      const track = destination.stream.getAudioTracks()[0];
+      const originalStop = track.stop.bind(track);
+      track.stop = () => {
+        oscillator.stop();
+        context.close();
+        originalStop();
+      };
+
+      return destination.stream;
+    };
+  });
+}
+
+export async function startMicAndAssertLive(page: Page) {
+  await page.locator('#start').click();
+  const status = page.locator('[data-testid="mic-status"]');
+  await page.waitForFunction(
+    () => {
+      const text = document.querySelector('[data-testid="mic-status"]')
+        ?.textContent;
+      return text === 'live' || text === 'error';
+    },
+    null,
+    { timeout: 15_000 }
+  );
+  await expect(
+    status,
+    (await status.getAttribute('data-error')) ?? 'microphone should start'
+  ).toHaveText('live');
+  await page.waitForFunction(
+    () =>
+      Number(
+        document.querySelector('[data-testid="mic-level"]')?.textContent
+      ) > 0.01,
+    null,
+    { timeout: 15_000 }
+  );
+}

--- a/examples/fake-microphone/microphone.journey.ts
+++ b/examples/fake-microphone/microphone.journey.ts
@@ -1,0 +1,26 @@
+import { journey, step } from '@elastic/synthetics';
+import {
+  installMockMicrophone,
+  openMicDemo,
+  startMicAndAssertLive,
+} from './helpers';
+
+/**
+ * In-page getUserMedia mock. Copy this pattern for a real voice app
+ * (LiveKit, WebRTC, etc.): call `installMockMicrophone(page)` before
+ * `goto` so the SDK never sees an empty device list.
+ *
+ * Chromium fake-device flags are not enough on the default Synthetics
+ * runner (Playwright chrome-headless-shell returns NotSupportedError
+ * for getUserMedia). The mock does not depend on that.
+ */
+journey('mocked getUserMedia', ({ page }) => {
+  step('install mock and open microphone demo', async () => {
+    await installMockMicrophone(page);
+    await openMicDemo(page);
+  });
+
+  step('capture from mocked stream and see audio energy', async () => {
+    await startMicAndAssertLive(page);
+  });
+});

--- a/examples/fake-microphone/package.json
+++ b/examples/fake-microphone/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "synthetics-fake-microphone-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Example: fake microphone / getUserMedia mock for Elastic Synthetics browser monitors",
+  "scripts": {
+    "test": "npx @elastic/synthetics ."
+  },
+  "dependencies": {
+    "@elastic/synthetics": "*"
+  }
+}

--- a/examples/fake-microphone/synthetics.config.ts
+++ b/examples/fake-microphone/synthetics.config.ts
@@ -1,0 +1,30 @@
+import type { SyntheticsConfig } from '@elastic/synthetics';
+
+/**
+ * Microphone permission is a Playwright *context* option; the runner
+ * spreads `playwrightOptions` into both `chromium.launch()` and
+ * `browser.newContext()`.
+ *
+ * `--use-fake-ui-for-media-stream` / `--use-fake-device-for-media-stream`
+ * only help on full Chromium. Playwright 1.49+ launches
+ * chrome-headless-shell by default, which rejects getUserMedia with
+ * `NotSupportedError`. Elastic Synthetics uses that default, so the
+ * journey relies on the in-page mock instead of these flags.
+ *
+ * `--use-file-for-fake-audio-capture=/path/file.wav` also does not
+ * survive `push`: sidecar files are not bundled, and the flag needs a
+ * launch-time filesystem path the managed host does not have.
+ */
+export default () => {
+  const config: SyntheticsConfig = {
+    playwrightOptions: {
+      permissions: ['microphone'],
+      args: [
+        '--use-fake-ui-for-media-stream',
+        '--use-fake-device-for-media-stream',
+        '--autoplay-policy=no-user-gesture-required',
+      ],
+    },
+  };
+  return config;
+};


### PR DESCRIPTION
## Summary
- 🎤 Adds `examples/fake-microphone` — a self-contained journey that injects a Web Audio `getUserMedia` mock *before* navigation and asserts the page actually hears audio.
- 📦 Documents why bundling a `.wav` (and Chromium `--use-file-for-fake-audio-capture` / fake-device flags) does **not** work on managed locations: `push` only ships JS, and Playwright's chrome-headless-shell rejects real `getUserMedia`.

No Private Location required. No host files. Just a fake mic that works on public locations. 🚀

## Example README

Browser monitors on Elastic-hosted locations have no real microphone.
Chromium's `--use-file-for-fake-audio-capture` flag also does not work
after `push`: sidecar `.wav` files are not bundled, and the flag needs a
launch-time filesystem path the managed host does not have.

This example feeds a synthetic `MediaStream` through `getUserMedia`
before the page loads. That works on public locations, without a
Private Location, and without host files.

Playwright 1.49+ launches **chrome-headless-shell** by default (Elastic
Synthetics uses that). Headless shell rejects real `getUserMedia` with
`NotSupportedError`, so `--use-fake-device-for-media-stream` is not
enough on the default runner. The in-page mock does not depend on it.

### 📁 Files

| File | Purpose |
|---|---|
| `synthetics.config.ts` | Mic permission + optional Chromium fake-device flags |
| `microphone.journey.ts` | Journey that installs the mock, then asserts audio energy |
| `helpers.ts` | Demo page (via `page.route`), mock, assertions |

The demo page is fulfilled in-process so the example is self-contained.
Point `page.goto` at your own LiveKit / WebRTC app when adapting this.

Install the mock **before** `page.goto` so the page's SDK never sees an
empty `getUserMedia`. Resume `AudioContext` inside the mock — a
suspended context is the usual reason a mock "kinda works". 😅

### ▶️ Running

```sh
npm install
npx @elastic/synthetics .
```

From the synthetics repo root, after `npm run build`:

```sh
node dist/cli.js examples/fake-microphone
```

### 🎧 Adapting for a real voice app

1. Keep `installMockMicrophone(page)` before navigation.
2. Replace `openMicDemo()` with `page.goto` to your app.
3. Drive the UI until the client publishes/listens, then assert
   whatever yes/no signal you have (connection state, "audio
   detected", etc.).

Need a **specific** wav rather than a tone? Inline it as base64 in the
journey, write it to `/tmp/fake.wav` in `beforeAll` (that hook runs
before Chromium launches), and add
`--use-file-for-fake-audio-capture=/tmp/fake.wav` to
`playwrightOptions.args`. Do not `import './file.wav'` — `push` will
not ship it. This still requires full Chromium, not headless shell.

### ⚠️ Limitations

- The mock proves the **capture pipeline**, not playback quality or a
  physical mic.
- `--use-file-for-fake-audio-capture` with a repo-relative path only
  works locally, where the file exists on disk.
- Lightweight HTTP monitors cannot exercise WebRTC.

See [`examples/fake-microphone/README.md`](https://github.com/elastic/synthetics/blob/docs/fake-microphone-example/examples/fake-microphone/README.md).

## Test plan
- [x] `node dist/cli.js examples/fake-microphone` — `mocked getUserMedia` passes ✅
- [ ] Adapt `installMockMicrophone(page)` before `goto` against a real LiveKit/WebRTC app
